### PR TITLE
PSDconvert was missing in the binding

### DIFF
--- a/bindings/python/python_image.cpp
+++ b/bindings/python/python_image.cpp
@@ -101,6 +101,8 @@ PyMethodDef Image_methods[] =
           "Read image preview, downsample in Fourier space" },
         { "equal", (PyCFunction) Image_equal, METH_VARARGS,
           "return true if both images are equal up to precision" },
+        { "convertPSD", (PyCFunction) Image_convertPSD, METH_VARARGS,
+          "Convert to PSD: center FFT and use logarithm" },
         { "readApplyGeo", (PyCFunction) Image_readApplyGeo, METH_VARARGS,
           "Read image from disk applying geometry in referring metadata" },
         { "write", (PyCFunction) Image_write, METH_VARARGS,

--- a/bindings/python/xmippmodule.cpp
+++ b/bindings/python/xmippmodule.cpp
@@ -1038,13 +1038,13 @@ xmipp_errorMaxFreqCTFs2D(PyObject *obj, PyObject *args, PyObject *kwargs)
 PyObject *
 Image_convertPSD(PyObject *obj, PyObject *args, PyObject *kwargs)
 {
-	PyObject *pyImage;
-    if (PyArg_ParseTuple(args, "O", &pyImage))
+    ImageObject *self = (ImageObject*) obj;
+
+    if (self != NULL)
     {
-        ImageObject *img=(ImageObject *)pyImage;
         try
         {
-            ImageGeneric *image = img->image;
+            ImageGeneric *image = self->image;
             image->convert2Datatype(DT_Double);
             MultidimArray<double> *in;
             MULTIDIM_ARRAY_GENERIC(*image).getMultidimArrayPointer(in);


### PR DESCRIPTION
convertPSD was missing in the binding and the function was failing. I take what we have in the scipion/devel and it works again... @cossorzano please review the function in xmippmodule.cpp because maybe you want to include something new and I'm reverting it...