### PR TITLE
Release 19.03 fixes

### DIFF
--- a/tar.py
+++ b/tar.py
@@ -26,7 +26,7 @@ import subprocess
 import sys
 import os
 import shutil
-from os.path import dirname, realpath, join, isfile, exists
+from os.path import join, isfile, exists
 
 
 def usage(error=''):
@@ -34,31 +34,41 @@ def usage(error=''):
     print("\n"
           "    %s"
           "\n"
-          "    Usage: python tar.py <mode> <version>\n"
+          "    Usage: python tar.py <mode> <version> [branch]\n"
           "\n"
-          "             mode: Binaries: Just the binaries \n"
+          "             mode: Binaries: Just the binaries. \n"
           "                   Sources: Just the source code.\n"
+          "\n"
+          "             branch if for the sources (default: master)\n"
           "\n"
           "             version: X.YY.MM  (version, year and month)\n"
           "    " % errorStr)
     sys.exit(1)
 
 
-def run(label, version):
+def run(label, version, branch):
     MODES = {'Binaries': 'build', 'Sources': 'src'}
 
     def makeTarget(target, label):
         if exists(target):
-            print("%s already exists. Removing it...")
+            print("'%s' already exists. Removing it..." % target)
             os.system("rm -rf %s" % target)
         print("...preparing the bundle...")
-        shutil.copytree(MODES[label], target, symlinks=True)
+        cwd = os.getcwd()
+        os.mkdir(target)
+        shutil.copy('xmipp', target)
+        os.chdir(target)
+        os.environ['CUDA'] = 'True'
+        os.system('./xmipp config')  # just to write the config file
+        os.system('./xmipp get_dependencies')
+        os.system('./xmipp get_devel_sources %s' % branch)
+        os.system('rm -rf tmp xmipp xmipp.conf')
+        os.chdir(cwd)
 
     excludeTgz = ''
-    tgzPath = "xmipp%s-%s"
     if label == 'Binaries':
         print("Recompiling to make sure that last version is there...")
-        target = tgzPath % ('Bin', version)
+        target = 'xmippBin-'+version
         try:
             # doing compilation and install separately to skip overwriting config
             os.system("./xmipp compile 4")
@@ -77,9 +87,8 @@ def run(label, version):
                      "--exclude='*.java' --exclude='resources/test' " \
                      "--exclude='*xmipp_test*main'"
     elif label == 'Sources':
-        target = tgzPath % ('Src', version)
-        os.mkdir(target)
-        makeTarget(join(target, 'src'), label)
+        target = 'xmippSrc-v'+version
+        makeTarget(target, label)
         excludeTgz = " --exclude='models/*' --exclude='src/*/bin/*' --exclude='*.so'"
     else:
         usage("Incorrect <mode>")
@@ -108,10 +117,11 @@ def run(label, version):
 
 if __name__ == '__main__':
 
-    if not len(sys.argv) == 3:
+    if not len(sys.argv) > 3:
         usage("Incorrect number of input parameters")
 
     label = sys.argv[1]
     version = sys.argv[2]
+    branch = sys.argv[3] if len(sys.argv)>3 else 'master'
 
-    run(label, version)
+    run(label, version, branch)

--- a/tests/test.py
+++ b/tests/test.py
@@ -336,10 +336,18 @@ def visitTests(tests, grepStr=''):
 
 
 if __name__ == "__main__":
+
+    cudaTests = True
+    for i, arg in enumerate(sys.argv):
+        if arg == '--noCuda':
+            cudaTests = False
+            sys.argv.pop(i)
+
     testNames = sys.argv[1:]
 
-    cTests = subprocess.check_output('compgen -ac | grep xmipp_test_', shell=True,
-                                     executable='/bin/bash').splitlines()
+    cudaExcludeStr = '| grep -v xmipp_test_cuda_' if not cudaTests else ''
+    cTests = subprocess.check_output('compgen -ac | grep xmipp_test_ %s' % cudaExcludeStr,
+                                     shell=True, executable='/bin/bash').splitlines()
 
     tests = unittest.TestSuite()
     if '--show' in testNames or '--allPrograms' in testNames:

--- a/xmipp
+++ b/xmipp
@@ -27,6 +27,7 @@
 import distutils.spawn
 import glob
 import os
+import re
 import shutil
 import sys
 import unittest
@@ -56,6 +57,12 @@ REPOSITORIES = {XMIPP: 'https://github.com/I2PC/xmipp.git',
 TMP_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'tmp')
 CONFIG_FILE_NAME = "xmipp.conf"
 
+# if a skippable compilation fails (if 'key' in the error log),
+#   xmipp.conf file will be updated following the value[0]=value[1]
+#   and the compilation is re-tried.
+SKIPPABLE_BINS = {"optical_alignment": ("OPENCV", "False"),
+                  "volume_homogenizer": ("OPENCV", "False"),
+                  "cuda": ("CUDA", "False")}
 
 
 def checkGithubConnection():
@@ -712,7 +719,7 @@ def configCuda(configDict):
         if configDict["NVCC_CXXFLAGS"]=="":
             cxxVersion, cxxStrVersion = getGccVersion(configDict["CXX"])
             if cxxVersion > 5:
-                print(red("%s version later than 5 detected. Finding alternative..." % configDict["CXX"]))
+                print(red("%s version later than 5 detected. Finding alternative for CUDA compilations..." % configDict["CXX"]))
                 if checkProgram(configDict["CXX"]+"-5"):
                     configDict["CXX_CUDA"] = configDict["CXX"]+"-5"
                 elif checkProgram(configDict["CXX"]+"-4.8"):
@@ -814,7 +821,7 @@ def writeConfig(configDict):
             configFile.write("%s=%s\n"%(label,configDict[label]))
 
 def updateConfig(updatingDict):
-    cmdTemplate = 'sed -i -e "s/%s=.*/%s=%s/" %s'
+    cmdTemplate = "sed -i -e 's/^%s=.*/%s=%s/' %s"
     for k, v in updatingDict.iteritems():
         runJob(cmdTemplate % (k, k, v.replace('/', '\/'), CONFIG_FILE_NAME))
 
@@ -851,7 +858,6 @@ def checkConfig():
     print("Checking configuration ------------------------------")
     ensureConfig()
     newConf = {}  # to update the config if something fails
-    print configDict['VERIFIED']
     if configDict['VERIFIED'] != 'True':
         if not checkCompiler(configDict):
             print(red("Cannot compile"))
@@ -878,13 +884,28 @@ def checkConfig():
     return True
 
 
-def compileModule(Nproc,module):
+def compileModule(Nproc,module, tries=0):
     shutil.copyfile(CONFIG_FILE_NAME,"src/%s/install/%s" % (module, CONFIG_FILE_NAME))
     if module == "xmipp":
         stampVersion()
-    ok = runJob("scons -j%s"%Nproc, "src/%s"%module)
+    log = []
+    ok = runJob("scons -j%s"%Nproc, "src/%s"%module, log=log)
+    if not ok:
+        newConf = {}
+        for l in log[-30:]:  # inspecting last 30 lines
+            # expected error: 'scons: *** [some/program/to/compile] Error 1'
+            failingBin = re.match("scons: \*\*\* \[(.*)\] Error .*", l)
+            if failingBin:
+                for k, v in SKIPPABLE_BINS.iteritems():
+                    if k in failingBin.group(1):
+                        print(red("Some error during compiling '%s' program." % failingBin.group(1).split('/')[-1]))
+                        print(green("Trying with '%s=%s' to skip that programs." % (v[0], v[1])))
+                        newConf.update({v[0]: v[1]})
+        if newConf and tries < 6:
+            updateConfig(newConf)
+            tries += 1
+            ok = compileModule(Nproc, module, tries)
     return ok
-
 
 def compile_cuFFTAdvisor():
     advisorDir = "src/cuFFTAdvisor/"

--- a/xmipp
+++ b/xmipp
@@ -39,7 +39,7 @@ from datetime import datetime
 VERSION_TAG = "Xmipp version"
 ##############################
 XMIPP_VERSION = '3.19.03b4'  #
-RELEASE_DATE = '18/03/2019'  #
+RELEASE_DATE = '03/04/2019'  #
 ##############################
 
 XMIPP = 'xmipp'

--- a/xmipp
+++ b/xmipp
@@ -412,7 +412,7 @@ def readConfigFile(fnConfig):
 def createEmptyConfig():
     labels = ['CC','CXX','LINKERFORPROGRAMS','INCDIRFLAGS','LIBDIRFLAGS','CCFLAGS','CXXFLAGS',
               'LINKFLAGS','PYTHONINCFLAGS','MPI_CC','MPI_CXX','MPI_LINKERFORPROGRAMS','MPI_CXXFLAGS',
-              'MPI_LINKFLAGS','NVCC','NVCC_CXXFLAGS','NVCC_LINKFLAGS',
+              'MPI_LINKFLAGS','NVCC','CXX_CUDA','NVCC_CXXFLAGS','NVCC_LINKFLAGS',
               'MATLAB_DIR','CUDA','DEBUG','MATLAB','OPENCV','OPENCVSUPPORTSCUDA','OPENCV3',
               'JAVA_HOME','JAVA_BINDIR','JAVAC','JAR','JNI_CPPPATH', 'USE_DL']
     configDict = {}
@@ -702,10 +702,29 @@ def configCuda(configDict):
     if configDict["CUDA"]=="True":
         if configDict["NVCC"]=="":
             if checkProgram("nvcc"):
+                nvccVersion, nvccFullVersion = getCudaVersion("nvcc")
+                if nvccVersion != 8.0:
+                    print(red('Detected CUDA-' + nvccFullVersion + '. Version 8.0 is required.'))
+                    print(red("Skipping CUDA compilation. Please, set cuda-8.0 as default.'"))
+                    configDict["CUDA"] = 'False'
+                    return
                 configDict["NVCC"] = "nvcc"
         if configDict["NVCC_CXXFLAGS"]=="":
-            configDict["NVCC_CXXFLAGS"] = "--x cu -D_FORCE_INLINES -Xcompiler " \
-                                              "-fPIC -Wno-deprecated-gpu-targets -ccbin %s -std=c++11" % configDict["CXX"]
+            cxxVersion, cxxStrVersion = getGccVersion(configDict["CXX"])
+            if cxxVersion > 5:
+                print(red("%s version later than 5 detected. Finding alternative..." % configDict["CXX"]))
+                if checkProgram(configDict["CXX"]+"-5"):
+                    configDict["CXX_CUDA"] = configDict["CXX"]+"-5"
+                elif checkProgram(configDict["CXX"]+"-4.8"):
+                    configDict["CXX_CUDA"] = configDict["CXX"]+"-4.8"
+                else:
+                    print(red("No alternative found. Skipping CUDA compilation.\n"
+                              "If an alternative exists, please set 'CXX_CUDA' in 'xmipp.conf' to point to there."))
+                    configDict["CUDA"] = "False"
+                    return
+                print(green("%s detected. Using it to compile CUDA related code." % configDict["CXX_CUDA"]))
+            configDict["NVCC_CXXFLAGS"] = ("--x cu -D_FORCE_INLINES -Xcompiler -fPIC "
+                                           "-Wno-deprecated-gpu-targets -ccbin %(CXX_CUDA)s -std=c++11")
         if configDict["NVCC_LINKFLAGS"]=="":
             nvccPath=distutils.spawn.find_executable("nvcc")
             if nvccPath:
@@ -1209,6 +1228,26 @@ def getVersion(onlyNumbers=False):
 
     return cleanInfo.strip(' ')
 
+def getCudaVersion(nvcc):
+    log = []
+    runJob(nvcc + " --version", show_output=False, show_command=False, log=log)
+    # expected lst line: 'Cuda compilation tools, release 8.0, V8.0.61'
+    full_version = log[-1].strip().split(', ')[-1].lstrip('V')
+    tokens = full_version.split('.')
+    if len(tokens) < 2:
+        tokens.append('0')  # for version 5.0, only '5' is returned
+    nvccVersion = float(str(tokens[0] + '.' + tokens[1]))
+    return nvccVersion, full_version
+
+def getGccVersion(compiler):
+    log = []
+    runJob(compiler + " -dumpversion", show_output=False, show_command=False, log=log)
+    full_version = log[0].strip()
+    tokens = full_version.split('.')
+    if len(tokens) < 2:
+        tokens.append('0')  # for version 5.0, only '5' is returned
+    gccVersion = float(str(tokens[0] + '.' + tokens[1]))
+    return gccVersion, full_version
 
 def ensureCompilerVersion(compiler):
     if 'g++' in compiler or 'gcc' in compiler:
@@ -1220,21 +1259,15 @@ def ensureCompilerVersion(compiler):
 def ensureGCC_GPPVersion(compiler):
     if 'TRAVIS' in os.environ:
         return  # skip detection on TRAVIS
-    log = []
     if not checkProgram(compiler, True):
         sys.exit(-7)
-    runJob(compiler + " -dumpversion", show_output=False, show_command=False, log=log)
-    # expected first line format:
-    # 5.5.0
-    full_version = log[0].strip()
-    tokens = full_version.split('.')
-    if len(tokens) < 2:
-        tokens.append('0')  # for version 5.0, only '5' is returned
-    if float(str(tokens[0] + '.' + tokens[1])) < 4.8:  # join first two numbers, i.e. major and minor version
-        print(red('Detected ' + compiler + " in version " + full_version + '. Version 4.8 or higher is required.'))
+    gccVersion, fullVersion = getGccVersion(compiler)
+
+    if gccVersion < 4.8:  # join first two numbers, i.e. major and minor version
+        print(red('Detected ' + compiler + " in version " + fullVersion + '. Version 4.8 or higher is required.'))
         sys.exit(-8)
     else:
-        print(green(compiler + ' ' + full_version + ' detected'))
+        print(green(compiler + ' ' + fullVersion + ' detected'))
 
 def ensureConfig():
     # assuming the config file is not loaded in the main(), i.e. it does not exists yet and has not been created

--- a/xmipp
+++ b/xmipp
@@ -209,6 +209,8 @@ def checkProgram(programName, show=True):
                         for instructions in systemInstructions[programName]:
                             print(red("    - In %s: %s"%(systems[idx],instructions)))
                             idx+=1
+                    print("\nRemember to re-run './xmipp config' after install new software in order to "
+                          "take into account the new system configuration.")
             ok = False
         else:
             ok = False
@@ -870,6 +872,10 @@ def checkConfig():
             print("In Ubuntu: sudo apt-get -y install libsqlite3-dev libfftw3-dev libhdf5-dev libopencv-dev python2.7-dev "\
                   "python-numpy python-scipy python-mpi4py")
             print("In Manjaro: sudo pacman -Syu install hdf5 python2-numpy python2-scipy --noconfirm")
+            print("Please, see 'https://scipion-em.github.io/docs/docs/scipion-modes/"
+                  "install-from-sources.html#step-2-dependencies' for more information about libraries dependencies.")
+            print("\nRemember to re-run './xmipp config' after installing libraries in order to "
+                  "take into account the new system configuration.")
             return False
         if not checkMPI(configDict):
             print(red("Cannot compile with MPI or use it"))

--- a/xmipp
+++ b/xmipp
@@ -57,12 +57,11 @@ REPOSITORIES = {XMIPP: 'https://github.com/I2PC/xmipp.git',
 TMP_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'tmp')
 CONFIG_FILE_NAME = "xmipp.conf"
 
-# if a skippable compilation fails (if 'key' in the error log),
-#   xmipp.conf file will be updated following the value[0]=value[1]
-#   and the compilation is re-tried.
-SKIPPABLE_BINS = {"optical_alignment": ("OPENCV", "False"),
-                  "volume_homogenizer": ("OPENCV", "False"),
-                  "cuda": ("CUDA", "False")}
+# if a skippable compilation fails (if 'key' found in the failed code),
+# a hint is printed in order to export 'value' or edit the config file
+SKIPPABLE_BINS = {"optical_alignment": "OPENCV=False",
+                  "volume_homogenizer": "OPENCV=False",
+                  "cuda": "CUDA=False"}
 
 
 def checkGithubConnection():
@@ -435,7 +434,7 @@ def findFileInDirList(fnH,dirlist):
     return False
 
 def configOpenCV(configDict):
-    print("Checking compiler configuration ...")
+    print("Checking openCV configuration ...")
     cppProg="#include <opencv2/core/core.hpp>\n"
     cppProg+="int main(){}\n"
     with open("xmipp_test_opencv.cpp", "w") as cppFile:
@@ -552,6 +551,7 @@ def configCompiler(configDict):
             elif findFileInDirList("ndarraytypes.h",["/usr/local/lib/python2.7/dist-packages/numpy/core/include/numpy"]):
                 configDict["PYTHONINCFLAGS"]+=" -I/usr/local/lib/python2.7/dist-packages/numpy/core/include/"
                 incDirs+=["usr/local/lib/python2.7/dist-packages/numpy/core/include/"]
+    configDict["OPENCV"] = os.environ.get("OPENCV", "")
     if configDict["OPENCV"]=="" or configDict["OPENCVSUPPORTSCUDA"] or configDict["OPENCV3"]:
         configOpenCV(configDict)
 
@@ -862,8 +862,8 @@ def config():
 def checkConfig():
     print("Checking configuration ------------------------------")
     ensureConfig()
-    newConf = {}  # to update the config if something fails
     if configDict['VERIFIED'] != 'True':
+        newConf = {}  # to update the config if something fails
         if not checkCompiler(configDict):
             print(red("Cannot compile"))
             print("Possible solutions")
@@ -889,28 +889,23 @@ def checkConfig():
     return True
 
 
-def compileModule(Nproc,module, tries=0):
+def compileModule(Nproc,module):
     shutil.copyfile(CONFIG_FILE_NAME,"src/%s/install/%s" % (module, CONFIG_FILE_NAME))
     if module == "xmipp":
         stampVersion()
     log = []
     ok = runJob("scons -j%s"%Nproc, "src/%s"%module, log=log)
-    if not ok and tries < 6:
-        newConf = {}
+    if not ok:
         for l in log[-30:]:  # inspecting last 30 lines
             # expected error: 'scons: *** [some/program/to/compile] Error 1'
             failingBin = re.match("scons: \*\*\* \[(.*)\] Error .*", l)
             if failingBin:
                 for k, v in SKIPPABLE_BINS.iteritems():
                     if k in failingBin.group(1):
-                        print(red("Some error during compiling '%s' program." % failingBin.group(1).split('/')[-1]))
-                        print(green("Trying with '%s=%s' to skip that programs." % (v[0], v[1])))
-                        newConf.update({v[0]: v[1]})
-        if newConf:
-            updateConfig(newConf)
-            tries += 1
-            ok = compileModule(Nproc, module, tries)
-    if not ok:
+                        print(red("\nSome error found compiling '%s' program."
+                                  % failingBin.group(1).split('/')[-1]))
+                        print(red("You can skip this program running 'export %s' "
+                                  "or including '%s' in the config file." % (v, v)))
         print(red("\nSome error occurred during the compilation of '%s'.\n" % module))
         sys.exit(1)
     return ok

--- a/xmipp
+++ b/xmipp
@@ -994,7 +994,7 @@ def runTests(testNames):
     noCudaStr = '--noCuda' if configDict['CUDA'] != 'True' else ''
     print(" Tests to do: %s" % ', '.join(testNames))
     runJob("(cd src/xmipp/tests; %s test.py %s %s)"
-           % (getPython(), ' '.join(testNames), noCudaStr))  # noCudaStr must be the last
+           % (getPython(), ' '.join(testNames), noCudaStr))
 
 def getPython():
     scipionHome = getScipionHome()

--- a/xmipp
+++ b/xmipp
@@ -826,7 +826,9 @@ def writeConfig(configDict):
 def updateConfig(updatingDict):
     cmdTemplate = "sed -i -e 's/^%s=.*/%s=%s/' %s"
     for k, v in updatingDict.iteritems():
-        runJob(cmdTemplate % (k, k, v.replace('/', '\/'), CONFIG_FILE_NAME))
+        print(blue("Setting %s=%s" % (k, v)))
+        runJob(cmdTemplate % (k, k, v.replace('/', '\/'), CONFIG_FILE_NAME),
+               show_command=False)
 
 def config_DL(configDict):
     k = 'USE_DL'
@@ -908,6 +910,9 @@ def compileModule(Nproc,module, tries=0):
             updateConfig(newConf)
             tries += 1
             ok = compileModule(Nproc, module, tries)
+    if not ok:
+        print(red("\nSome error occurred during the compilation of '%s'.\n" % module))
+        sys.exit(1)
     return ok
 
 def compile_cuFFTAdvisor():
@@ -1396,7 +1401,6 @@ if __name__ == '__main__':
         else:
             Nproc=8
         compileDependencies(Nproc)
-        downloadDeepLearningModels("build")
         compile(Nproc)
         install("build")
     elif mode=="install":

--- a/xmipp
+++ b/xmipp
@@ -414,7 +414,7 @@ def createEmptyConfig():
               'LINKFLAGS','PYTHONINCFLAGS','MPI_CC','MPI_CXX','MPI_LINKERFORPROGRAMS','MPI_CXXFLAGS',
               'MPI_LINKFLAGS','NVCC','CXX_CUDA','NVCC_CXXFLAGS','NVCC_LINKFLAGS',
               'MATLAB_DIR','CUDA','DEBUG','MATLAB','OPENCV','OPENCVSUPPORTSCUDA','OPENCV3',
-              'JAVA_HOME','JAVA_BINDIR','JAVAC','JAR','JNI_CPPPATH', 'USE_DL']
+              'JAVA_HOME','JAVA_BINDIR','JAVAC','JAR','JNI_CPPPATH', 'USE_DL', 'VERIFIED']
     configDict = {}
     for label in labels:
         configDict[label]=""
@@ -813,6 +813,10 @@ def writeConfig(configDict):
         for label in sorted(configDict.keys()):
             configFile.write("%s=%s\n"%(label,configDict[label]))
 
+def updateConfig(updatingDict):
+    cmdTemplate = 'sed -i -e "s/%s=.*/%s=%s/" %s'
+    for k, v in updatingDict.iteritems():
+        runJob(cmdTemplate % (k, k, v.replace('/', '\/'), CONFIG_FILE_NAME))
 
 def config_DL(configDict):
     k = 'USE_DL'
@@ -827,6 +831,9 @@ def config():
     if useScipion and not getScipionHome():
         print(red("$SCIPION_HOME is not set and scipion is not in the path. Use 'export XMIPP_NOSCIPION=True; ./xmipp' to configure without scipion"))
         return False
+
+    if new_config_dict['VERIFIED'] == '':
+        new_config_dict['VERIFIED'] = 'False'
 
     configCompiler(new_config_dict)
     configMPI(new_config_dict)
@@ -843,7 +850,9 @@ def config():
 def checkConfig():
     print("Checking configuration ------------------------------")
     ensureConfig()
-    if not 'VERIFIED' in configDict:
+    newConf = {}  # to update the config if something fails
+    print configDict['VERIFIED']
+    if configDict['VERIFIED'] != 'True':
         if not checkCompiler(configDict):
             print(red("Cannot compile"))
             print("Possible solutions")
@@ -860,12 +869,12 @@ def checkConfig():
         if not checkCuda(configDict):
             print(red("Cannot compile with NVCC, continuing without CUDA"))
             runJob("rm xmipp_cuda_test*")  # if fails, the test files remains
-            configDict["CUDA"]="False"
+            newConf["CUDA"]="False"
         if not checkMatlab(configDict):
             print(red("Cannot compile with Matlab, continuing without Matlab"))
-            configDict["MATLAB"]="False"
-        configDict['VERIFIED']="True"
-        writeConfig(configDict)
+            newConf["MATLAB"]="False"
+        newConf['VERIFIED']="True"
+        updateConfig(newConf)
     return True
 
 

--- a/xmipp
+++ b/xmipp
@@ -904,8 +904,8 @@ def compileModule(Nproc,module):
                     if k in failingBin.group(1):
                         print(red("\nSome error found compiling '%s' program."
                                   % failingBin.group(1).split('/')[-1]))
-                        print(red("You can skip this program running 'export %s' "
-                                  "or including '%s' in the config file." % (v, v)))
+                        print(red("You can skip this program by including '%s' "
+                                  "in the config file." % (v)))
         print(red("\nSome error occurred during the compilation of '%s'.\n" % module))
         sys.exit(1)
     return ok

--- a/xmipp
+++ b/xmipp
@@ -49,10 +49,10 @@ SCIPION_EM_XMIPP = 'scipion-em-xmipp'
 CUFFTADVISOR = 'cuFFTAdvisor'
 
 REPOSITORIES = {XMIPP: 'https://github.com/I2PC/xmipp.git',
-                                    XMIPP_CORE : 'https://github.com/I2PC/xmippCore.git',
-                                    XMIPP_VIZ: 'https://github.com/I2PC/xmippViz.git',
-                                    SCIPION_EM_XMIPP: 'https://github.com/I2PC/scipion-em-xmipp.git',
-                                    CUFFTADVISOR: 'https://github.com/DStrelak/cuFFTAdvisor.git'}
+                XMIPP_CORE : 'https://github.com/I2PC/xmippCore.git',
+                XMIPP_VIZ: 'https://github.com/I2PC/xmippViz.git',
+                SCIPION_EM_XMIPP: 'https://github.com/I2PC/scipion-em-xmipp.git',
+                CUFFTADVISOR: 'https://github.com/DStrelak/cuFFTAdvisor.git'}
 
 TMP_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'tmp')
 CONFIG_FILE_NAME = "xmipp.conf"

--- a/xmipp
+++ b/xmipp
@@ -948,7 +948,7 @@ def compile(Nproc):
     return True
 
 def runTests(testNames):
-    if len(testNames)==0 or 'help' in  testNames or '--help' in testNames:
+    if len(testNames)==0 or 'help' in testNames or '--help' in testNames:
         print("Usage: xmipp test op\n"
               "\n"
               "         op = --show: Show how to invoke all available tests\n"
@@ -990,9 +990,11 @@ def runTests(testNames):
     args = "%s %s %s" % ("tests/data", url, dataset)
     runJob("bin/xmipp_sync_data %s %s" % (task, args), cwd='src/xmipp')
 
+    configDict = readConfigFile(CONFIG_FILE_NAME)
+    noCudaStr = '--noCuda' if configDict['CUDA'] != 'True' else ''
     print(" Tests to do: %s" % ', '.join(testNames))
-    runJob("(cd src/xmipp/tests; %s test.py %s)"
-           % (getPython(), ' '.join(testNames)))
+    runJob("(cd src/xmipp/tests; %s test.py %s %s)"
+           % (getPython(), ' '.join(testNames), noCudaStr))  # noCudaStr must be the last
 
 def getPython():
     scipionHome = getScipionHome()

--- a/xmipp
+++ b/xmipp
@@ -38,7 +38,7 @@ from datetime import datetime
 # --K-E-E-P--U-P-D-A-T-E-D-- #
 VERSION_TAG = "Xmipp version"
 ##############################
-XMIPP_VERSION = '3.19.03b3'  #
+XMIPP_VERSION = '3.19.03b4'  #
 RELEASE_DATE = '18/03/2019'  #
 ##############################
 
@@ -1244,9 +1244,9 @@ def usage(msg=''):
           "   addModel login modelName:   Takes a deepLearning model from the src/xmipp/models/<modelName>, makes a tgz, \n"
           "                                   uploads the .tgz according to the <login>. \n"
           "                                   Note that login=usr@server must have write permisions to Nolan machine.\n"
-          "   tar <mode> <version>:       Create a bundle of the xmipp\n"
-          "                                   <mode> can be 'Sources' or 'Binaries'\n"
-          "                                   <version> usually X.YY.MM\n"
+          "   tar <mode> [v=ver] [br=br]: Create a bundle of the xmipp (without arguments shows a detailed help)\n"
+          "                                   <mode> can be 'Sources' or 'Binaries, when Sources put a branch (default: master).'\n"
+          "                                   <ver> usually X.YY.MM\n"
           )
 
 
@@ -1467,12 +1467,19 @@ if __name__ == '__main__':
             sys.exit(1)
         addDeepLearninModel(*sys.argv[2:])
     elif mode=='tar':
-        if not len(sys.argv) in (3, 4):
-            usage("Incorrect number of input parameters")
-        elif len(sys.argv) == 3:
-            runJob("src/xmipp/tar.py %s %s" % (sys.argv[2], XMIPP_VERSION))
-        else:
-            runJob("src/xmipp/tar.py %s" % ' '.join(sys.argv[2:]))
+        if len(sys.argv) < 3:
+            runJob("src/xmipp/tar.py --help")
+            sys.exit(0)
+        ver = XMIPP_VERSION
+        br = 'master'
+        mode = sys.argv[2]
+        for arg in sys.argv[3:]:
+            if arg.startswith('br='):
+                br = arg.split('br=')[1]
+            if arg.startswith('v='):
+                ver = arg.split('v=')[1]
+        runJob("src/xmipp/tar.py %s %s %s" % (mode, ver, br))
+
     else:
         usage(" -> option not found <- \n")
 

--- a/xmipp
+++ b/xmipp
@@ -1270,7 +1270,7 @@ def getCudaVersion(nvcc):
     full_version = log[-1].strip().split(', ')[-1].lstrip('V')
     tokens = full_version.split('.')
     if len(tokens) < 2:
-        tokens.append('0')  # for version 5.0, only '5' is returned
+        tokens.append('0')  # just in case when only one digit is returned
     nvccVersion = float(str(tokens[0] + '.' + tokens[1]))
     return nvccVersion, full_version
 

--- a/xmipp
+++ b/xmipp
@@ -712,7 +712,8 @@ def configCuda(configDict):
                 nvccVersion, nvccFullVersion = getCudaVersion("nvcc")
                 if nvccVersion != 8.0:
                     print(red('Detected CUDA-' + nvccFullVersion + '. Version 8.0 is required.'))
-                    print(red("Skipping CUDA compilation. Please, set cuda-8.0 as default.'"))
+                    print(red("Skipping CUDA compilation. Please, set cuda-8.0 as default "
+                              "to be able to use Xmipp Cuda programs.'"))
                     configDict["CUDA"] = 'False'
                     return
                 configDict["NVCC"] = "nvcc"
@@ -730,6 +731,8 @@ def configCuda(configDict):
                     configDict["CUDA"] = "False"
                     return
                 print(green("%s detected. Using it to compile CUDA related code." % configDict["CXX_CUDA"]))
+            else:
+                configDict["CXX_CUDA"] = configDict["CXX"]
             configDict["NVCC_CXXFLAGS"] = ("--x cu -D_FORCE_INLINES -Xcompiler -fPIC "
                                            "-Wno-deprecated-gpu-targets -ccbin %(CXX_CUDA)s -std=c++11")
         if configDict["NVCC_LINKFLAGS"]=="":
@@ -890,7 +893,7 @@ def compileModule(Nproc,module, tries=0):
         stampVersion()
     log = []
     ok = runJob("scons -j%s"%Nproc, "src/%s"%module, log=log)
-    if not ok:
+    if not ok and tries < 6:
         newConf = {}
         for l in log[-30:]:  # inspecting last 30 lines
             # expected error: 'scons: *** [some/program/to/compile] Error 1'
@@ -901,7 +904,7 @@ def compileModule(Nproc,module, tries=0):
                         print(red("Some error during compiling '%s' program." % failingBin.group(1).split('/')[-1]))
                         print(green("Trying with '%s=%s' to skip that programs." % (v[0], v[1])))
                         newConf.update({v[0]: v[1]})
-        if newConf and tries < 6:
+        if newConf:
             updateConfig(newConf)
             tries += 1
             ok = compileModule(Nproc, module, tries)

--- a/xmipp
+++ b/xmipp
@@ -986,7 +986,7 @@ def runTests(testNames):
     runJob("bin/xmipp_sync_data %s %s" % (task, args), cwd='src/xmipp')
 
     configDict = readConfigFile(CONFIG_FILE_NAME)
-    noCudaStr = '--noCuda' if configDict['CUDA'] != 'True' else ''
+    noCudaStr = '--noCuda' if not is_config_true('CUDA') else ''
     print(" Tests to do: %s" % ', '.join(testNames))
     runJob("(cd src/xmipp/tests; %s test.py %s %s)"
            % (getPython(), ' '.join(testNames), noCudaStr))
@@ -1264,6 +1264,7 @@ def getVersion(onlyNumbers=False):
     return cleanInfo.strip(' ')
 
 def getCudaVersion(nvcc):
+    # FIXME: Refator/unify this with getGccVersion()
     log = []
     runJob(nvcc + " --version", show_output=False, show_command=False, log=log)
     # expected lst line: 'Cuda compilation tools, release 8.0, V8.0.61'


### PR DESCRIPTION
News:
 * Allowing compilation with `g++>5` and `CUDA`: Finding `g++-5` or `g++-4.8` to fill `-ccbin` flag for nvcc compilation if the default `g++` is latter than 5. If no alternative is found `CUDA=False` is set.
 * ~Trying to re-compile if a skippable programs (CUDA or OpenCV based code) is failing via re-setting the xmipp.conf file (`CUDA=False` or `OPENCV=False`, respectively).~
 * Giving a hint if a skkipable failure is found and allowing `CUDA=False` or `OPENCV=False` from Scipion's config file.
 * Avoiding to write  the xmipp.conf from scratch twice in order to avoid resolving dynamic assignations like `%(VAR)s`. Alternatively, `updateConfig(newDict)` is implemented via `sed 's/old/new/' xmipp.conf`.