### PR TITLE
Ds reconstruct significant gpu part1

### DIFF
--- a/applications/tests/function_tests/test_cuda_shift_aligner.cpp
+++ b/applications/tests/function_tests/test_cuda_shift_aligner.cpp
@@ -1,0 +1,84 @@
+#include <gtest/gtest.h>
+#include "reconstruction_cuda/cuda_shift_aligner.h"
+
+template<typename T>
+class CudaShiftAlignerTest : public ::testing::Test { };
+TYPED_TEST_CASE_P(CudaShiftAlignerTest);
+
+template<typename T>
+void correlate2D(FFTSettingsNew<T> &dims) {
+    using std::complex;
+    using Alignment::CudaShiftAligner;
+
+    // allocate and prepare data
+    auto inOut = new complex<T>[dims.fDim().size()];
+    auto ref = new complex<T>[dims.fDim().xy()];
+    for (int n = 0; n < dims.fDim().n(); ++n) {
+        for (int y = 0; y < dims.fDim().y(); ++y) {
+            for (int x = 0; x < dims.fDim().x(); ++x) {
+                int index = (n * dims.fDim().xy()) + (y * dims.fDim().x()) + x;
+                inOut[index] = complex<T>(x + n, y + n);
+                if (0 == n) { // ref is a single image
+                    ref[index] = inOut[index];
+                }
+            }
+        }
+    }
+
+    CudaShiftAligner<T>::computeCorrelations2DOneToN(inOut, ref, dims, true);
+
+    T delta = 0.0001;
+    for (int n = 0; n < dims.fDim().n(); ++n) {
+        for (int y = 0; y < dims.fDim().y(); ++y) {
+            for (int x = 0; x < dims.fDim().x(); ++x) {
+                int index = (n * dims.fDim().xy()) + (y * dims.fDim().x()) + x;
+                auto expected = complex<T>(x, y)
+                        * conj(complex<T>(x + n, y + n));
+                auto actual = inOut[index];
+                EXPECT_NEAR(expected.real(), actual.real(), delta);
+                EXPECT_NEAR(expected.imag(), actual.imag(), delta);
+            }
+        }
+    }
+
+    delete[] inOut;
+    delete[] ref;
+}
+
+
+TYPED_TEST_P( CudaShiftAlignerTest, correlate2DOneToOne)
+{
+    // test one reference vs one image
+    FFTSettingsNew<TypeParam> dims(29, 13);
+}
+
+
+TYPED_TEST_P( CudaShiftAlignerTest, correlate2DOneToMany)
+{
+    // check that n == batch works properly
+    FFTSettingsNew<TypeParam> dims(29, 13, 1, 5, 5);
+}
+
+TYPED_TEST_P( CudaShiftAlignerTest, correlate2DOneToManyBatched1)
+{
+    // test that n mod batch != 0 works
+    FFTSettingsNew<TypeParam> dims(29, 13, 1, 5, 3);
+    correlate2D(dims);
+}
+
+TYPED_TEST_P( CudaShiftAlignerTest, correlate2DOneToManyBatched2)
+{
+    // test that n mod batch = 0 works
+    FFTSettingsNew<TypeParam> dims(29, 13, 1, 6, 3);
+    correlate2D(dims);
+}
+
+REGISTER_TYPED_TEST_CASE_P(CudaShiftAlignerTest,
+    correlate2DOneToOne,
+    correlate2DOneToMany,
+    correlate2DOneToManyBatched1,
+    correlate2DOneToManyBatched2
+);
+
+typedef ::testing::Types<float, double> TestTypes;
+INSTANTIATE_TYPED_TEST_CASE_P(SomeRandomText, CudaShiftAlignerTest, TestTypes);

--- a/applications/tests/function_tests/test_cuda_shift_aligner.cpp
+++ b/applications/tests/function_tests/test_cuda_shift_aligner.cpp
@@ -7,10 +7,12 @@ class CudaShiftAlignerTest : public ::testing::Test { };
 TYPED_TEST_CASE_P(CudaShiftAlignerTest);
 
 template<typename T>
-void correlate2DNoCenter(const FFTSettingsNew<T> &dims) {
+void correlate2DNoCenter(size_t n, size_t batch) {
     using std::complex;
     using Alignment::CudaShiftAligner;
     using Alignment::AlignType;
+
+    FFTSettingsNew<T> dims(30, 14, 1, n, batch); // only even sizes are supported
 
     // allocate and prepare data
     auto inOut = new complex<T>[dims.fDim().size()];
@@ -50,38 +52,29 @@ void correlate2DNoCenter(const FFTSettingsNew<T> &dims) {
     delete[] ref;
 }
 
-template<typename T>
-void correlate2D(size_t n, size_t batch) {
-    correlate2DNoCenter<T>(FFTSettingsNew<T>(29, 13, 1, n, batch)); // odd, odd
-    correlate2DNoCenter<T>(FFTSettingsNew<T>(29, 14, 1, n, batch)); // odd, even
-    correlate2DNoCenter<T>(FFTSettingsNew<T>(30, 13, 1, n, batch)); // even, odd
-    correlate2DNoCenter<T>(FFTSettingsNew<T>(30, 14, 1, n, batch)); // even, even
-}
-
-
 TYPED_TEST_P( CudaShiftAlignerTest, correlate2DOneToOne)
 {
     // test one reference vs one image
-    correlate2D<TypeParam>(1, 1);
+    correlate2DNoCenter<TypeParam>(1, 1);
 }
 
 
 TYPED_TEST_P( CudaShiftAlignerTest, correlate2DOneToMany)
 {
     // check that n == batch works properly
-    correlate2D<TypeParam>(5, 5);
+    correlate2DNoCenter<TypeParam>(5, 5);
 }
 
 TYPED_TEST_P( CudaShiftAlignerTest, correlate2DOneToManyBatched1)
 {
     // test that n mod batch != 0 works
-    correlate2D<TypeParam>(5, 3);
+    correlate2DNoCenter<TypeParam>(5, 3);
 }
 
 TYPED_TEST_P( CudaShiftAlignerTest, correlate2DOneToManyBatched2)
 {
     // test that n mod batch = 0 works
-    correlate2D<TypeParam>(6, 3);
+    correlate2DNoCenter<TypeParam>(6, 3);
 }
 
 template<typename T>

--- a/applications/tests/function_tests/test_cuda_shift_aligner.cpp
+++ b/applications/tests/function_tests/test_cuda_shift_aligner.cpp
@@ -111,7 +111,7 @@ void shift2D(FFTSettingsNew<T> &dims)
     auto shifts = std::vector<Point2D<T>>();
     shifts.reserve(dims.fDim().n());
     for(size_t n = 0; n < dims.fDim().n(); ++n) {
-        // generate shifts so that the Eucledian distance is smaller than max shift
+        // generate shifts so that the Euclidean distance is smaller than max shift
         int shiftX = dist(mt);
         int shiftXSq = shiftX * shiftX;
         int maxShiftY = std::floor(sqrt(maxShiftSq - shiftXSq));

--- a/applications/tests/function_tests/test_cuda_shift_aligner.cpp
+++ b/applications/tests/function_tests/test_cuda_shift_aligner.cpp
@@ -7,9 +7,10 @@ class CudaShiftAlignerTest : public ::testing::Test { };
 TYPED_TEST_CASE_P(CudaShiftAlignerTest);
 
 template<typename T>
-void correlate2D(const FFTSettingsNew<T> &dims) {
+void correlate2DNoCenter(const FFTSettingsNew<T> &dims) {
     using std::complex;
     using Alignment::CudaShiftAligner;
+    using Alignment::AlignType;
 
     // allocate and prepare data
     auto inOut = new complex<T>[dims.fDim().size()];
@@ -26,7 +27,10 @@ void correlate2D(const FFTSettingsNew<T> &dims) {
         }
     }
 
-    CudaShiftAligner<T>::computeCorrelations2DOneToN(inOut, ref, dims);
+    CudaShiftAligner<T> aligner;
+    aligner.init2D(AlignType::OneToN, dims);
+    aligner.load2DReferenceOneToN(ref);
+    aligner.template computeCorrelations2DOneToN<false>(inOut);
 
     T delta = 0.0001;
     for (int n = 0; n < dims.fDim().n(); ++n) {
@@ -48,10 +52,10 @@ void correlate2D(const FFTSettingsNew<T> &dims) {
 
 template<typename T>
 void correlate2D(size_t n, size_t batch) {
-    correlate2D<T>(FFTSettingsNew<T>(29, 13, 1, n, batch)); // odd, odd
-    correlate2D<T>(FFTSettingsNew<T>(29, 14, 1, n, batch)); // odd, even
-    correlate2D<T>(FFTSettingsNew<T>(30, 13, 1, n, batch)); // even, odd
-    correlate2D<T>(FFTSettingsNew<T>(30, 14, 1, n, batch)); // even, even
+    correlate2DNoCenter<T>(FFTSettingsNew<T>(29, 13, 1, n, batch)); // odd, odd
+    correlate2DNoCenter<T>(FFTSettingsNew<T>(29, 14, 1, n, batch)); // odd, even
+    correlate2DNoCenter<T>(FFTSettingsNew<T>(30, 13, 1, n, batch)); // even, odd
+    correlate2DNoCenter<T>(FFTSettingsNew<T>(30, 14, 1, n, batch)); // even, even
 }
 
 
@@ -186,4 +190,4 @@ REGISTER_TYPED_TEST_CASE_P(CudaShiftAlignerTest,
 );
 
 typedef ::testing::Types<float> TestTypes; // FIXME add double
-INSTANTIATE_TYPED_TEST_CASE_P(SomeRandomText, CudaShiftAlignerTest, TestTypes);
+INSTANTIATE_TYPED_TEST_CASE_P(Alignment, CudaShiftAlignerTest, TestTypes);

--- a/applications/tests/function_tests/test_cuda_shift_aligner.cpp
+++ b/applications/tests/function_tests/test_cuda_shift_aligner.cpp
@@ -115,7 +115,7 @@ void shift2D(FFTSettingsNew<T> &dims)
         int shiftX = dist(mt);
         int shiftXSq = shiftX * shiftX;
         int maxShiftY = std::floor(sqrt(maxShiftSq - shiftXSq));
-        int shiftY = dist(mt) % maxShiftY;
+        int shiftY = (0 == maxShiftY) ? 0 : dist(mt) % maxShiftY;
         shifts.emplace_back(shiftX, shiftY);
     }
 

--- a/libraries/data/dimensions.h
+++ b/libraries/data/dimensions.h
@@ -55,7 +55,11 @@ public:
         return m_x * m_y;
     }
 
-    constexpr size_t size() const {
+    inline constexpr size_t xyz() const {
+        return m_x * m_y * m_z;
+    }
+
+    inline constexpr size_t size() const {
         return m_x * m_y * m_z * m_n;
     }
 

--- a/libraries/data/fft_settings_new.h
+++ b/libraries/data/fft_settings_new.h
@@ -42,6 +42,7 @@ public:
             m_batch(batch),
             m_isInPlace(isInPlace) {
         assert(batch <= n);
+        assert(batch > 0);
     };
 
     explicit FFTSettingsNew(const Dimensions &spatial,
@@ -52,6 +53,7 @@ public:
             m_batch(batch),
             m_isInPlace(isInPlace) {
         assert(batch <= spatial.n());
+        assert(batch > 0);
     };
 
     inline constexpr Dimensions sDim() const {

--- a/libraries/data/fft_settings_new.h
+++ b/libraries/data/fft_settings_new.h
@@ -1,0 +1,100 @@
+/***************************************************************************
+ *
+ * Authors:    David Strelak (davidstrelak@gmail.com)
+ *
+ * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ * 02111-1307  USA
+ *
+ *  All comments concerning this program package may be sent to the
+ *  e-mail address 'xmipp@cnb.csic.es'
+ ***************************************************************************/
+
+#ifndef FFTSETTINGS_NEW_H_
+#define FFTSETTINGS_NEW_H_
+
+//#include <iosfwd>
+#include "dimensions.h"
+#include <cassert>
+#include <complex>
+
+template<typename T>
+class FFTSettingsNew {
+public:
+    explicit FFTSettingsNew(size_t x, size_t y = 1, size_t z = 1, size_t n = 1,
+            size_t batch = 1, // meaning no batch processing
+            bool isInPlace = false) :
+            m_spatial(Dimensions(x, y, z, n)),
+            m_freq(x / 2 + 1, y, z, n),
+            m_batch(batch),
+            m_isInPlace(isInPlace) {
+        assert(batch <= n);
+    };
+
+    explicit FFTSettingsNew(const Dimensions &spatial,
+            size_t batch = 1, // meaning no batch processing
+            bool isInPlace = false) :
+            m_spatial(spatial),
+            m_freq(spatial.x() / 2 + 1, spatial.y(), spatial.z(), spatial.n()),
+            m_batch(batch),
+            m_isInPlace(isInPlace) {
+        assert(batch <= spatial.n());
+    };
+
+    inline constexpr Dimensions sDim() const {
+        return m_spatial;
+    }
+
+    inline constexpr Dimensions fDim() const {
+        return m_freq;
+    }
+
+    inline constexpr size_t batch() const {
+        return m_batch;
+    }
+
+    inline constexpr size_t fBytesSingle() const {
+        return m_freq.xyz() * sizeof(std::complex<T>);
+    }
+
+    inline constexpr size_t fBytes() const {
+        return m_freq.size() * sizeof(std::complex<T>);
+    }
+
+    inline constexpr size_t fBytesBatch() const {
+        return m_freq.xyz() * m_batch * sizeof(std::complex<T>);
+    }
+
+    inline constexpr size_t sBytesSingle() const {
+        return m_spatial.xyz() * sizeof(T);
+    }
+
+    inline constexpr size_t sBytes() const {
+        return m_spatial.size() * sizeof(T);
+    }
+
+    inline constexpr size_t sBytesBatch() const {
+        return m_spatial.xyz() * m_batch * sizeof(T);
+    }
+
+private:
+    Dimensions m_spatial;
+    Dimensions m_freq;
+    size_t m_batch;
+    size_t m_isInPlace;
+};
+
+#endif /* FFTSETTINGS_NEW_H_ */

--- a/libraries/data/filters.cpp
+++ b/libraries/data/filters.cpp
@@ -1567,7 +1567,7 @@ T bestShift(MultidimArray<T> &Mcorr,
     else
     {
     	int maxShift2=maxShift*maxShift;
-    	double bestCorr=std::numeric_limits<T>::min();
+    	double bestCorr=-1e38;
     	for (int i=-maxShift; i<=maxShift; i++)
     		for (int j=-maxShift; j<=maxShift; j++)
     		{

--- a/libraries/data/filters.cpp
+++ b/libraries/data/filters.cpp
@@ -1567,11 +1567,11 @@ T bestShift(MultidimArray<T> &Mcorr,
     else
     {
     	int maxShift2=maxShift*maxShift;
-    	double bestCorr=-1e38;
+    	double bestCorr=std::numeric_limits<T>::min();
     	for (int i=-maxShift; i<=maxShift; i++)
     		for (int j=-maxShift; j<=maxShift; j++)
     		{
-    			if (i*i+j*j>maxShift2)
+    			if (i*i+j*j>maxShift2) // continue if the eucledian distance is too far
     				continue;
     			else if (A2D_ELEM(Mcorr, i, j)>bestCorr)
     			{

--- a/libraries/data/filters.cpp
+++ b/libraries/data/filters.cpp
@@ -1571,7 +1571,7 @@ T bestShift(MultidimArray<T> &Mcorr,
     	for (int i=-maxShift; i<=maxShift; i++)
     		for (int j=-maxShift; j<=maxShift; j++)
     		{
-    			if (i*i+j*j>maxShift2) // continue if the eucledian distance is too far
+    			if (i*i+j*j>maxShift2) // continue if the Euclidean distance is too far
     				continue;
     			else if (A2D_ELEM(Mcorr, i, j)>bestCorr)
     			{

--- a/libraries/data/grids.h
+++ b/libraries/data/grids.h
@@ -1493,7 +1493,7 @@ public:
 
     /** Show volume.
         \\Ex: std::cout << V; */
-    friend std::ostream& operator <<< > (std::ostream &o, const GridVolumeT &GV);
+//    friend std::ostream& operator <<< > (std::ostream &o, const GridVolumeT &GV);
     //@}
 };
 

--- a/libraries/data/grids.h
+++ b/libraries/data/grids.h
@@ -1490,11 +1490,6 @@ public:
         }
     }
 #undef DEBUG
-
-    /** Show volume.
-        \\Ex: std::cout << V; */
-//    friend std::ostream& operator <<< > (std::ostream &o, const GridVolumeT &GV);
-    //@}
 };
 
 typedef GridVolumeT<double> GridVolume;

--- a/libraries/data/point2D.h
+++ b/libraries/data/point2D.h
@@ -32,12 +32,13 @@
 template<typename T>
 class Point2D: Point {
 public:
-    explicit Point2D(T x, T y) :
+     Point2D(T x, T y) :
             x(x), y(y) {
     }
     ;
-    const T x;
-    const T y;
+    T x; // FIXME this should be private member with setters / getters
+    T y;
+
 
     Point2D operator/=(T rhs) const {
         return Point2D(x / rhs, y / rhs);

--- a/libraries/reconstruction/ashift_aligner.cpp
+++ b/libraries/reconstruction/ashift_aligner.cpp
@@ -1,0 +1,52 @@
+/***************************************************************************
+ *
+ * Authors:    David Strelak (davidstrelak@gmail.com)
+ *
+ * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ * 02111-1307  USA
+ *
+ *  All comments concerning this program package may be sent to the
+ *  e-mail address 'xmipp@cnb.csic.es'
+ ***************************************************************************/
+#include "ashift_aligner.h"
+
+namespace Alignment {
+
+template<typename T>
+std::vector<Point2D<T>> AShiftAligner<T>::computeShiftFromCorrelations2D(
+        T *h_centers, MultidimArray<T> &helper, size_t nDim,
+        size_t centerSize, size_t maxShift) {
+    assert(centerSize == (2 * maxShift + 1));
+    assert(helper.xdim == helper.ydim);
+    assert(helper.xdim == centerSize);
+    T x;
+    T y;
+    auto result = std::vector<Point2D<T>>();
+    helper.setXmippOrigin(); // tell the array that the 'center' is in the center
+    for (size_t n = 0; n < nDim; ++n) {
+        helper.data = h_centers + n * centerSize * centerSize;
+        bestShift(helper, x, y, nullptr, maxShift);
+        result.emplace_back(x, y);
+    }
+    // avoid data corruption
+    helper.data = nullptr;
+    return result;
+}
+
+template class AShiftAligner<float>;
+
+} /* namespace Alignment */

--- a/libraries/reconstruction/ashift_aligner.h
+++ b/libraries/reconstruction/ashift_aligner.h
@@ -1,0 +1,52 @@
+/***************************************************************************
+ *
+ * Authors:    David Strelak (davidstrelak@gmail.com)
+ *
+ * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ * 02111-1307  USA
+ *
+ *  All comments concerning this program package may be sent to the
+ *  e-mail address 'xmipp@cnb.csic.es'
+ ***************************************************************************/
+
+#ifndef LIBRARIES_RECONSTRUCTION_ASHIFT_ALIGNER_H_
+#define LIBRARIES_RECONSTRUCTION_ASHIFT_ALIGNER_H_
+
+//#include <complex>
+#include <vector>
+//#include "data/dimensions.h"
+#include "data/point2D.h"
+#include "data/filters.h"
+#include <cassert>
+
+namespace Alignment {
+
+enum class AlignType { OneToN, NToM, Consecutive };
+
+template<typename T>
+class AShiftAligner {
+public:
+    static std::vector<Point2D<T>> computeShiftFromCorrelations2D(
+        T *h_centers, MultidimArray<T> &helper, size_t nDim,
+        size_t centerSize, size_t maxShift);
+
+    virtual void release() = 0;
+};
+
+} /* namespace Alignment */
+
+#endif /* LIBRARIES_RECONSTRUCTION_ASHIFT_ALIGNER_H_ */

--- a/libraries/reconstruction/ashift_aligner.h
+++ b/libraries/reconstruction/ashift_aligner.h
@@ -26,9 +26,7 @@
 #ifndef LIBRARIES_RECONSTRUCTION_ASHIFT_ALIGNER_H_
 #define LIBRARIES_RECONSTRUCTION_ASHIFT_ALIGNER_H_
 
-//#include <complex>
 #include <vector>
-//#include "data/dimensions.h"
 #include "data/point2D.h"
 #include "data/filters.h"
 #include <cassert>

--- a/libraries/reconstruction_cuda/cuda_gpu_movie_alignment_correlation_kernels.cu
+++ b/libraries/reconstruction_cuda/cuda_gpu_movie_alignment_correlation_kernels.cu
@@ -54,7 +54,7 @@ void scaleFFT2DKernel(const T* __restrict__ in, T* __restrict__ out,
     if (idx >= outX || idy >= outY ) return;
     size_t fIndex = idy*outX + idx; // index within single image
     U filterCoef = filter[fIndex];
-    U centerCoef = 1-2*((idx+idy)&1); // center FFT, input must have be even
+    U centerCoef = 1-2*((idx+idy)&1); // center FT, input must be even
     int yhalf = outY/2;
 
     size_t origY = (idy <= yhalf) ? idy : (inY - (outY-idy)); // take top N/2+1 and bottom N/2 lines
@@ -73,6 +73,52 @@ void scaleFFT2DKernel(const T* __restrict__ in, T* __restrict__ out,
         }
     }
 }
+
+/**
+ * Function computes correlation of one signal and many others.
+ * If 'center', the signal has to be even
+ * @param ref first signal in FT
+ * @param inOut other signals in FT, also output (centered FTs)
+ * @param xDim of the signal
+ * @param yDim of the signal
+ * @param nDim no of other signals
+ */
+template<typename T, bool center> // float2 or double2
+__global__
+void computeCorrelations2DOneToNKernel(
+        T* __restrict__ inOut,
+        const T* __restrict__ ref,
+        int xDim, int yDim, int nDim) {
+    // assign element to thread
+#if TILE > 1
+    int id = threadIdx.y * blockDim.x + threadIdx.x;
+    int tidX = threadIdx.x % TILE + (id / (blockDim.y * TILE)) * TILE;
+    int tidY = (id / TILE) % blockDim.y;
+    int idx = blockIdx.x*blockDim.x + tidX;
+    int idy = blockIdx.y*blockDim.y + tidY;
+#else
+    volatile int idx = blockIdx.x*blockDim.x + threadIdx.x;
+    volatile int idy = blockIdx.y*blockDim.y + threadIdx.y;
+#endif
+    int centerCoeff = 1-2*((idx+idy)&1); // center FT, input must be even
+
+    if (idx >= xDim || idy >= yDim ) return;
+    int elem = idy*xDim + idx;
+    T refVal = ref[elem]; // load reference value
+
+    for (int i = 0; i < nDim; i++) {
+        int offset = i * xDim * yDim;
+        T otherVal = inOut[offset + elem];
+        T tmp;
+        tmp.x = (refVal.x * otherVal.x) + (refVal.y * otherVal.y);
+        tmp.y = (refVal.y * otherVal.x) - (refVal.x * otherVal.y);
+        if (center) {
+            otherVal *= centerCoeff;
+        }
+        inOut[offset + elem] = tmp;
+    }
+}
+
 
 /**
  * Function computes correlation between two batches of images
@@ -104,7 +150,7 @@ void correlate(const T* __restrict__ in1, const T* __restrict__ in2,
     volatile int idx = blockIdx.x*blockDim.x + threadIdx.x;
     volatile int idy = blockIdx.y*blockDim.y + threadIdx.y;
 #endif
-    int a = 1-2*((idx+idy)&1); // center FFT, input must have be even
+    int a = 1-2*((idx+idy)&1); // center FFT, input must be even
 
     if (idx >= xDim || idy >= yDim ) return;
     size_t pixelIndex = idy*xDim + idx; // index within single image

--- a/libraries/reconstruction_cuda/cuda_gpu_movie_alignment_correlation_kernels.cu
+++ b/libraries/reconstruction_cuda/cuda_gpu_movie_alignment_correlation_kernels.cu
@@ -27,6 +27,7 @@
 #define CUDA_GPU_MOVIE_CORRELATION_KERNELS
 
 #include "reconstruction/movie_alignment_gpu_defines.h"
+#include "reconstruction_cuda/cuda_basic_math.h"
 
 /**
  * Kernel performing scaling of the 2D FFT images, with possible normalization,
@@ -113,7 +114,7 @@ void computeCorrelations2DOneToNKernel(
         tmp.x = (refVal.x * otherVal.x) + (refVal.y * otherVal.y);
         tmp.y = (refVal.y * otherVal.x) - (refVal.x * otherVal.y);
         if (center) {
-            otherVal *= centerCoeff;
+            tmp *= centerCoeff;
         }
         inOut[offset + elem] = tmp;
     }
@@ -187,13 +188,14 @@ void correlate(const T* __restrict__ in1, const T* __restrict__ in2,
  * @param in input images
  * @param out output images
  * @param xDim input X dim
- * @param yDim output Y dim
+ * @param yDim input Y dim
  * @param noOfImgs no if images to process
- * @param outDim output dimension
+ * @param outDim output dimension(s)
  */
 template<typename T>
 __global__
-void cropSquareInCenter(const T* __restrict__ in, T* out, int xDim, int yDim, int noOfImgs,
+void cropSquareInCenter(const T* __restrict__ in, T* __restrict__ out,
+        int xDim, int yDim, int noOfImgs,
         int outDim) {
     // assign pixel to thread
     int idx = blockIdx.x*blockDim.x + threadIdx.x;

--- a/libraries/reconstruction_cuda/cuda_gpu_movie_alignment_correlation_kernels.cu
+++ b/libraries/reconstruction_cuda/cuda_gpu_movie_alignment_correlation_kernels.cu
@@ -198,8 +198,8 @@ void cropSquareInCenter(const T* __restrict__ in, T* __restrict__ out,
         int xDim, int yDim, int noOfImgs,
         int outDim) {
     // assign pixel to thread
-    int idx = blockIdx.x*blockDim.x + threadIdx.x;
-    int idy = blockIdx.y*blockDim.y + threadIdx.y;
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    int idy = blockIdx.y * blockDim.y + threadIdx.y;
 
     if (idx >= outDim || idy >= outDim ) return;
 

--- a/libraries/reconstruction_cuda/cuda_shift_aligner.cpp
+++ b/libraries/reconstruction_cuda/cuda_shift_aligner.cpp
@@ -1,0 +1,113 @@
+/***************************************************************************
+ *
+ * Authors:    David Strelak (davidstrelak@gmail.com)
+ *
+ * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ * 02111-1307  USA
+ *
+ *  All comments concerning this program package may be sent to the
+ *  e-mail address 'xmipp@cnb.csic.es'
+ ***************************************************************************/
+
+#include <cuda_runtime_api.h>
+#include "reconstruction_cuda/cuda_utils.h"
+#include "reconstruction_cuda/cuda_basic_math.h"
+#include "cuda_shift_aligner.h"
+#include "reconstruction_cuda/cuda_gpu_movie_alignment_correlation_kernels.cu"
+
+namespace Alignment {
+
+template<typename T>
+void CudaShiftAligner<T>::computeCorrelations2DOneToN(
+        std::complex<T> *h_inOut,
+        std::complex<T> *h_ref,
+        FFTSettingsNew<T> &dims,
+        bool copyToHost) {
+    // FIXME make sure that dim is less than 4GB
+    // allocate and copy reference signal
+    std::complex<T> *d_ref;
+    gpuErrchk(cudaMalloc(&d_ref, dims.fBytesSingle()));
+    gpuErrchk(cudaMemcpy(d_ref, h_ref, dims.fBytesSingle(),
+            cudaMemcpyHostToDevice));
+
+    // compute kernel size
+    dim3 dimBlock(BLOCK_DIM_X, BLOCK_DIM_X);
+    dim3 dimGrid(
+            ceil(dims.fDim().x()/(float)dimBlock.x),
+            ceil(dims.fDim().y()/(float)dimBlock.y));
+
+    // allocate memory for other signals
+    std::complex<T> *d_inOut;
+    gpuErrchk(cudaMalloc(&d_inOut, dims.fBytesBatch()));
+
+    // process other signals
+    for (size_t offset = 0; offset < dims.fDim().n(); offset += dims.batch()) {
+        // how many signals to process
+        size_t toProcess = std::min(dims.batch(), dims.fDim().n() - offset);
+
+        // copy memory
+        gpuErrchk(cudaMemcpy(
+                d_inOut,
+                h_inOut + offset * dims.fDim().xy(),
+                toProcess * dims.fBytesSingle(),
+                    cudaMemcpyHostToDevice));
+
+        computeCorrelations2DOneToN<false>(&dimBlock, &dimGrid, // FIXME handle center template
+                d_inOut, d_ref,
+                dims.fDim().x(), dims.fDim().y(), toProcess);
+
+        // copy data back if requested
+        if (copyToHost) {
+            gpuErrchk(cudaMemcpy(
+                    h_inOut + offset * dims.fDim().xy(),
+                    d_inOut,
+                    toProcess * dims.fBytesSingle(),
+                    cudaMemcpyDeviceToHost));
+        }
+    }
+
+    // release memory
+    gpuErrchk(cudaFree(d_inOut));
+    gpuErrchk(cudaFree(d_ref));
+}
+
+template<typename T>
+template<bool center>
+void CudaShiftAligner<T>::computeCorrelations2DOneToN(
+        void *dimBlock, void *dimGrid,
+        std::complex<T> *d_inOut,
+        std::complex<T> *d_ref,
+        size_t xDim, size_t yDim, size_t nDim) {
+    if (std::is_same<T, float>::value) {
+        computeCorrelations2DOneToNKernel<float2, center>
+            <<<*(dim3*)dimGrid, *(dim3*)dimBlock>>> (
+                (float2*)d_inOut, (float2*)d_ref,
+                xDim, yDim, nDim);
+    } else if (std::is_same<T, double>::value) {
+        computeCorrelations2DOneToNKernel<double2, center>
+            <<<*(dim3*)dimGrid, *(dim3*)dimBlock>>> (
+                (double2*)d_inOut, (double2*)d_ref,
+                xDim, yDim, nDim);
+    } else {
+        REPORT_ERROR(ERR_TYPE_INCORRECT, "Not implemented");
+    }
+}
+
+template class CudaShiftAligner<float>;
+template class CudaShiftAligner<double>;
+
+} /* namespace Alignment */

--- a/libraries/reconstruction_cuda/cuda_shift_aligner.cpp
+++ b/libraries/reconstruction_cuda/cuda_shift_aligner.cpp
@@ -75,14 +75,12 @@ void CudaShiftAligner<T>::computeCorrelations2DOneToN(
     gpuErrchk(cudaFree(d_ref));
 }
 
-
 template<typename T>
 std::vector<Point2D<T>> CudaShiftAligner<T>::computeShift2DOneToN(
         T *h_others,
         T *h_ref,
         FFTSettingsNew<T> &dims,
-        size_t maxShift,
-        size_t batch) {
+        size_t maxShift) {
     // transform reference signal
     GpuMultidimArrayAtGpu<T> d_ref(dims.sDim().x(), dims.sDim().y());
     d_ref.copyToGpu(h_ref);
@@ -190,6 +188,7 @@ std::vector<Point2D<T>> CudaShiftAligner<T>::computeShifts2DOneToN(
     cropSquareInCenter<<<dimGridCrop, dimBlockCrop>>>(
             spatial.d_data, (T*)ft.d_data,
             xDimS, yDimF, nDim, centerSize);
+    // FIXME make sure that spatial_d_data is big enough, there is invalid memory access now
 
     // copy data back
     gpuErrchk(cudaMemcpy(h_centers, ft.d_data,

--- a/libraries/reconstruction_cuda/cuda_shift_aligner.cpp
+++ b/libraries/reconstruction_cuda/cuda_shift_aligner.cpp
@@ -75,6 +75,200 @@ void CudaShiftAligner<T>::computeCorrelations2DOneToN(
     gpuErrchk(cudaFree(d_ref));
 }
 
+
+template<typename T>
+std::vector<Point2D<T>> CudaShiftAligner<T>::computeShift2DOneToN(
+        T *h_others,
+        T *h_ref,
+        FFTSettingsNew<T> &dims,
+        size_t maxShift,
+        size_t batch) {
+    // transform reference signal
+    GpuMultidimArrayAtGpu<T> d_ref(dims.sDim().x(), dims.sDim().y());
+    d_ref.copyToGpu(h_ref);
+    mycufftHandle handleRef;
+    GpuMultidimArrayAtGpu<std::complex<T>> d_ref_ft;
+    d_ref.fft(d_ref_ft, handleRef);
+
+    // prepare space for FT in batch
+    mycufftHandle handleOthers;
+    GpuMultidimArrayAtGpu<std::complex<T>> d_others_ft;
+    GpuMultidimArrayAtGpu<T> d_others(dims.sDim().x(), dims.sDim().y(), dims.sDim().z(), dims.batch());
+
+    size_t centerSize = maxShift * 2 + 1;
+    auto h_centers = new T[centerSize * centerSize * dims.batch()];
+    MultidimArray<T> helper(centerSize, centerSize);
+    auto origHelperData = helper.data;
+    mycufftHandle handleOthersInv; // for inverse transform
+
+    // reserve enough space for shifts
+    auto result = std::vector<Point2D<T>>();
+    result.reserve(dims.fDim().n());
+    // process signals
+    for (size_t offset = 0; offset < dims.fDim().n(); offset += dims.batch()) {
+        // how many signals to process
+        size_t toProcess = std::min(dims.batch(), dims.fDim().n() - offset);
+
+        // copy memory
+       gpuErrchk(cudaMemcpy(
+               d_others.d_data,
+               h_others + offset * dims.sDim().xy(),
+               toProcess * dims.sBytesSingle(),
+               cudaMemcpyHostToDevice));
+
+        // perform FT
+        d_others.fft(d_others_ft, handleOthers);
+
+        // compute shifts
+        auto shifts = computeShifts2DOneToN(
+                d_others_ft.d_data,
+                d_ref_ft.d_data,
+                dims.fDim().x(), dims.fDim().y(), toProcess,
+                d_others.d_data, handleOthersInv, // reuse data
+                dims.sDim().x(),
+                h_centers, helper, maxShift);
+
+        // append shifts to existing results
+        result.insert(result.end(), shifts.begin(), shifts.end());
+    }
+
+    // release memory
+    delete[] h_centers;
+    // avoid memory leak
+    helper.data = origHelperData;
+    return result;
+}
+
+template<typename T>
+std::vector<Point2D<T>> CudaShiftAligner<T>::computeShiftFromCorrelations2D(
+        T *h_centers, MultidimArray<T> &helper, size_t nDim,
+        size_t centerSize, size_t maxShift) {
+    assert(centerSize == (2 * maxShift + 1));
+    assert(helper.xdim == helper.ydim);
+    assert(helper.xdim == centerSize);
+    T x;
+    T y;
+    auto result = std::vector<Point2D<T>>();
+    helper.setXmippOrigin(); // tell the array that the 'center' is in the center
+    for (size_t n = 0; n < nDim; ++n) {
+        helper.data = h_centers + n * centerSize * centerSize;
+        bestShift(helper, x, y, nullptr, maxShift);
+        result.emplace_back(x, y);
+    }
+    // avoid data corruption
+    helper.data = nullptr;
+    return result;
+}
+
+template<typename T>
+std::vector<Point2D<T>> CudaShiftAligner<T>::computeShifts2DOneToN(
+        std::complex<T> *d_othersF,
+        std::complex<T> *d_ref,
+        size_t xDimF, size_t yDimF, size_t nDim,
+        T *d_othersS, mycufftHandle handle,
+        size_t xDimS,
+        T *h_centers, MultidimArray<T> &helper, size_t maxShift) {
+    // correlate signals and shift FT so that it will be centered after IFT
+    computeCorrelations2DOneToN<true>(
+            d_othersF, d_ref,
+            xDimF, yDimF, nDim);
+
+    // perform IFT
+    GpuMultidimArrayAtGpu<std::complex<T>> ft(
+            xDimF, yDimF, 1, nDim, d_othersF);
+    GpuMultidimArrayAtGpu<T> spatial(
+            xDimS, yDimF, 1, nDim, d_othersS);
+    ft.ifft(spatial, handle);
+
+    // crop images in spatial domain, use memory for FT to avoid realocation
+    // FIXME add check that the resulting centers are small enough to fit the FT
+    size_t centerSize = maxShift * 2 + 1;
+    dim3 dimBlockCrop(BLOCK_DIM_X, BLOCK_DIM_X);
+    dim3 dimGridCrop(
+            std::ceil(centerSize / (float)dimBlockCrop.x),
+            std::ceil(centerSize / (float)dimBlockCrop.y));
+    cropSquareInCenter<<<dimGridCrop, dimBlockCrop>>>(
+            spatial.d_data, (T*)ft.d_data,
+            xDimS, yDimF, nDim, centerSize);
+
+    // copy data back
+    gpuErrchk(cudaMemcpy(h_centers, ft.d_data,
+            nDim * centerSize * centerSize * sizeof(T),
+            cudaMemcpyDeviceToHost));
+
+    // unbind the memory, otherwise the destructor would release it
+    ft.d_data = nullptr;
+    spatial.d_data = nullptr;
+
+    // compute shifts
+    return computeShiftFromCorrelations2D(h_centers, helper, nDim, centerSize, maxShift);
+}
+
+template<typename T>
+std::vector<Point2D<T>> CudaShiftAligner<T>::computeShift2DOneToN(
+    std::complex<T> *h_others,
+    std::complex<T> *h_ref,
+    FFTSettingsNew<T> &dims,
+    size_t maxShift) {
+    // FIXME make sure that dim is less than 4GB
+    // FIXME shift should be less than half of the input
+    // allocate and copy reference signal
+    std::complex<T> *d_ref;
+    gpuErrchk(cudaMalloc(&d_ref, dims.fBytesSingle()));
+    gpuErrchk(cudaMemcpy(d_ref, h_ref, dims.fBytesSingle(),
+            cudaMemcpyHostToDevice));
+
+    // allocate memory for other signals
+    std::complex<T> *d_others;
+    gpuErrchk(cudaMalloc(&d_others, dims.fBytesBatch()));
+    T *d_spatial;
+    gpuErrchk(cudaMalloc(&d_spatial, dims.sBytesBatch()));
+
+    size_t centerSize = maxShift * 2 + 1;
+    auto h_centers = new T[centerSize * centerSize * dims.batch()];
+    MultidimArray<T> helper(centerSize, centerSize);
+    auto origHelperData = helper.data;
+    mycufftHandle handle;
+
+    // reserve enough space for shifts
+    auto result = std::vector<Point2D<T>>();
+    result.reserve(dims.fDim().n());
+    // process signals
+    for (size_t offset = 0; offset < dims.fDim().n(); offset += dims.batch()) {
+        // how many signals to process
+        size_t toProcess = std::min(dims.batch(), dims.fDim().n() - offset);
+
+        // copy memory
+        gpuErrchk(cudaMemcpy(
+                d_others,
+                h_others + offset * dims.fDim().xy(),
+                toProcess * dims.fBytesSingle(),
+                cudaMemcpyHostToDevice));
+
+        // compute shift
+        auto shifts = computeShifts2DOneToN(
+                d_others,
+                d_ref,
+                dims.fDim().x(), dims.fDim().y(), toProcess,
+                d_spatial, handle,
+                dims.sDim().x(),
+                h_centers, helper, maxShift);
+
+        // append shifts to existing results
+        result.insert(result.end(), shifts.begin(), shifts.end());
+    }
+
+    // release memory
+    delete[] h_centers;
+    gpuErrchk(cudaFree(d_ref));
+    gpuErrchk(cudaFree(d_others));
+    gpuErrchk(cudaFree(d_spatial));
+    // avoid memory leak
+    helper.data = origHelperData;
+
+    return result;
+}
+
 template<typename T>
 template<bool center>
 void CudaShiftAligner<T>::computeCorrelations2DOneToN(
@@ -102,6 +296,6 @@ void CudaShiftAligner<T>::computeCorrelations2DOneToN(
 }
 
 template class CudaShiftAligner<float>;
-template class CudaShiftAligner<double>;
+//template class CudaShiftAligner<double>;
 
 } /* namespace Alignment */

--- a/libraries/reconstruction_cuda/cuda_shift_aligner.h
+++ b/libraries/reconstruction_cuda/cuda_shift_aligner.h
@@ -41,6 +41,31 @@ namespace Alignment {
 template<typename T>
 class CudaShiftAligner {
 public:
+    static std::vector<Point2D<T>> computeShift2DOneToN(
+        T *h_others,
+        T *h_ref,
+        FFTSettingsNew<T> &dims,
+        size_t maxShift,
+        size_t batch = 1);
+
+    static std::vector<Point2D<T>> computeShift2DOneToN(
+        std::complex<T> *h_others,
+        std::complex<T> *h_ref,
+        FFTSettingsNew<T> &dims,
+        size_t maxShift);
+
+    static std::vector<Point2D<T>> computeShifts2DOneToN(
+        std::complex<T> *d_othersF,
+        std::complex<T> *d_ref,
+        size_t xDimF, size_t yDimF, size_t nDim,
+        T *d_othersS, mycufftHandle handle,
+        size_t xDimS,
+        T *h_centers, MultidimArray<T> &helper, size_t maxShift);
+
+    static std::vector<Point2D<T>> computeShiftFromCorrelations2D(
+        T *h_centers, MultidimArray<T> &helper, size_t nDim,
+        size_t centerSize, size_t maxShift);
+
     static void computeCorrelations2DOneToN(
         std::complex<T> *h_inOut,
         const std::complex<T> *h_ref,

--- a/libraries/reconstruction_cuda/cuda_shift_aligner.h
+++ b/libraries/reconstruction_cuda/cuda_shift_aligner.h
@@ -1,0 +1,57 @@
+/***************************************************************************
+ *
+ * Authors:    David Strelak (davidstrelak@gmail.com)
+ *
+ * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ * 02111-1307  USA
+ *
+ *  All comments concerning this program package may be sent to the
+ *  e-mail address 'xmipp@cnb.csic.es'
+ ***************************************************************************/
+
+#ifndef LIBRARIES_RECONSTRUCTION_ADAPT_CUDA_CUDA_SHIFT_ALIGNER_H_
+#define LIBRARIES_RECONSTRUCTION_ADAPT_CUDA_CUDA_SHIFT_ALIGNER_H_
+
+#include <type_traits>
+//#include "reconstruction/ashift_aligner.h"
+#include "data/fft_settings_new.h"
+#include "core/xmipp_error.h"
+//#include "reconstruction_adapt_cuda/cuda_compatibility.h"
+
+namespace Alignment {
+
+template<typename T>
+class CudaShiftAligner {
+public:
+    static void computeCorrelations2DOneToN(
+        std::complex<T> *h_inOut,
+        std::complex<T> *h_ref,
+        FFTSettingsNew<T> &dim,
+        bool copyToHost = false);
+
+    template<bool center>
+    static void computeCorrelations2DOneToN(
+            void *dimBlock, void *dimGrid,
+            std::complex<T> *d_inOut,
+            std::complex<T> *d_ref,
+            size_t xDim, size_t yDim, size_t nDim);
+};
+
+
+} /* namespace Alignment */
+
+#endif /* LIBRARIES_RECONSTRUCTION_ADAPT_CUDA_CUDA_SHIFT_ALIGNER_H_ */

--- a/libraries/reconstruction_cuda/cuda_shift_aligner.h
+++ b/libraries/reconstruction_cuda/cuda_shift_aligner.h
@@ -82,10 +82,10 @@ private:
     AlignType m_type;
 
     // device memory
-    std::complex<T> *m_d_single_FT; // FIXME rename to FD
-    std::complex<T> *m_d_batch_FT;
-    T *m_d_single_S; // FIXME rename to SD
-    T *m_d_batch_S; // FIXME allocate this big enought to hold also the centers
+    std::complex<T> *m_d_single_FD;
+    std::complex<T> *m_d_batch_FD;
+    T *m_d_single_SD;
+    T *m_d_batch_SD;
 
     // host memory
     T *m_h_centers;
@@ -93,14 +93,14 @@ private:
     T *m_origHelperData;
 
     // FT data
-    mycufftHandle m_singleToFT;
-    mycufftHandle m_batchToFT;
+    mycufftHandle m_singleToFD;
+    mycufftHandle m_batchToFD;
     mycufftHandle m_batchToSD;
 
     // flags
     bool m_includingFT;
     bool m_isInit;
-    bool m_is_d_single_FT_loaded;
+    bool m_is_d_single_FD_loaded;
 
     void check();
     void init2DOneToN();

--- a/libraries/reconstruction_cuda/cuda_shift_aligner.h
+++ b/libraries/reconstruction_cuda/cuda_shift_aligner.h
@@ -27,12 +27,9 @@
 #define LIBRARIES_RECONSTRUCTION_ADAPT_CUDA_CUDA_SHIFT_ALIGNER_H_
 
 #include <type_traits>
-//#include <vector>
 #include "reconstruction/ashift_aligner.h"
 #include "data/fft_settings_new.h"
 #include "core/xmipp_error.h"
-//#include "data/point2D.h"
-//#include "data/filters.h"
 #include "reconstruction_cuda/cuda_xmipp_utils.h"
 
 namespace Alignment {
@@ -48,38 +45,29 @@ public:
         release();
     }
 
-
     void init2D(AlignType type, const FFTSettingsNew<T> &dims, size_t maxShift=0, bool includingFT=false);
 
     void release();
 
     void load2DReferenceOneToN(const std::complex<T> *h_ref);
 
+    void load2DReferenceOneToN(const T *h_ref);
+
     template<bool center>
     void computeCorrelations2DOneToN(
         std::complex<T> *h_inOut);
 
-
-    static std::vector<Point2D<T>> computeShift2DOneToN(
-        T *h_others,
-        T *h_ref,
-        FFTSettingsNew<T> &dims,
-        size_t maxShift);
-
-    static std::vector<Point2D<T>> computeShift2DOneToN(
-        std::complex<T> *h_others,
-        std::complex<T> *h_ref,
-        FFTSettingsNew<T> &dims,
-        size_t maxShift);
+    std::vector<Point2D<T>> computeShift2DOneToN(
+        T *h_others);
 
     static std::vector<Point2D<T>> computeShifts2DOneToN(
         std::complex<T> *d_othersF,
         std::complex<T> *d_ref,
         size_t xDimF, size_t yDimF, size_t nDim,
-        T *d_othersS, mycufftHandle handle,
+        T *d_othersS, // this must be big enough to hold batch * centerSize^2 elements!
+        mycufftHandle handle,
         size_t xDimS,
         T *h_centers, MultidimArray<T> &helper, size_t maxShift);
-
 
     template<bool center>
     static void computeCorrelations2DOneToN(
@@ -90,19 +78,29 @@ public:
 private:
     FFTSettingsNew<T> m_dims;
     size_t m_maxShift;
+    size_t m_centerSize;
     AlignType m_type;
 
     // device memory
-    std::complex<T> *m_d_single_FT;
-    T *m_d_ref_S;
+    std::complex<T> *m_d_single_FT; // FIXME rename to FD
     std::complex<T> *m_d_batch_FT;
+    T *m_d_single_S; // FIXME rename to SD
+    T *m_d_batch_S; // FIXME allocate this big enought to hold also the centers
 
     // host memory
+    T *m_h_centers;
+    MultidimArray<T> m_helper;
+    T *m_origHelperData;
+
+    // FT data
+    mycufftHandle m_singleToFT;
+    mycufftHandle m_batchToFT;
+    mycufftHandle m_batchToSD;
 
     // flags
     bool m_includingFT;
     bool m_isInit;
-    bool m_is_d_ref_FT_loaded;
+    bool m_is_d_single_FT_loaded;
 
     void check();
     void init2DOneToN();

--- a/libraries/reconstruction_cuda/cuda_shift_aligner.h
+++ b/libraries/reconstruction_cuda/cuda_shift_aligner.h
@@ -27,9 +27,13 @@
 #define LIBRARIES_RECONSTRUCTION_ADAPT_CUDA_CUDA_SHIFT_ALIGNER_H_
 
 #include <type_traits>
+#include <vector>
 //#include "reconstruction/ashift_aligner.h"
 #include "data/fft_settings_new.h"
 #include "core/xmipp_error.h"
+#include "data/point2D.h"
+#include "data/filters.h"
+#include "reconstruction_cuda/cuda_xmipp_utils.h"
 //#include "reconstruction_adapt_cuda/cuda_compatibility.h"
 
 namespace Alignment {
@@ -39,16 +43,15 @@ class CudaShiftAligner {
 public:
     static void computeCorrelations2DOneToN(
         std::complex<T> *h_inOut,
-        std::complex<T> *h_ref,
-        FFTSettingsNew<T> &dim,
-        bool copyToHost = false);
+        const std::complex<T> *h_ref,
+        const FFTSettingsNew<T> &dims);
 
     template<bool center>
     static void computeCorrelations2DOneToN(
-            void *dimBlock, void *dimGrid,
-            std::complex<T> *d_inOut,
-            std::complex<T> *d_ref,
-            size_t xDim, size_t yDim, size_t nDim);
+        std::complex<T> *d_inOut,
+        const std::complex<T> *d_ref,
+        size_t xDim, size_t yDim, size_t nDim);
+
 };
 
 

--- a/libraries/reconstruction_cuda/cuda_shift_aligner.h
+++ b/libraries/reconstruction_cuda/cuda_shift_aligner.h
@@ -45,8 +45,7 @@ public:
         T *h_others,
         T *h_ref,
         FFTSettingsNew<T> &dims,
-        size_t maxShift,
-        size_t batch = 1);
+        size_t maxShift);
 
     static std::vector<Point2D<T>> computeShift2DOneToN(
         std::complex<T> *h_others,


### PR DESCRIPTION
This is work in progress, but a already a sufficiently big (and working) part.

This new code is able to determine a shift of one signal (float only at this point) in respect to N (>=1) others, using cross-correlation.
It uses batch processing on GPU.

The CudaShiftAligner is able to do so without storing any data (see the static methods), but it can also take care of the necessary data allocation and handling.

Basic set of tests is included.