### PR TITLE
downgrading to C++11

### DIFF
--- a/libraries/data/bspline_grid.h
+++ b/libraries/data/bspline_grid.h
@@ -35,15 +35,15 @@ public:
     BSplineGrid(Dimensions &dim, Matrix1D<T> &coeffsX, Matrix1D<T> &coeffsY):
         dim(dim), coeffsX(coeffsX), coeffsY(coeffsY) {}
 
-    auto constexpr getDim() const {
+    constexpr const Dimensions& getDim() const {
         return dim;
     }
 
-    const auto getCoeffsX() const {
+    constexpr const Matrix1D<T>& getCoeffsX() const {
         return coeffsX;
     }
 
-    const auto getCoeffsY() const {
+    constexpr const Matrix1D<T>& getCoeffsY() const {
         return coeffsY;
     }
 

--- a/libraries/reconstruction/bspline_helper.h
+++ b/libraries/reconstruction/bspline_helper.h
@@ -72,7 +72,7 @@ public:
      */
     // FIXME unify with CUDA implementation
     template<typename T>
-    static constexpr inline T Bspline03(T argument)    {
+    static inline T Bspline03(T argument) {
 
         static_assert(std::is_same<float, T>::value
                 || std::is_same<double, T>::value, "T must be either float or double");

--- a/libraries/reconstruction/movie_alignment_correlation_base.cpp
+++ b/libraries/reconstruction/movie_alignment_correlation_base.cpp
@@ -416,7 +416,7 @@ void AProgMovieAlignmentCorrelation<T>::storeGlobalShifts(
 }
 
 template<typename T>
-auto AProgMovieAlignmentCorrelation<T>::loadGlobalShifts(MetaData &movie) {
+AlignmentResult<T> AProgMovieAlignmentCorrelation<T>::loadGlobalShifts(MetaData &movie) {
     AlignmentResult<T> alignment;
     int n = 0;
     T shiftX;

--- a/libraries/reconstruction/movie_alignment_correlation_base.h
+++ b/libraries/reconstruction/movie_alignment_correlation_base.h
@@ -250,7 +250,7 @@ private:
      * @param movie where shifts are stored
      * @return global alignment as stored in the movie
      */
-    auto loadGlobalShifts(MetaData &movie);
+    AlignmentResult<T> loadGlobalShifts(MetaData &movie);
 
     /**
      * Method loads dark correction image

--- a/libraries/reconstruction_adapt_cuda/movie_alignment_correlation_gpu.h
+++ b/libraries/reconstruction_adapt_cuda/movie_alignment_correlation_gpu.h
@@ -324,10 +324,10 @@ private:
     /**
      * Keywords representing optimal settings of the algorithm.
      */
-    std::string minMemoryStr = "minMem";
-    std::string optSizeXStr = "optSizeX";
-    std::string optSizeYStr = "optSizeY";
-    std::string optBatchSizeStr = "optBatchSize";
+    std::string minMemoryStr = std::string("minMem");
+    std::string optSizeXStr = std::string("optSizeX");
+    std::string optSizeYStr = std::string("optSizeY");
+    std::string optBatchSizeStr = std::string("optBatchSize");
 };
 
 #endif /* MOVIE_ALIGNMENT_CORRELATION_GPU */

--- a/libraries/reconstruction_adapt_cuda/movie_alignment_correlation_gpu.h
+++ b/libraries/reconstruction_adapt_cuda/movie_alignment_correlation_gpu.h
@@ -27,7 +27,7 @@
 #define MOVIE_ALIGNMENT_CORRELATION_GPU
 
 #include <thread>
-#include <shared_mutex>
+#include <mutex>
 #include <future>
 #include "reconstruction/movie_alignment_correlation_base.h"
 #include "reconstruction_cuda/cuda_gpu_movie_alignment_correlation.h"
@@ -79,7 +79,7 @@ private:
      * @param crop if true, FFT can be of smaller size
      * @return best FFT setting
      */
-    auto getSettingsOrBenchmark(const Dimensions &d, size_t extraMem,
+    FFTSettings<T> getSettingsOrBenchmark(const Dimensions &d, size_t extraMem,
             bool crop);
 
     /**
@@ -103,7 +103,7 @@ private:
      * @param optimize the sizes?
      * @return optimal FFT setting for the movie
      */
-    auto getMovieSettings(const MetaData &movie, bool optimize);
+    FFTSettings<T> getMovieSettings(const MetaData &movie, bool optimize);
 
     /**
      * Method will align data of given size, using cross-correlation of
@@ -120,7 +120,7 @@ private:
      * @param verbose level
      * @return global alignment of each frame
      */
-    auto align(T *data, const FFTSettings<T> &in, const FFTSettings<T> &correlation,
+    AlignmentResult<T> align(T *data, const FFTSettings<T> &in, const FFTSettings<T> &correlation,
             MultidimArray<T> &filter, core::optional<size_t> &refFrame,
             size_t maxShift,
             size_t framesInCorrelationBuffer, int verbose);
@@ -141,7 +141,7 @@ private:
      * @param refFrame reference frame, if any
      * @return alignment of the data
      */
-    auto computeShifts(int verbose, size_t maxShift, std::complex<T>* data,
+    AlignmentResult<T> computeShifts(int verbose, size_t maxShift, std::complex<T>* data,
             const FFTSettings<T> &settings, size_t N, std::pair<T, T> &scale,
             size_t framesInCorrelationBuffer,
             const core::optional<size_t>& refFrame);
@@ -152,7 +152,7 @@ private:
      * @param dowscale that should be applied for correlation
      * @return optimal FFT settings
      */
-    auto getCorrelationSettings(const FFTSettings<T> &orig,
+    FFTSettings<T> getCorrelationSettings(const FFTSettings<T> &orig,
             const std::pair<T, T> &downscale);
 
     /**
@@ -160,7 +160,7 @@ private:
      * @param orig movie setting
      * @return optimal setting for each patch
      */
-    auto getPatchSettings(const FFTSettings<T> &orig);
+    FFTSettings<T> getPatchSettings(const FFTSettings<T> &orig);
 
     /**
      * Inherited, see parent
@@ -191,7 +191,7 @@ private:
      * @param requested downscale used during correlation
      * @return FFT setting describing requested correlation
      */
-    auto getCorrelationHint(const FFTSettings<T> &s,
+    Dimensions getCorrelationHint(const FFTSettings<T> &s,
             const std::pair<T, T> &downscale);
 
     /**
@@ -209,7 +209,7 @@ private:
      * @param applyCrop flag
      * @return stored setting, if any
      */
-    auto getStoredSizes(const Dimensions &dim,
+    core::optional<FFTSettings<T>> getStoredSizes(const Dimensions &dim,
             bool applyCrop);
 
     /**
@@ -218,7 +218,7 @@ private:
      * @param extraMem to leave on GPU
      * @param crop flag
      */
-    auto runBenchmark(const Dimensions &d, size_t extraMem,
+    FFTSettings<T> runBenchmark(const Dimensions &d, size_t extraMem,
             bool crop);
 
     /**
@@ -227,7 +227,7 @@ private:
      * @param movie size
      * @param patch size
      */
-    auto getPatchesLocation(const std::pair<T, T> &borders,
+    std::vector<FramePatchMeta<T>> getPatchesLocation(const std::pair<T, T> &borders,
             const Dimensions &movie,
             const Dimensions &patch);
 
@@ -240,7 +240,7 @@ private:
      * @param verbose level
      * @return no of pixels in X (Y) dimension where there might NOT be data from each frame
      */
-    auto getMovieBorders(const AlignmentResult<T> &globAlignment,
+    std::pair<T,T> getMovieBorders(const AlignmentResult<T> &globAlignment,
             int verbose);
 
     /**
@@ -261,7 +261,7 @@ private:
      * @param movie to use
      * @param globAlignment to use
      */
-    auto localFromGlobal(
+    LocalAlignmentResult<T> localFromGlobal(
             const MetaData& movie,
             const AlignmentResult<T> &globAlignment);
 
@@ -287,7 +287,7 @@ private:
      * Method returns requested downscale (<1) for the correlations used
      * for local alignment
      */
-    auto getLocalAlignmentCorrelationDownscale(
+    std::pair<T,T> getLocalAlignmentCorrelationDownscale(
             const Dimensions &patchDim, T maxShift);
 
     /**
@@ -319,7 +319,7 @@ private:
     Dimensions rawMovieDim = Dimensions(0);
 
     /** mutex indicating when a thread can access data array used for alignment */
-    mutable std::shared_timed_mutex alignDataMutex;
+    mutable std::mutex alignDataMutex;
 
     /**
      * Keywords representing optimal settings of the algorithm.

--- a/libraries/reconstruction_cuda/cuda_gpu_geo_transformer.cpp
+++ b/libraries/reconstruction_cuda/cuda_gpu_geo_transformer.cpp
@@ -28,8 +28,6 @@
 #include <cuda_runtime_api.h>
 #include "cuda_all.cpp"
 
-template class GeoTransformer<float> ;
-
 template<typename T>
 void GeoTransformer<T>::release() {
     cudaFree(d_in);
@@ -599,3 +597,4 @@ void GeoTransformer<T>::checkRestrictions(int splineDegree,
                 "To init function, pass N control points.");
 }
 
+template class GeoTransformer<float>;

--- a/xmipp
+++ b/xmipp
@@ -493,7 +493,7 @@ def configCompiler(configDict):
             configDict["CCFLAGS"]+=" -std=c99"
     if 'g++' in configDict["CXX"]:
         if not "-std=c99" in configDict["CXXFLAGS"]:
-            configDict["CXXFLAGS"]+=" -std=c++14"
+            configDict["CXXFLAGS"]+=" -std=c++11"
     # Nothing special to add to LINKFLAGS
 
     if configDict["DEBUG"]=="":


### PR DESCRIPTION
Making necessary changes to compile using c++11.
However, bear in mind that I used GCC 5.5, so we should first check this on other machine(s).
C++11 standard [requires](https://en.cppreference.com/w/cpp/compiler_support#cpp11) GCC 5 (4.8) to get majority of the features, so this still might be incompatible with many systems (OpenSuse < 12, Ubuntu < 14.04 etc).