### PR TITLE
Ds copying git on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 sudo: true
 dist: trusty
 env: TRAVIS=1
+git:
+    depth: false
 addons:
   apt:
     sources: ubuntu-toolchain-r-test

--- a/scripts/travis_before_script.py
+++ b/scripts/travis_before_script.py
@@ -9,9 +9,13 @@ xmipp_folder = os.path.join(folder, src_folder_name, xmipp_folder_name)
 xmipp_script = 'xmipp'
 sonar_script = 'sonar-project.properties'
 sync_script = 'sync_data.py'
+git_folder = '.git'
 # get folder relative to home dir and strip os.path separators
 script_dir = os.path.dirname(os.path.realpath(__file__)).split(os.getcwd())[1][1:]
 copy_list = [xmipp_script, script_dir, sonar_script, sync_script]
+if 'TRAVIS' in os.environ:
+    # we need git folder so that SonarCloud can use it for PR decoration
+    copy_list.append(git_folder)
 black_list = [src_folder_name]
 os.makedirs(xmipp_folder)
 for item in os.listdir(folder):
@@ -28,3 +32,4 @@ for item in os.listdir(folder):
                 shutil.copy(item_path, xmipp_folder)
     except Exception as e:
         print(e)
+


### PR DESCRIPTION
This should solve the problem of:
- missing PR decoration by SonarCloud (missing git folder, which is used for referencing PR, see https://community.sonarsource.com/t/pr-decoration-for-github-no-longer-working/5875/7)
- SonarCloud complaining about missing SCM information (Travis making shallow copies of 50 commits)

The PR decoration should start working once this is merged to devel and new branches are derived from it.