### PR TITLE
Add StarPU-based reconstruct fourier variants

### DIFF
--- a/src/xmipp/SConscript
+++ b/src/xmipp/SConscript
@@ -46,6 +46,7 @@ matlab = get('MATLAB')
 opencv = env.GetOption('opencv') and get('OPENCV')
 opencvsupportscuda = get('OPENCVSUPPORTSCUDA')
 opencv_3 = get('OPENCV3')
+starpu = get('STARPU')
 
 if opencv:
     opencvLibs = ['opencv_core',
@@ -156,6 +157,27 @@ if cuda:
     addLib('XmippParallelCuda', dirs=['libraries'], patterns=['parallel_adapt_cuda/*.cpp'],
            libs=['Xmipp','XmippInterfaceCuda','XmippCuda'], mpi=True)
 
+    if starpu:
+        starpu_include = [os.environ.get('STARPU_INCLUDE')]
+        starpu_lib = ['lib', os.environ.get('STARPU_LIB')]
+        starpu_library = os.environ.get('STARPU_LIBRARY')
+
+        addLib('XmippStarPu',
+               dirs=['libraries'],
+               patterns=['reconstruction_starpu/*.cpp'],
+               incs=starpu_include,
+               nvcc=True,
+               deps=['XmippCuda'],
+               libs=['XmippCuda', starpu_library, 'fftw3f'],
+               libpath=starpu_lib)
+
+        addLib('XmippStarPuMpi', dirs=['libraries'], patterns=['reconstruction_starpu/mpi/*.cpp'],
+               incs=starpu_include,
+               deps=['XmippCuda', 'XmippStarPu'],
+               libs=['XmippCuda', 'XmippStarPu', starpu_library, 'fftw3f'],
+               libpath=starpu_lib,
+               mpi=True)
+
 # MPI
 dirs = ['libraries']
 patterns=['parallel/*.cpp']
@@ -225,20 +247,37 @@ PROGRAMS_WITH_PYTHON = ['volume_align_prog','mpi_classify_CLTomo_prog']
 PROGRAMS_WITH_OPENCV = ['movie_optical_alignment_cpu','mpi_volume_homogenizer']
 PROGRAMS_WITH_OPENCV_AND_CUDA = ['movie_optical_alignment_gpu']
 for p in glob(os.path.join(XMIPP_PATH,'applications','programs','*')):
-	pname = os.path.basename(p)
-	if pname in PROGRAMS_WITH_PYTHON:
-		addProg(pname,incs=python_incdirs,libs=['python2.7'])
-	elif pname in PROGRAMS_WITH_OPENCV:
-		if opencv:
-			addProg(pname,libs=opencvLibs,deps=['opencv'])
-	elif pname in PROGRAMS_WITH_OPENCV_AND_CUDA:
-		if opencv and opencvsupportscuda:
-			addProg(pname,libs=opencvLibs,deps=['opencv'],cuda=True)
-	elif 'cuda' in pname:
-		if cuda:
-			addProg(pname)
-	else:
-		addProg(pname)
+    pname = os.path.basename(p)
+    pnameTokens = pname.split('_')
+    if pname in PROGRAMS_WITH_PYTHON:
+        addProg(pname,incs=python_incdirs,libs=['python2.7'])
+    elif pname in PROGRAMS_WITH_OPENCV:
+        if opencv:
+            addProg(pname,libs=opencvLibs,deps=['opencv'])
+    elif pname in PROGRAMS_WITH_OPENCV_AND_CUDA:
+        if opencv and opencvsupportscuda:
+            addProg(pname,libs=opencvLibs,deps=['opencv'],cuda=True)
+    elif 'starpu' in pnameTokens:
+        if not cuda or not starpu:
+            continue
+        starpu_lib = ['lib', os.environ.get('STARPU_LIB')]
+        starpu_deps = ['XmippStarPu', 'XmippCuda']
+        starpu_libs = ['XmippStarPu', 'XmippCuda', os.environ.get('STARPU_LIBRARY'), 'fftw3f']
+        if 'mpi' in pnameTokens:
+            starpu_deps = ['XmippStarPuMpi'] + starpu_deps
+            starpu_libs = ['XmippStarPuMpi'] + starpu_libs
+        addProg(pname,
+                cuda=True,
+                deps=starpu_deps,
+                libs=starpu_libs,
+                libPaths=starpu_lib,
+                # Ensure, that StarPU's shared libraries are accessible even when not in LD_LIBRARY_PATH
+                linkflags=['-Wl,-rpath=%s' % os.environ.get('STARPU_LIB')])
+    elif 'cuda' in pnameTokens:
+        if cuda:
+            addProg(pname)
+    else:
+        addProg(pname)
 
 for p in glob(os.path.join(XMIPP_PATH,'applications','tests','function_tests','*.cpp')):
     if not cuda and 'cuda' in p:

--- a/src/xmipp/applications/programs/mpi_starpu_reconstruct_fourier/mpi_starpu_reconstruct_fourier_main.cpp
+++ b/src/xmipp/applications/programs/mpi_starpu_reconstruct_fourier/mpi_starpu_reconstruct_fourier_main.cpp
@@ -1,0 +1,32 @@
+/***************************************************************************
+ *
+ * Authors:     Jan Polak (456647@mail.muni.cz)
+ *
+ * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ * 02111-1307  USA
+ *
+ *  All comments concerning this program package may be sent to the
+ *  e-mail address 'xmipp@cnb.csic.es'
+ ***************************************************************************/
+
+#include <reconstruction_starpu/mpi/mpi_reconstruct_fourier_starpu.h>
+
+int main(int argc, char **argv) {
+	ProgRecFourierMpiStarPU program;
+	program.read(argc, argv);
+	return program.tryRun();
+}

--- a/src/xmipp/applications/programs/starpu_reconstruct_fourier/starpu_reconstruct_fourier_main.cpp
+++ b/src/xmipp/applications/programs/starpu_reconstruct_fourier/starpu_reconstruct_fourier_main.cpp
@@ -1,0 +1,32 @@
+/***************************************************************************
+ *
+ * Authors:     Jan Polak (456647@mail.muni.cz)
+ *
+ * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ * 02111-1307  USA
+ *
+ *  All comments concerning this program package may be sent to the
+ *  e-mail address 'xmipp@cnb.csic.es'
+ ***************************************************************************/
+
+#include <reconstruction_starpu/reconstruct_fourier_starpu.h>
+
+int main(int argc, const char **argv) {
+    ProgRecFourierStarPU program;
+    program.read(argc, argv);
+    return program.tryRun();
+}

--- a/src/xmipp/libraries/reconstruction_starpu/mpi/mpi_reconstruct_fourier_starpu.cpp
+++ b/src/xmipp/libraries/reconstruction_starpu/mpi/mpi_reconstruct_fourier_starpu.cpp
@@ -1,0 +1,444 @@
+/***************************************************************************
+ *
+ * Authors:     Jan Polak (456647@mail.muni.cz)
+ *              David Strelak (davidstrelak@gmail.com)
+ *
+ * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ * 02111-1307  USA
+ *
+ *  All comments concerning this program package may be sent to the
+ *  e-mail address 'xmipp@cnb.csic.es'
+ ***************************************************************************/
+
+#include <cstdint>
+#include <vector>
+#include <deque>
+#include <semaphore.h>
+
+#define STARPU_DONT_INCLUDE_CUDA_HEADERS
+#include <starpu.h>
+
+#include "../reconstruct_fourier_util.h"
+#include "../reconstruct_fourier_starpu_util.h"
+
+#include "mpi_reconstruct_fourier_starpu.h"
+
+/** DEVELOPMENT: Enable to display logs from this file */
+const bool mpiLogging = false;
+
+#define LOG_MPI(COUT) do { if (mpiLogging) {\
+int logRank = -1, logIsMpiInitialized = 0;\
+MPI_Initialized(&logIsMpiInitialized);\
+if (logIsMpiInitialized) MPI_Comm_rank(MPI_COMM_WORLD, &logRank);\
+std::cout << "[mpi_rec_fou] " << logRank << ": " << COUT << '\n'; } } while (0)
+
+void ProgRecFourierMpiStarPU::defineParams() {
+	ProgRecFourierStarPU::defineParams();
+	addParamsLine("  [--mpiDistribute <pc=0.3>]     : Ratio [0,1] describing how many batches should be initially distributed.");
+	addParamsLine("                                 : Use less for more heterogeneous group of computers, more for more homogeneous group.");
+	addParamsLine("  [--mpiPrefetch <batches=25>]    : How many batches should be in the processing pipeline at all times.");
+	addParamsLine("                                 : Higher numbers could be faster with faster and/or more homogeneous computers.");
+	addParamsLine("                                 : Very low numbers will have severe performance implications.");
+}
+
+void ProgRecFourierMpiStarPU::readParams() {
+	ProgRecFourierStarPU::readParams();
+
+	percentOfJobsDistributedByDefault = static_cast<float>(getDoubleParam("--mpiDistribute"));
+	preferredBatchesInPipeline = static_cast<uint32_t>(getIntParam("--mpiPrefetch"));
+}
+
+void ProgRecFourierMpiStarPU::run() {
+	int rank, size;
+	CHECK_MPI(MPI_Comm_rank(MPI_COMM_WORLD, &rank));
+	CHECK_MPI(MPI_Comm_size(MPI_COMM_WORLD, &size));
+
+	{// Implementation of tip 6 from https://www.open-mpi.org/faq/?category=debugging
+		// Set this env variable to the rank which is to be debugged
+		char* rankStr = getenv("XMIPP_MPI_DEBUG_RANK");
+		int rankToBlock = rankStr == nullptr ? -1 : atoi(rankStr);
+
+		if (rankToBlock == rank) {
+			volatile /* so it isn't optimized out */ int i = 0;
+			char hostname[256];
+			gethostname(hostname, sizeof(hostname));
+			printf("PID %d on %s ready for attach\n", getpid(), hostname);
+			fflush(stdout);
+
+			// After attaching with debugger, set i to arbitrary non-zero value to continue
+			// gdb> set var i = 7
+			while (0 == i)
+				sleep(1);
+		}
+	}
+
+	if (size < 2) {
+		if (rank == 0) {
+			REPORT_ERROR(ERR_ARG_DEPENDENCE, "This MPI implementation needs at least two instances");
+		} else {
+			// no need to report error from all nodes at the same time
+			return;
+		}
+	}
+
+	MPI_Comm workComm;
+	// Rest of the code in this file assumes, that world rank 0 is master and other ranks are simply shifted by 1 to form workComm.
+	// This code does that, but any modification must take this requirement into account.
+	CHECK_MPI(MPI_Comm_split(MPI_COMM_WORLD, rank == 0 ? MPI_UNDEFINED : 0, 0, &workComm));
+
+	const int workerCount = size - 1;
+
+	if (workComm == MPI_COMM_NULL) {
+		runMaster(workerCount);
+	} else {
+		int workerRank;
+		CHECK_MPI(MPI_Comm_rank(workComm, &workerRank));
+		runWorker(workComm, workerCount, workerRank);
+	}
+}
+
+/** How many and which batches should each worker get by default.
+ * @param batchCount how many batches are there to distribute
+ * @param workerCount between how many workers should the work be distributed
+ * @param selfWorkerId if called from worker id, myBatches will be filled with the numbers of batches to be processed
+ * by default by this worker. The worker can begin to work on these right away.
+ * @param myBatches will be filled with numbers of batches on which this worker should work on, may be nullptr
+ * @return amount of batches distributed by default, equal to the next batch to distribute. If this value is equal to batchCount,
+ * it means that all batches have been distributed by default and dynamic batch distribution is not needed. */
+uint32_t ProgRecFourierMpiStarPU::defaultBatchDistribution(const uint32_t batchCount, const int workerCount, const int selfWorkerId, std::deque<uint32_t>* myBatches) const {
+	uint32_t distributedByDefault = static_cast<uint32_t>(percentOfJobsDistributedByDefault * batchCount);
+	// Always distribute at least preferredBatchesInPipeline batches to each worker
+	distributedByDefault = XMIPP_MAX(distributedByDefault, workerCount * preferredBatchesInPipeline);
+	// But when there is less batches than workers, that is not possible
+	distributedByDefault = XMIPP_MIN(distributedByDefault, batchCount);
+
+	uint32_t nextRoundFirstBatch = 0;
+	while (nextRoundFirstBatch < distributedByDefault) {
+		// There is still something to distribute
+		uint32_t roundSize = XMIPP_MIN(distributedByDefault - nextRoundFirstBatch, workerCount);
+		if (myBatches != nullptr && selfWorkerId < roundSize) {
+			myBatches->push_back(nextRoundFirstBatch + selfWorkerId);
+		}
+		nextRoundFirstBatch += roundSize;
+	}
+
+	return nextRoundFirstBatch;
+}
+
+const int TAG_WORKER_TO_MASTER = 1;
+const int TAG_MASTER_TO_WORKER = 2;
+
+void ProgRecFourierMpiStarPU::runMaster(int workerCount) {
+	if (verbose) {
+		show();
+	}
+
+	// mpiLogging completely breaks the progress bar
+	const bool progressBar = !mpiLogging && static_cast<bool>(verbose) && false /* Progress bar on MPI processes is broken anyway. */;
+
+	prepareMetaData(fn_in, SF);
+	const uint32_t batchCount = computeBatchCount(params, SF);
+
+	if (progressBar) {
+		init_progress_bar(batchCount);
+	}
+
+	uint32_t nextBatch = defaultBatchDistribution(batchCount, workerCount, workerCount, nullptr);
+	assert(nextBatch <= batchCount);
+
+	LOG_MPI("default distributed " << nextBatch << " out of " << batchCount << " batches");
+
+	if (nextBatch == batchCount) {
+		// Everything has been given out by default, nobody should ask for anything, master is done
+		LOG_MPI("skipping batch distribution loop");
+		return;
+	}
+
+	// Workers will send how many batches they have processed uint32_t[1]
+	// and master will respond with the next batch they should process int32_t[1], or -1 if they should not process any more batches
+
+	struct WorkerInfo {
+		/** Amount of batches the worker reports as processed. */
+		uint32_t processedBatches;
+		/** MPI ISend buffer */
+		int32_t sendBuffer;
+		/** Last request which used the sendBuffer. */
+		MPI_Request lastSendRequest = MPI_REQUEST_NULL;
+	};
+	std::vector<WorkerInfo> workerInfos(workerCount);
+	int workersComplete = 0;
+	uint32_t batchesComplete = 0;
+
+	while (workersComplete < workerCount) {
+		LOG_MPI("waiting for next batch query");
+		MPI_Status recvStatus;
+		uint32_t complete;
+		CHECK_MPI(MPI_Recv(&complete, 1, MPI_UINT32_T, MPI_ANY_SOURCE, TAG_WORKER_TO_MASTER, MPI_COMM_WORLD, &recvStatus));
+		// Somebody needs another batch to process
+
+		LOG_MPI("batch query received from " << recvStatus.MPI_SOURCE << " (" << complete << " completed)");
+
+		// NOTE: This assumes, that ranks of workers are 1..workerCount! This is currently true as it is how MPI_Comm_split does things.
+		WorkerInfo& workerInfo = workerInfos[recvStatus.MPI_SOURCE - 1];
+		CHECK_MPI(MPI_Wait(&workerInfo.lastSendRequest, MPI_STATUS_IGNORE)); // Should be no-op
+
+		// Send new batch or notification that there are no more batches
+		if (nextBatch >= batchCount) {
+			LOG_MPI("replying with no more batches");
+			workerInfo.sendBuffer = -1;
+			workersComplete++;
+		} else {
+			LOG_MPI("replying with batch " << nextBatch);
+			workerInfo.sendBuffer = nextBatch++;
+		}
+		CHECK_MPI(MPI_Isend(&workerInfo.sendBuffer, 1, MPI_INT32_T, recvStatus.MPI_SOURCE, TAG_MASTER_TO_WORKER, MPI_COMM_WORLD, &workerInfo.lastSendRequest));
+
+		// Request carried information about how many batches has that worker completed in total.
+		// Update internal counters with that.
+		uint32_t newCompleteBatches = workerInfo.processedBatches - complete;
+		workerInfo.processedBatches = complete;
+		batchesComplete += newCompleteBatches;
+
+		if (progressBar) {
+			progress_bar(batchesComplete);
+		}
+	}
+
+	LOG_MPI("batch loop complete, waiting for any pending messages");
+
+	// Every batch has been sent, make sure it has reached its destination
+	for (WorkerInfo& workerInfo : workerInfos) {
+		CHECK_MPI(MPI_Wait(&workerInfo.lastSendRequest, MPI_STATUS_IGNORE));
+	}
+
+	if (progressBar) {
+		// Just to make sure that it is really done
+		progress_bar(batchCount);
+	}
+
+	LOG_MPI("done");
+	// Done
+}
+
+struct ProgRecFourierMpiStarPU::DistributedBatchProvider : ProgRecFourierStarPU::BatchProvider {
+private:
+	const ProgRecFourierMpiStarPU& parent;
+
+	/** Queue of batches to be processed */
+	std::deque<uint32_t> defaultBatchQueue;
+
+	/** The maximum possible amount of batches this provider will ever provide */
+	uint32_t maxBatchCount;
+
+	enum class State {
+		/** There are some items in default queue and after that runs out, check the pool */
+		QUEUE_AND_POOL,
+		/** All items are in the default queue, do not check the pool */
+		QUEUE_ONLY,
+		/** Default queue is empty, next item should be retrieved by waiting for the MPI request */
+		POOL_REQUEST_PENDING,
+		/** There are no more batches anywhere, distribution task is done */
+		NO_MORE_BATCHES
+	} state;
+
+	/** Amount of batches that were marked as completed by batchCompleted() */
+	uint32_t completedBatches = 0;
+	/** Semaphore controlling the amount of batches that were retrieved by nextBatch(), but not yet marked as completed.
+	 * This exists to never have more than preferredBatchesInPipeline batches in the pipeline. */
+	sem_t batchesInPipeline;
+
+	MPI_Request mpiRequests[2];
+	uint32_t mpiSendBuf;
+	int32_t mpiRecvBuf;
+
+	void doRequestFromPool() {
+		// See runMaster() for description of sent data
+		LOG_MPI("doRequestFromPool");
+		mpiSendBuf = completedBatches;
+		CHECK_MPI(MPI_Isend(&mpiSendBuf, 1, MPI_UINT32_T, 0, TAG_WORKER_TO_MASTER, MPI_COMM_WORLD, &mpiRequests[0]));
+		CHECK_MPI(MPI_Irecv(&mpiRecvBuf, 1, MPI_INT32_T, 0, TAG_MASTER_TO_WORKER, MPI_COMM_WORLD, &mpiRequests[1]));
+	}
+
+	int32_t doCompleteRequestFromPool() {
+		// Wait for the request!
+		LOG_MPI("doCompleteRequestFromPool");
+		CHECK_MPI(MPI_Waitall(2, mpiRequests, MPI_STATUSES_IGNORE));
+		return mpiRecvBuf;
+	}
+
+public:
+	DistributedBatchProvider(const ProgRecFourierMpiStarPU& parent, uint32_t batchCount, int workerCount, int workerRank)
+	: parent(parent) {
+		uint32_t nextBatch = parent.defaultBatchDistribution(batchCount, workerCount, workerRank, &defaultBatchQueue);
+		maxBatchCount = static_cast<uint32_t>(defaultBatchQueue.size() + batchCount - nextBatch);
+
+		if (defaultBatchQueue.empty()) {
+			assert(nextBatch >= batchCount);
+			state = State::NO_MORE_BATCHES;
+		} else if (nextBatch >= batchCount) {
+			state = State::QUEUE_ONLY;
+		} else {
+			state = State::QUEUE_AND_POOL;
+		}
+
+		sem_init(&batchesInPipeline, 0, parent.preferredBatchesInPipeline);
+	}
+
+	~DistributedBatchProvider() {
+		sem_destroy(&batchesInPipeline);
+	}
+
+	uint32_t maxBatches() override {
+		return maxBatchCount;
+	}
+
+	int32_t nextBatch() override {
+		switch (state) {
+			case State::QUEUE_AND_POOL: {
+				uint32_t fromQueue = defaultBatchQueue.front();
+				defaultBatchQueue.pop_front();
+				if (defaultBatchQueue.empty()) {
+					// Send request for more
+					doRequestFromPool();
+					state = State::POOL_REQUEST_PENDING;
+				}
+				sem_wait(&batchesInPipeline);
+				return fromQueue;
+			}
+			case State::QUEUE_ONLY: {
+				uint32_t fromQueue = defaultBatchQueue.front();
+				defaultBatchQueue.pop_front();
+				if (defaultBatchQueue.empty()) {
+					// That's it
+					state = State::NO_MORE_BATCHES;
+				}
+				sem_wait(&batchesInPipeline);
+				return fromQueue;
+			}
+			case State::POOL_REQUEST_PENDING: {
+				int32_t fromPool = doCompleteRequestFromPool();
+				if (fromPool == -1) {
+					// That's it
+					state = State::NO_MORE_BATCHES;
+					return -1;
+				} else {
+					assert(fromPool >= 0);
+					// Got something meaningful, query for more!
+					doRequestFromPool();
+					sem_wait(&batchesInPipeline);
+					return fromPool;
+				}
+			}
+			case State::NO_MORE_BATCHES: {
+				return -1;
+			}
+		}
+		assert(false);
+	}
+
+	void batchCompleted() override {
+		completedBatches++;
+		sem_post(&batchesInPipeline);
+	}
+};
+
+void ProgRecFourierMpiStarPU::runWorker(MPI_Comm workComm, int workerCount, int workerRank) {
+	prepareMetaData(fn_in, SF);
+	const uint32_t batchCount = computeBatchCount(params, SF);
+
+	prepareConstants(params, SF, fn_sym, computeConstants);
+
+	initStarPU();
+
+	LOG_MPI("runWorker - starpu start");
+	ProgRecFourierMpiStarPU::DistributedBatchProvider batchSource(*this, batchCount, workerCount, workerRank);
+	ComputeStarPUResult result = computeStarPU(params, SF, computeConstants, batchSource, (bool) verbose);
+	LOG_MPI("runWorker - starpu end");
+
+	// We won't need StarPU anymore
+	shutdownStarPU();
+
+	const bool primary = workerRank == 0;
+	{ // Reduce result into the primary worker
+		int reduceSize = (computeConstants.maxVolumeIndex + 1) * (computeConstants.maxVolumeIndex + 1) *
+		                 (computeConstants.maxVolumeIndex + 1);
+		MPI_Request requests[2];
+		LOG_MPI("runWorker - reduce submit");
+		CHECK_MPI(MPI_Ireduce(primary ? MPI_IN_PLACE : result.volumeData, result.volumeData,
+		                      reduceSize * 2, MPI_FLOAT,
+		                      MPI_SUM, 0, workComm, &requests[0]));
+		CHECK_MPI(MPI_Ireduce(primary ? MPI_IN_PLACE : result.weightsData, result.weightsData,
+		                      reduceSize, MPI_FLOAT,
+		                      MPI_SUM, 0, workComm, &requests[1]));
+
+		LOG_MPI("runWorker - reduce wait");
+		CHECK_MPI(MPI_Waitall(2, requests, MPI_STATUSES_IGNORE));
+		LOG_MPI("runWorker - reduce done");
+	}
+
+	if (!primary) {
+		// Only primary worker continues past this point, other workers may end now
+		result.destroy();
+		LOG_MPI("runWorker - non primary quitting");
+		return;
+	}
+
+	// Convert flat volume and weight arrays into multidimensional arrays and destroy originals
+	std::complex<float>*** tempVolume = result.createXmippStyleVolume(computeConstants.maxVolumeIndex);
+	float*** tempWeights = result.createXmippStyleWeights(computeConstants.maxVolumeIndex);
+	result.destroy();
+
+	// Adjust and save the resulting volume
+	postProcessAndSave(params, computeConstants, fn_out, tempVolume, tempWeights);
+}
+
+void ProgRecFourierMpiStarPU::read(int argc, char **argv, bool reportErrors) {
+	// Not using XmippMpiProgram, because it is unnecessarily complicated for this use-case
+	// and does not initialize MPI with thread support, which is required
+	LOG_MPI("Initializing MPI");
+	int providedThreadSupport;
+	CHECK_MPI(MPI_Init_thread(&argc, &argv, MPI_THREAD_SERIALIZED, &providedThreadSupport));
+	mpiInitialized = true;
+	LOG_MPI("MPI initialized with thread level " << providedThreadSupport);
+
+	if (providedThreadSupport < MPI_THREAD_SERIALIZED) {
+		std::cerr << "MPI implementation does not support MPI_THREAD_SERIALIZED concurrency level, which is required. Provided level is " << providedThreadSupport << '\n';
+		REPORT_ERROR(ERR_NOT_IMPLEMENTED, "Could not initialize MPI");
+	}
+
+	XmippProgram::read(argc, argv, reportErrors);
+}
+
+int ProgRecFourierMpiStarPU::tryRun() {
+	// Based on XmippMpiProgram::tryRun()
+	try {
+		if (doRun)
+			this->run();
+	} catch (XmippError &xe) {
+		std::cerr << xe;
+		errorCode = xe.__errno;
+		MPI_Abort(MPI_COMM_WORLD, xe.__errno);
+	}
+	return errorCode;
+}
+
+ProgRecFourierMpiStarPU::~ProgRecFourierMpiStarPU() {
+	if (mpiInitialized) {
+		LOG_MPI("Finalizing MPI");
+		CHECK_MPI(MPI_Finalize());
+	}
+}

--- a/src/xmipp/libraries/reconstruction_starpu/mpi/mpi_reconstruct_fourier_starpu.h
+++ b/src/xmipp/libraries/reconstruction_starpu/mpi/mpi_reconstruct_fourier_starpu.h
@@ -1,0 +1,111 @@
+/***************************************************************************
+ *
+ * Authors:     Jan Polak (456647@mail.muni.cz)
+ *              Roberto Marabini (roberto@cnb.csic.es)
+ *              Carlos Oscar S. Sorzano (coss@cnb.csic.es)
+ *              Jose Roman Bilbao-Castro (jrbcast@ace.ual.es)
+ *              Vahid Abrishami (vabrishami@cnb.csic.es)
+ *              David Strelak (davidstrelak@gmail.com)
+ *
+ * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ * 02111-1307  USA
+ *
+ *  All comments concerning this program package may be sent to the
+ *  e-mail address 'xmipp@cnb.csic.es'
+ ***************************************************************************/
+
+#ifndef __RECONSTRUCT_FOURIER_GPU_MPI_H
+#define __RECONSTRUCT_FOURIER_GPU_MPI_H
+
+// Uses its transitive dependencies
+#include <reconstruction_starpu/reconstruct_fourier_starpu.h>
+#include <mpi.h>
+#include <deque>
+
+/**
+ * MPI extension of ProgRecFourierStarPU.
+ * MPI should already be initialized externally. (This is done by runReconstructFourierMpiStarPU function)
+ *
+ * At least two program instances are needed - one master and at least one worker (though any real speedup is expected
+ * only with multiple workers). It is expected, but not required, that the master will run on the same machine as one
+ * of the workers, as it uses minimal processing power.
+ *
+ * All program instances, no matter their role, should have the access to identical input files (through network storage,
+ * manual copy, etc.).
+ *
+ * First worker (i.e. second global rank) will write out the result.
+ */
+class ProgRecFourierMpiStarPU : public ProgRecFourierStarPU {
+
+	bool mpiInitialized = false;
+
+	/** 0..1, how many batches should be distributed by default?
+	* Larger values lead to less overhead in homogeneous environment,
+	* while smaller values can distribute batches better in more heterogeneous environment.
+	* At least one batch is always given to workers, no matter what. */
+	float percentOfJobsDistributedByDefault = 0.3f;
+	/** Amount of batches that should always be in the pipeline, if possible.
+	* Similar tradeoff like percentOfJobsDistributedByDefault,
+	* but some number is always needed so that the pipeline does not stall. */
+	uint32_t preferredBatchesInPipeline = 5;
+
+public:
+
+	/** Specify supported command line arguments */
+	void defineParams() override;
+
+	/** Read arguments from command line */
+	void readParams() override;
+
+	/** Read with MPI Initialization */
+	void read(int argc, char **argv, bool reportErrors = true) override;
+
+	/** try with MPI abort */
+	int tryRun() override;
+
+	void run() override;
+
+	/** MPI shutdown */
+	~ProgRecFourierMpiStarPU() override;
+
+private:
+
+	/** How many and which batches should each worker get by default.
+	 * @param batchCount how many batches are there to distribute
+	 * @param workerCount between how many workers should the work be distributed
+	 * @param selfWorkerId if called from worker id, myBatches will be filled with the numbers of batches to be processed
+	 * by default by this worker. The worker can begin to work on these right away.
+	 * @param myBatches will be filled with numbers of batches on which this worker should work on, may be nullptr
+	 * @return amount of batches distributed by default, equal to the next batch to distribute. If this value is equal to batchCount,
+	 * it means that all batches have been distributed by default and dynamic batch distribution is not needed. */
+	uint32_t defaultBatchDistribution(uint32_t batchCount, int workerCount, int selfWorkerId, std::deque<uint32_t>* myBatches) const;
+
+	/** Distributes the work to workers. Does not do any work itself.
+	 * @param workerCount amount of workers */
+	void runMaster(int workerCount);
+
+	/** Takes orders from the master and processes given batches.
+	 * @param workComm shared communicator for all workers
+	 * @param workerCount amount of workers in workComm
+	 * @param workerRank of this worker. Rank 0 is primary and the one which gathers results,
+	 *                   post-processes them and saves the final output. */
+	void runWorker(MPI_Comm workComm, int workerCount, int workerRank);
+
+	struct DistributedBatchProvider;
+};
+
+#endif // __RECONSTRUCT_FOURIER_GPU_MPI_H

--- a/src/xmipp/libraries/reconstruction_starpu/reconstruct_fourier_codelet_load_projections.cpp
+++ b/src/xmipp/libraries/reconstruction_starpu/reconstruct_fourier_codelet_load_projections.cpp
@@ -1,0 +1,161 @@
+/***************************************************************************
+ *
+ * Authors:     Jan Polak (456647@mail.muni.cz)
+ *              (some code derived from other Xmipp programs by other authors)
+ *
+ * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ * 02111-1307  USA
+ *
+ *  All comments concerning this program package may be sent to the
+ *  e-mail address 'xmipp@cnb.csic.es'
+ ***************************************************************************/
+
+#include <iostream>
+
+#include <core/args.h>
+#include <core/metadata.h>
+#include <data/projection.h>
+#include <core/xmipp_fftw.h>
+
+#include "reconstruct_fourier_codelets.h"
+#include "reconstruct_fourier_starpu_util.h"
+
+/**
+ * @param shiftMatrix 3x3 matrix for 2D affine transformations
+ * @param orientationMatrix 3x3 matrix for 3D rotation
+ */
+static void loadMatrices(MDRow& row, Matrix2D<double>& shiftMatrix, Matrix2D<double>& orientationMatrix) {
+	if (!row.containsLabel(MDL_TRANSFORM_MATRIX)) {
+		geo2TransformationMatrix(row, shiftMatrix, /*only_apply_shifts*/ true);
+	} else {
+		//TODO This ignores only_apply_shifts!
+		String matrixStr;
+		row.getValue(MDL_TRANSFORM_MATRIX, matrixStr);
+		string2TransformationMatrix(matrixStr, shiftMatrix, 3);
+	}
+
+	// Compute the coordinate axes associated to this projection
+	double rot = 0, tilt = 0, psi = 0;
+	row.getValue(MDL_ANGLE_ROT, rot);
+	row.getValue(MDL_ANGLE_TILT, tilt);
+	row.getValue(MDL_ANGLE_PSI, psi);
+	Euler_angles2matrix(rot, tilt, psi, orientationMatrix);
+	orientationMatrix = orientationMatrix.transpose();
+}
+
+void func_load_projections(void* buffers[], void* cl_arg) {
+	const LoadProjectionArgs& arg = *static_cast<LoadProjectionArgs*>(cl_arg);
+
+	uint32_t& amountLoaded = ((LoadedImagesBuffer*) STARPU_VARIABLE_GET_PTR(buffers[0]))->noOfImages;
+	float* outImageData = (float*)STARPU_VECTOR_GET_PTR(buffers[1]);
+	const size_t outImageDataStride = STARPU_VECTOR_GET_ELEMSIZE(buffers[1]) / sizeof(float);
+	auto* outSpaces = (RecFourierProjectionTraverseSpace*)STARPU_MATRIX_GET_PTR(buffers[2]);
+
+	MultidimArray<float> transformedImageData;
+	MultidimArray<float> paddedImageData(arg.paddedImageSize, arg.paddedImageSize); // Declared here so that internal allocated memory can be reused
+
+	uint32_t traverseSpaceIndex = 0;
+	uint32_t projectionIndex = 0;
+
+	for (uint32_t projectionInBatch = arg.batchStart; projectionInBatch < arg.batchEnd; projectionInBatch++) {
+		const size_t imageObjectIndex = arg.imageObjectIndices[projectionInBatch];
+
+		// Read projection from selfile, read also angles and shifts if present but only apply shifts
+		Projection proj;
+		MDRow row;
+		arg.selFile.getRow(row, imageObjectIndex);
+
+		double headerWeight = 1;
+		row.getValue(MDL_WEIGHT, headerWeight);
+		if (arg.useWeights && headerWeight == 0.f) {
+			continue;
+		}
+
+		{
+			FileName name;
+			row.getValue(MDL_IMAGE, name);
+			proj.read(name);
+		}
+
+		// NOTE(jp): Weight has to be read after the image data is read, it cannot be inferred just from the selFile,
+		// as the image file may contain weight on its own.
+		const float weight =  arg.useWeights ? static_cast<float>(proj.weight() * headerWeight) : 1.0f;
+		if (weight == 0.f) {
+			continue;
+		}
+
+		Matrix2D<double> shiftMatrix(3, 3);
+		Matrix2D<double> orientationMatrix(3, 3);
+		loadMatrices(row, shiftMatrix, orientationMatrix);
+
+		transformedImageData.resizeNoCopy(proj());
+		// FIXME following line is a current bottleneck, as it calls BSpline interpolation
+		applyGeometry(BSPLINE3, transformedImageData, proj.data, shiftMatrix, IS_NOT_INV, WRAP);
+
+		paddedImageData.initZeros(arg.paddedImageSize, arg.paddedImageSize);
+		paddedImageData.setXmippOrigin();
+		transformedImageData.setXmippOrigin();
+		FOR_ALL_ELEMENTS_IN_ARRAY2D(transformedImageData)
+				A2D_ELEM(paddedImageData,i,j) = static_cast<float>(A2D_ELEM(transformedImageData, i, j));
+
+#if 0
+		{// Debug dump
+			FILE* debug_file = fopen("debug_new.bin", "w");
+			uint32_t header[] = {
+					1234567890,
+					sizeof(float),
+					(uint32_t) paddedImageData.xdim,
+					(uint32_t) paddedImageData.ydim,
+					(uint32_t) paddedImageData.zdim,
+					1
+			};
+			fwrite(&header, sizeof(header[0]), sizeof(header)/sizeof(header[0]), debug_file);
+			fwrite(paddedImageData.data, paddedImageData.getSize(), sizeof(float), debug_file);
+			fclose(debug_file);
+		}
+#endif
+
+		// CenterFFT = center for fft (not fft itself)
+		// NOTE(jp): I am not sure why is this done. It seems to flip some signs in the result of FFT according to some pattern.
+		CenterFFT(paddedImageData, true);
+
+		// NOTE(jp): No `continue` skipping after this point, indices to outputs are in lockstep
+		memcpy(outImageData + projectionIndex * outImageDataStride, paddedImageData.data, paddedImageData.getSize() * sizeof(float));
+
+		// Prepare transforms for all symmetries
+		for (const Matrix2D<double>& symmetry : arg.rSymmetries) {
+			RecFourierProjectionTraverseSpace& space = outSpaces[traverseSpaceIndex++];
+			space.weight = weight;
+			space.projectionIndex = projectionIndex; // "index to some array where the respective projection is stored"
+
+			Matrix2D<double> A_SL = symmetry * orientationMatrix;
+			Matrix2D<double> A_SLInv = A_SL.inv();
+			float transf[3][3];
+			float transfInv[3][3];
+			A_SL.convertTo(transf);
+			A_SLInv.convertTo(transfInv);
+
+			computeTraverseSpace(arg.fftSizeX, arg.fftSizeY,
+			                     transf, transfInv, space,
+			                     arg.maxVolumeIndexX, arg.maxVolumeIndexYZ, arg.fastLateBlobbing, arg.blobRadius);
+		}
+
+		projectionIndex++;
+	}
+
+	amountLoaded = projectionIndex;
+}

--- a/src/xmipp/libraries/reconstruction_starpu/reconstruct_fourier_codelet_padded_image_to_fft.cpp
+++ b/src/xmipp/libraries/reconstruction_starpu/reconstruct_fourier_codelet_padded_image_to_fft.cpp
@@ -1,0 +1,249 @@
+/***************************************************************************
+ *
+ * Authors:     Jan Polak (456647@mail.muni.cz)
+ *              (some code derived from other Xmipp programs by other authors)
+ *
+ * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ * 02111-1307  USA
+ *
+ *  All comments concerning this program package may be sent to the
+ *  e-mail address 'xmipp@cnb.csic.es'
+ ***************************************************************************/
+
+#include <core/multidim_array.h>
+
+#include <reconstruction_cuda/cuda_xmipp_utils.h>
+#include <reconstruction_cuda/cuda_asserts.h>
+
+#include <fftw3.h>
+#include <starpu.h>
+#include <pthread.h>
+
+#include <core/xmipp_fft.h>
+#include <core/xmipp_fftw.h>
+
+#include "reconstruct_fourier_codelets.h"
+#include "reconstruct_fourier_defines.h"
+#include "reconstruct_fourier_util.h"
+
+/*
+ * Codelet will create and process the 'paddedFourier' (not shifted, i.e. low frequencies are in corners) in the following way:
+ * - high frequencies are skipped (replaced by zero (0))
+ * - space is shifted, so that low frequencies are in the middle of the Y axis
+ * - resulting space is cropped
+ * - values are normalized
+ * Codelet outputs a 2D array with Fourier coefficients, shifted so that low frequencies are
+ * in the center of the Y axis (i.e. semicircle).
+ */
+
+/**
+ * Index to frequency. Same as xmipp_fft.h::FFT_IDX2DIGFREQ, but compatible with CUDA and not using doubles.
+ * Given an index and a size of the FFT, this function returns the corresponding digital frequency (-1/2 to 1/2).
+ */
+__host__ __device__
+inline float fft_IDX2DIGFREQ(int idx, int size) {
+	if (size <= 1) return 0;
+	return ((idx <= (size / 2)) ? idx : (-size + idx)) / (float) size;
+}
+
+// ======================================= CPU =====================================
+
+static void cropAndShift(
+		const float2* input,
+		uint32_t inputSizeX,
+		uint32_t inputSizeY,
+		uint32_t outputSizeX,
+		float2* output,
+		const float maxResolutionSqr,
+		const float normalizationFactor) {
+
+	// convert image (shift to center and remove high frequencies)
+	int halfY = static_cast<int>(inputSizeY / 2);
+	for (uint32_t y = 0; y < inputSizeY; y++) {
+		for (uint32_t x = 0; x < outputSizeX; x++) {
+			if (y < outputSizeX || y >= (inputSizeY - outputSizeX)) {
+				// check the frequency
+				float2 freq = { fft_IDX2DIGFREQ(x, inputSizeY),
+				                fft_IDX2DIGFREQ(y, inputSizeY) };
+
+				float2 item;
+				if (freq.x * freq.x + freq.y * freq.y > maxResolutionSqr) {
+					item = float2 { 0.0f, 0.0f };
+				} else {
+					item = input[y * inputSizeX + x];
+					item.x *= normalizationFactor;
+					item.y *= normalizationFactor;
+				}
+				// do the shift
+				int myPadI = static_cast<int>((y < halfY) ? y + outputSizeX : y - inputSizeY + outputSizeX);
+				int index = static_cast<int>(myPadI * outputSizeX + x);
+				output[index] = item;
+			}
+		}
+	}
+}
+
+void func_padded_image_to_fft_cpu(void **buffers, void *cl_arg) {
+	float* inPaddedImage = (float*)STARPU_VECTOR_GET_PTR(buffers[0]);
+	float2* outProcessedFft = (float2*)STARPU_VECTOR_GET_PTR(buffers[1]);
+	float2* temporaryFftScratch = (float2*)STARPU_MATRIX_GET_PTR(buffers[2]);
+	const uint32_t noOfImages = ((LoadedImagesBuffer*) STARPU_VARIABLE_GET_PTR(buffers[3]))->noOfImages;
+	const PaddedImageToFftArgs& arg = *(PaddedImageToFftArgs*)(cl_arg);
+
+	const uint32_t rawFftSizeX = STARPU_MATRIX_GET_NX(buffers[2]);
+	const uint32_t rawFftSizeY = STARPU_MATRIX_GET_NY(buffers[2]);
+
+	const size_t imageStridePaddedImage = STARPU_VECTOR_GET_ELEMSIZE(buffers[0]) / sizeof(float);
+	const size_t temporaryFftScratchSizeBytes = STARPU_VECTOR_GET_ELEMSIZE(buffers[2]) * STARPU_VECTOR_GET_NX(buffers[2]);
+	const size_t imageStrideOutput = STARPU_VECTOR_GET_ELEMSIZE(buffers[1]) / sizeof(float2);
+
+	if (alignmentOf(inPaddedImage) < ALIGNMENT || alignmentOf(temporaryFftScratch) < ALIGNMENT) {
+		fprintf(stderr,"Bad alignments of buffers for FFT: %d, %d\n", alignmentOf(inPaddedImage), alignmentOf(temporaryFftScratch));
+		assert(false);
+	}
+
+	static pthread_mutex_t fftw_plan_mutex = PTHREAD_MUTEX_INITIALIZER;
+	// Planning API of FFTW is not thread safe
+	pthread_mutex_lock(&fftw_plan_mutex);
+	fftwf_plan plan = fftwf_plan_dft_r2c_2d(arg.paddedImageSize, arg.paddedImageSize,
+			inPaddedImage, (fftwf_complex*) temporaryFftScratch, FFTW_ESTIMATE);
+	pthread_mutex_unlock(&fftw_plan_mutex);
+
+	assert(plan != nullptr);
+
+	const float normalizationFactor = 1.0f / (arg.paddedImageSize * arg.paddedImageSize);
+
+	float* in = inPaddedImage;
+	float2* out = outProcessedFft;
+	for (uint32_t i = 0; i < noOfImages; i++) {
+		memset(temporaryFftScratch, 0, temporaryFftScratchSizeBytes);
+
+		fftwf_execute_dft_r2c(plan, in, (fftwf_complex*) temporaryFftScratch);
+
+		cropAndShift(temporaryFftScratch, rawFftSizeX, rawFftSizeY, arg.fftSizeX,
+		             out, arg.maxResolutionSqr, normalizationFactor);
+
+		in += imageStridePaddedImage;
+		out += imageStrideOutput;
+	}
+
+	pthread_mutex_lock(&fftw_plan_mutex);
+	fftwf_destroy_plan(plan);
+	pthread_mutex_unlock(&fftw_plan_mutex);
+}
+
+// ======================================= CUDA =====================================
+
+__global__
+void convertImagesKernel(
+		const float2* input,
+		uint32_t inputSizeX,
+		uint32_t inputSizeY,
+		uint32_t outputSizeX,//fftSizeX
+		float2* output,
+		const float maxResolutionSqr,
+		const float normFactor) {
+	// assign pixel to thread
+	volatile int idx = (blockIdx.x * blockDim.x) + threadIdx.x;
+	volatile int idy = (blockIdx.y * blockDim.y) + threadIdx.y;
+
+	int halfY = inputSizeY / 2;
+
+	// input is an image in Fourier space (not normalized)
+	// with low frequencies in the inner corners
+	float2 freq;
+	if ((idy < inputSizeY) // for all input lines
+	    && (idx < outputSizeX)) { // for all output pixels in the line
+		// process line only if it can hold sufficiently high frequency, i.e. process only
+		// first and last N lines
+		if (idy < outputSizeX || idy >= (inputSizeY - outputSizeX)) {
+			// check the frequency
+			freq.x = fft_IDX2DIGFREQ(idx, inputSizeY);
+			freq.y = fft_IDX2DIGFREQ(idy, inputSizeY);
+			if ((freq.x * freq.x + freq.y * freq.y) > maxResolutionSqr) {
+				return;
+			}
+			// do the shift (lower line will move up, upper down)
+			int newY = (idy < halfY) ? (idy + outputSizeX) : (idy - inputSizeY + outputSizeX);
+			int oIndex = newY * outputSizeX + idx;
+
+			// copy data and perform normalization
+			int iIndex = idy*inputSizeX + idx;
+			float2 value = input[iIndex];
+			value.x *= normFactor;
+			value.y *= normFactor;
+			output[oIndex] = value;
+		}
+	}
+}
+
+void func_padded_image_to_fft_cuda(void **buffers, void *cl_arg) {
+	float* inPaddedImage = (float*)STARPU_VECTOR_GET_PTR(buffers[0]);
+	float2* outProcessedFft = (float2*)STARPU_VECTOR_GET_PTR(buffers[1]);
+	float2* temporaryFftScratch = (float2*)STARPU_MATRIX_GET_PTR(buffers[2]);
+	const uint32_t noOfImages = ((LoadedImagesBuffer*) STARPU_VARIABLE_GET_PTR(buffers[3]))->noOfImages;
+	const PaddedImageToFftArgs& arg = *(PaddedImageToFftArgs*)(cl_arg);
+
+	const uint32_t rawFftSizeX = STARPU_MATRIX_GET_NX(buffers[2]);
+	const uint32_t rawFftSizeY = STARPU_MATRIX_GET_NY(buffers[2]);
+
+	const size_t imageStridePaddedImage = STARPU_VECTOR_GET_ELEMSIZE(buffers[0]) / sizeof(float);
+	const size_t temporaryFftScratchSizeBytes = STARPU_VECTOR_GET_ELEMSIZE(buffers[2]) * STARPU_VECTOR_GET_NX(buffers[2]);
+	const size_t imageStrideOutput = STARPU_VECTOR_GET_ELEMSIZE(buffers[1]) / sizeof(float2);
+
+	if (alignmentOf(inPaddedImage) < ALIGNMENT || alignmentOf(temporaryFftScratch) < ALIGNMENT) {
+		fprintf(stderr,"Bad alignments of buffers for FFT: %d, %d\n", alignmentOf(inPaddedImage), alignmentOf(temporaryFftScratch));
+		assert(false);
+	}
+
+	//TODO Investigate the use of cuFFTAdvisor to achieve better performance
+	//TODO Cache the plan explicitly
+	cufftHandle plan;
+	gpuErrchkFFT(cufftPlan2d(&plan, arg.paddedImageSize, arg.paddedImageSize, cufftType::CUFFT_R2C));
+	gpuErrchkFFT(cufftSetStream(plan, starpu_cuda_get_local_stream()));
+
+	const float normalizationFactor = 1.0f / (arg.paddedImageSize * arg.paddedImageSize);
+
+	float* in = inPaddedImage;
+	float2* out = outProcessedFft;
+	for (uint32_t i = 0; i < noOfImages; i++) {
+		// Clear the memory to which we will write
+		// Clear FFT output
+		gpuErrchk(cudaMemsetAsync(temporaryFftScratch, 0, temporaryFftScratchSizeBytes, starpu_cuda_get_local_stream()));
+		// Clear cropAndShift output (as the kernel writes only somewhere)
+		//TODO It could be cheaper to just write everywhere...
+		gpuErrchk(cudaMemsetAsync(out, 0, imageStrideOutput * sizeof(float2), starpu_cuda_get_local_stream()));
+
+		// Execute FFT plan
+		gpuErrchkFFT(cufftExecR2C(plan, in, temporaryFftScratch));
+
+		// Process results, one thread for each pixel of raw FFT
+		dim3 dimBlock(BLOCK_DIM, BLOCK_DIM);
+		dim3 dimGrid((rawFftSizeX + dimBlock.x - 1) / dimBlock.x, (rawFftSizeY + dimBlock.y - 1) / dimBlock.y);
+		convertImagesKernel<<<dimGrid, dimBlock, 0, starpu_cuda_get_local_stream()>>>(
+				temporaryFftScratch, rawFftSizeX, rawFftSizeY, arg.fftSizeX,
+				out, arg.maxResolutionSqr, normalizationFactor);
+		gpuErrchk(cudaPeekAtLastError());
+
+		in += imageStridePaddedImage;
+		out += imageStrideOutput;
+	}
+
+	cufftDestroy(plan);
+
+	// gpuErrchk(cudaStreamSynchronize(starpu_cuda_get_local_stream())); disabled because codelet is async
+}

--- a/src/xmipp/libraries/reconstruction_starpu/reconstruct_fourier_codelet_reconstruct.cpp
+++ b/src/xmipp/libraries/reconstruction_starpu/reconstruct_fourier_codelet_reconstruct.cpp
@@ -1,0 +1,1213 @@
+/***************************************************************************
+ *
+ * Authors:     David Strelak (davidstrelak@gmail.com)
+ *              Jan Polak (456647@mail.muni.cz)
+ *
+ * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ * 02111-1307  USA
+ *
+ *  All comments concerning this program package may be sent to the
+ *  e-mail address 'xmipp@cnb.csic.es'
+ ***************************************************************************/
+
+#include <atomic>
+#include <core/multidim_array.h>
+#include <core/xmipp_fft.h>
+#include <core/xmipp_fftw.h>
+#include <reconstruction/reconstruct_fourier_projection_traverse_space.h>
+
+#include <reconstruction_cuda/cuda_basic_math.h>
+#include <reconstruction_cuda/cuda_xmipp_utils.h>
+#include <reconstruction_cuda/cuda_asserts.h>
+
+#include <cuda_runtime_api.h>
+#include <starpu.h>
+
+#include "reconstruct_fourier_codelets.h"
+#include "reconstruct_fourier_defines.h"
+
+// ======================================= Fields and their manipulation =====================================
+
+#if SHARED_BLOB_TABLE
+__shared__ float BLOB_TABLE[BLOB_TABLE_SIZE_SQRT];
+#endif
+
+#if SHARED_IMG
+__shared__ Point3D<float> SHARED_AABB[2];
+extern __shared__ float2 IMG[];
+#endif
+
+// NOTE(jp): These are all used exclusively in this file. It was originally in constant storage, so it has been kept there.
+// StarPU would probably like to put it in codelet arguments, but that would uglify the code a lot and I am not sure about performance impact of that.
+struct CodeletConstants {
+	int cMaxVolumeIndexX = 0;
+	int cMaxVolumeIndexYZ = 0;
+	float cBlobRadius = 0.f;
+	float cOneOverBlobRadiusSqr = 0.f;
+	float cBlobAlpha = 0.f;
+	float cIw0 = 0.f;
+	float cIDeltaSqrt = 0.f;
+	float cOneOverBessiOrderAlpha = 0.f;
+};
+
+__device__ __constant__ CodeletConstants gpuC;
+CodeletConstants cpuC;
+
+void reconstruct_cuda_initialize_constants(
+		int maxVolIndexX, int maxVolIndexYZ,
+		float blobRadius, float blobAlpha,
+		float iDeltaSqrt, float iw0, float oneOverBessiOrderAlpha) {
+	CodeletConstants constants;
+	constants.cMaxVolumeIndexX = maxVolIndexX;
+	constants.cMaxVolumeIndexYZ = maxVolIndexYZ;
+	constants.cBlobRadius = blobRadius;
+	constants.cOneOverBlobRadiusSqr = 1.f / (blobRadius * blobRadius);
+	constants.cBlobAlpha = blobAlpha;
+	constants.cIw0 = iw0;
+	constants.cIDeltaSqrt = iDeltaSqrt;
+	constants.cOneOverBessiOrderAlpha = oneOverBessiOrderAlpha;
+
+	// "Hack" to not expose setConstants to outside code. Nested function would be fine as well, but that is not allowed in standard C(++).
+	struct Hidden {
+		static void setConstants(void *gpuConstants) {
+			gpuErrchk(cudaMemcpyToSymbol(gpuC, gpuConstants, sizeof(CodeletConstants)));
+		}
+	};
+	// Fill GPU side
+	// http://starpu.gforge.inria.fr/doc/html/FrequentlyAskedQuestions.html#HowToInitializeAComputationLibraryOnceForEachWorker
+	starpu_execute_on_each_worker(&Hidden::setConstants, &constants, STARPU_CPU);
+
+	// Fill CPU side
+	memcpy(&cpuC, &constants, sizeof(CodeletConstants));
+}
+
+// ========================================= Bessi Kaiser math  ====================================
+
+__host__ __device__
+float bessi0Fast(float x) { // X must be <= 15
+	// stable rational minimax approximations to the modified bessel functions, blair, edwards
+	// from table 5
+	float x2 = x*x;
+	float num = -0.8436825781374849e-19f; // p11
+	num = fmaf(num, x2, -0.93466495199548700e-17f); // p10
+	num = fmaf(num, x2, -0.15716375332511895e-13f); // p09
+	num = fmaf(num, x2, -0.42520971595532318e-11f); // p08
+	num = fmaf(num, x2, -0.13704363824102120e-8f);  // p07
+	num = fmaf(num, x2, -0.28508770483148419e-6f);  // p06
+	num = fmaf(num, x2, -0.44322160233346062e-4f);  // p05
+	num = fmaf(num, x2, -0.46703811755736946e-2f);  // p04
+	num = fmaf(num, x2, -0.31112484643702141e-0f);  // p03
+	num = fmaf(num, x2, -0.11512633616429962e+2f);  // p02
+	num = fmaf(num, x2, -0.18720283332732112e+3f);  // p01
+	num = fmaf(num, x2, -0.75281108169006924e+3f);  // p00
+
+	float den = 1.f; // q01
+	den = fmaf(den, x2, -0.75281109410939403e+3f); // q00
+
+	return num/den;
+}
+
+__host__ __device__
+float bessi0(float x) {
+	float y, ax, ans;
+	if ((ax = fabsf(x)) < 3.75f)
+	{
+		y = x / 3.75f;
+		y *= y;
+		ans = 1.f + y * (3.5156229f + y * (3.0899424f + y * (1.2067492f
+		                                                     + y * (0.2659732f + y * (0.360768e-1f + y * 0.45813e-2f)))));
+	}
+	else
+	{
+		y = 3.75f / ax;
+		ans = (expf(ax) * rsqrtf(ax)) * (0.39894228f + y * (0.1328592e-1f
+		                                                    + y * (0.225319e-2f + y * (-0.157565e-2f + y * (0.916281e-2f
+		                                                                                                    + y * (-0.2057706e-1f + y * (0.2635537e-1f + y * (-0.1647633e-1f
+		                                                                                                                                                      + y * 0.392377e-2f))))))));
+	}
+	return ans;
+}
+
+__host__ __device__
+float bessi1(float x) {
+	float ax, ans;
+	float y;
+	if ((ax = fabsf(x)) < 3.75f)
+	{
+		y = x / 3.75f;
+		y *= y;
+		ans = ax * (0.5f + y * (0.87890594f + y * (0.51498869f + y * (0.15084934f
+		                                                              + y * (0.2658733e-1f + y * (0.301532e-2f + y * 0.32411e-3f))))));
+	}
+	else
+	{
+		y = 3.75f / ax;
+		ans = 0.2282967e-1f + y * (-0.2895312e-1f + y * (0.1787654e-1f
+		                                                 - y * 0.420059e-2f));
+		ans = 0.39894228f + y * (-0.3988024e-1f + y * (-0.362018e-2f
+		                                               + y * (0.163801e-2f + y * (-0.1031555e-1f + y * ans))));
+		ans *= (expf(ax) * rsqrtf(ax));
+	}
+	return x < 0.0 ? -ans : ans;
+}
+
+__host__ __device__
+float bessi2(float x) {
+	return (x == 0) ? 0 : bessi0(x) - ((2*1) / x) * bessi1(x);
+}
+
+__host__ __device__
+float bessi3(float x) {
+	return (x == 0) ? 0 : bessi1(x) - ((2*2) / x) * bessi2(x);
+}
+
+__host__ __device__
+float bessi4(float x) {
+	return (x == 0) ? 0 : bessi2(x) - ((2*3) / x) * bessi3(x);
+}
+
+template<int order>
+__host__ __device__
+float kaiserValue(float r, float a) {
+	const CodeletConstants& c =
+#ifdef __CUDA_ARCH__
+		gpuC;
+#else
+		cpuC;
+#endif
+
+	float w;
+	float rda = r / a;
+	if (rda <= 1.f)
+	{
+		float rdas = rda * rda;
+		float arg = c.cBlobAlpha * sqrtf(1.f - rdas);
+		if (order == 0)
+		{
+			w = bessi0(arg) * c.cOneOverBessiOrderAlpha;
+		}
+		else if (order == 1)
+		{
+			w = sqrtf (1.f - rdas);
+			w *= bessi1(arg) * c.cOneOverBessiOrderAlpha;
+		}
+		else if (order == 2)
+		{
+			w = sqrtf (1.f - rdas);
+			w = w * w;
+			w *= bessi2(arg) * c.cOneOverBessiOrderAlpha;
+		}
+		else if (order == 3)
+		{
+			w = sqrtf (1.f - rdas);
+			w = w * w * w;
+			w *= bessi3(arg) * c.cOneOverBessiOrderAlpha;
+		}
+		else if (order == 4)
+		{
+			w = sqrtf (1.f - rdas);
+			w = w * w * w *w;
+			w *= bessi4(arg) * c.cOneOverBessiOrderAlpha;
+		}
+		else {
+			printf("order (%d) out of range in kaiser_value(): %s, %d\n", order, __FILE__, __LINE__);
+			w = 0.f;
+		}
+	}
+	else
+		w = 0.f;
+
+	return w;
+}
+
+__host__ __device__
+float kaiserValueFast(float distSqr) {
+	const CodeletConstants& c =
+#ifdef __CUDA_ARCH__
+			gpuC;
+#else
+			cpuC;
+#endif
+
+	float arg = c.cBlobAlpha * sqrtf(1.f - (distSqr * c.cOneOverBlobRadiusSqr)); // alpha * sqrt(1-(dist/blobRadius^2))
+	return bessi0Fast(arg) * c.cOneOverBessiOrderAlpha * c.cIw0;
+}
+
+// ========================================= Math utilities ====================================
+
+
+
+/** Calculates Z coordinate of the point [x, y] on the plane defined by p0 (origin) and normal */
+__host__ __device__
+float getZ(float x, float y, const Point3D<float>& n, const Point3D<float>& p0) {
+	// from a(x-x0)+b(y-y0)+c(z-z0)=0
+	return (-n.x*(x-p0.x)-n.y*(y-p0.y))/n.z + p0.z;
+}
+
+/** Calculates Y coordinate of the point [x, z] on the plane defined by p0 (origin) and normal */
+__host__ __device__
+float getY(float x, float z, const Point3D<float>& n, const Point3D<float>& p0){
+	// from a(x-x0)+b(y-y0)+c(z-z0)=0
+	return (-n.x*(x-p0.x)-n.z*(z-p0.z))/n.y + p0.y;
+}
+
+
+/** Calculates X coordinate of the point [y, z] on the plane defined by p0 (origin) and normal */
+__host__ __device__
+float getX(float y, float z, const Point3D<float>& n, const Point3D<float>& p0){
+	// from a(x-x0)+b(y-y0)+c(z-z0)=0
+	return (-n.y*(y-p0.y)-n.z*(z-p0.z))/n.x + p0.x;
+}
+
+/** Do 3x3 x 1x3 matrix-vector multiplication */
+__host__ __device__
+void multiply(const float transform[3][3], Point3D<float>& inOut) {
+	float tmp0 = transform[0][0] * inOut.x + transform[0][1] * inOut.y + transform[0][2] * inOut.z;
+	float tmp1 = transform[1][0] * inOut.x + transform[1][1] * inOut.y + transform[1][2] * inOut.z;
+	float tmp2 = transform[2][0] * inOut.x + transform[2][1] * inOut.y + transform[2][2] * inOut.z;
+	inOut.x = tmp0;
+	inOut.y = tmp1;
+	inOut.z = tmp2;
+}
+
+/**
+ * Method will rotate box using transformation matrix around center of the
+ * working space
+ */
+__host__ __device__
+void rotate(Point3D<float> box[8], const float transform[3][3]) {
+	const CodeletConstants& c =
+#ifdef __CUDA_ARCH__
+			gpuC;
+#else
+			cpuC;
+#endif
+
+	for (int i = 0; i < 8; i++) {
+		Point3D<float> imgPos;
+		// transform current point to center
+		imgPos.x = box[i].x - c.cMaxVolumeIndexX/2;
+		imgPos.y = box[i].y - c.cMaxVolumeIndexYZ/2;
+		imgPos.z = box[i].z - c.cMaxVolumeIndexYZ/2;
+		// rotate around center
+		multiply(transform, imgPos);
+		// transform back just Y coordinate, since X now matches to picture and Z is irrelevant
+		imgPos.y += c.cMaxVolumeIndexYZ / 2;
+
+		box[i] = imgPos;
+	}
+}
+
+// ========================================= AABBs ====================================
+
+/** Compute Axis Aligned Bounding Box of given cuboid */
+__host__ __device__
+void computeAABB(Point3D<float> AABB[2], const Point3D<float> cuboid[8]) {
+	AABB[0].x = AABB[0].y = AABB[0].z = INFINITY;
+	AABB[1].x = AABB[1].y = AABB[1].z = -INFINITY;
+	for (int i = 0; i < 8; i++) {
+		Point3D<float> tmp = cuboid[i];
+		if (AABB[0].x > tmp.x) AABB[0].x = tmp.x;
+		if (AABB[0].y > tmp.y) AABB[0].y = tmp.y;
+		if (AABB[0].z > tmp.z) AABB[0].z = tmp.z;
+		if (AABB[1].x < tmp.x) AABB[1].x = tmp.x;
+		if (AABB[1].y < tmp.y) AABB[1].y = tmp.y;
+		if (AABB[1].z < tmp.z) AABB[1].z = tmp.z;
+	}
+	AABB[0].x = ceilf(AABB[0].x);
+	AABB[0].y = ceilf(AABB[0].y);
+	AABB[0].z = ceilf(AABB[0].z);
+
+	AABB[1].x = floorf(AABB[1].x);
+	AABB[1].y = floorf(AABB[1].y);
+	AABB[1].z = floorf(AABB[1].z);
+}
+
+#if SHARED_IMG
+/**
+ * Method calculates an Axis Aligned Bounding Box in the image space.
+ * AABB is guaranteed to be big enough that all threads in the block,
+ * while processing the traverse space, will not read image data outside
+ * of the AABB
+ */
+__device__
+void calculateAABB(const RecFourierProjectionTraverseSpace* tSpace, Point3D<float> dest[2]) {
+	const CodeletConstants& c =
+#ifdef __CUDA_ARCH__
+		gpuC;
+#else
+		cpuC;
+#endif
+
+	Point3D<float> box[8];
+	// calculate AABB for the whole working block
+	if (tSpace->XY == tSpace->dir) { // iterate XY plane
+		box[0].x = box[3].x = box[4].x = box[7].x = blockIdx.x*blockDim.x - c.cBlobRadius;
+		box[1].x = box[2].x = box[5].x = box[6].x = (blockIdx.x+1)*blockDim.x + c.cBlobRadius - 1.f;
+
+		box[2].y = box[3].y = box[6].y = box[7].y = (blockIdx.y+1)*blockDim.y + c.cBlobRadius - 1.f;
+		box[0].y = box[1].y = box[4].y = box[5].y = blockIdx.y*blockDim.y- c.cBlobRadius;
+
+		box[0].z = getZ(box[0].x, box[0].y, tSpace->unitNormal, tSpace->bottomOrigin);
+		box[4].z = getZ(box[4].x, box[4].y, tSpace->unitNormal, tSpace->topOrigin);
+
+		box[3].z = getZ(box[3].x, box[3].y, tSpace->unitNormal, tSpace->bottomOrigin);
+		box[7].z = getZ(box[7].x, box[7].y, tSpace->unitNormal, tSpace->topOrigin);
+
+		box[2].z = getZ(box[2].x, box[2].y, tSpace->unitNormal, tSpace->bottomOrigin);
+		box[6].z = getZ(box[6].x, box[6].y, tSpace->unitNormal, tSpace->topOrigin);
+
+		box[1].z = getZ(box[1].x, box[1].y, tSpace->unitNormal, tSpace->bottomOrigin);
+		box[5].z = getZ(box[5].x, box[5].y, tSpace->unitNormal, tSpace->topOrigin);
+	} else if (tSpace->XZ == tSpace->dir) { // iterate XZ plane
+		box[0].x = box[3].x = box[4].x = box[7].x = blockIdx.x*blockDim.x - c.cBlobRadius;
+		box[1].x = box[2].x = box[5].x = box[6].x = (blockIdx.x+1)*blockDim.x + c.cBlobRadius - 1.f;
+
+		box[2].z = box[3].z = box[6].z = box[7].z = (blockIdx.y+1)*blockDim.y + c.cBlobRadius - 1.f;
+		box[0].z = box[1].z = box[4].z = box[5].z = blockIdx.y*blockDim.y - c.cBlobRadius;
+
+		box[0].y = getY(box[0].x, box[0].z, tSpace->unitNormal, tSpace->bottomOrigin);
+		box[4].y = getY(box[4].x, box[4].z, tSpace->unitNormal, tSpace->topOrigin);
+
+		box[3].y = getY(box[3].x, box[3].z, tSpace->unitNormal, tSpace->bottomOrigin);
+		box[7].y = getY(box[7].x, box[7].z, tSpace->unitNormal, tSpace->topOrigin);
+
+		box[2].y = getY(box[2].x, box[2].z, tSpace->unitNormal, tSpace->bottomOrigin);
+		box[6].y = getY(box[6].x, box[6].z, tSpace->unitNormal, tSpace->topOrigin);
+
+		box[1].y = getY(box[1].x, box[1].z, tSpace->unitNormal, tSpace->bottomOrigin);
+		box[5].y = getY(box[5].x, box[5].z, tSpace->unitNormal, tSpace->topOrigin);
+	} else { // iterate YZ plane
+		box[0].y = box[3].y = box[4].y = box[7].y = blockIdx.x*blockDim.x - c.cBlobRadius;
+		box[1].y = box[2].y = box[5].y = box[6].y = (blockIdx.x+1)*blockDim.x + c.cBlobRadius - 1.f;
+
+		box[2].z = box[3].z = box[6].z = box[7].z = (blockIdx.y+1)*blockDim.y + c.cBlobRadius - 1.f;
+		box[0].z = box[1].z = box[4].z = box[5].z = blockIdx.y*blockDim.y- c.cBlobRadius;
+
+		box[0].x = getX(box[0].y, box[0].z, tSpace->unitNormal, tSpace->bottomOrigin);
+		box[4].x = getX(box[4].y, box[4].z, tSpace->unitNormal, tSpace->topOrigin);
+
+		box[3].x = getX(box[3].y, box[3].z, tSpace->unitNormal, tSpace->bottomOrigin);
+		box[7].x = getX(box[7].y, box[7].z, tSpace->unitNormal, tSpace->topOrigin);
+
+		box[2].x = getX(box[2].y, box[2].z, tSpace->unitNormal, tSpace->bottomOrigin);
+		box[6].x = getX(box[6].y, box[6].z, tSpace->unitNormal, tSpace->topOrigin);
+
+		box[1].x = getX(box[1].y, box[1].z, tSpace->unitNormal, tSpace->bottomOrigin);
+		box[5].x = getX(box[5].y, box[5].z, tSpace->unitNormal, tSpace->topOrigin);
+	}
+	// transform AABB to the image domain
+	rotate(box, tSpace->transformInv);
+	// AABB is projected on image. Create new AABB that will encompass all vertices
+	computeAABB(dest, box);
+}
+
+/** Method returns true if AABB lies within the image boundaries */
+__device__
+bool isWithin(Point3D<float> AABB[2], int imgXSize, int imgYSize) {
+	return (AABB[0].x < imgXSize)
+	       && (AABB[1].x >= 0)
+	       && (AABB[0].y < imgYSize)
+	       && (AABB[1].y >= 0);
+}
+#endif
+
+// ========================================= Actual processing ====================================
+
+/**
+ * Method will map one voxel from the temporal
+ * spaces to the given projection and update temporal spaces
+ * using the pixel value of the projection.
+ */
+__device__
+void processVoxel(
+		float2* tempVolumeGPU, float* tempWeightsGPU,
+		int x, int y, int z,
+		int xSize, int ySize,
+		const float2* __restrict__ FFT,
+		const RecFourierProjectionTraverseSpace* const space)
+{
+	Point3D<float> imgPos;
+	float wBlob = 1.f;
+
+	float dataWeight = space->weight;
+
+	// transform current point to center
+	imgPos.x = x - gpuC.cMaxVolumeIndexX/2;
+	imgPos.y = y - gpuC.cMaxVolumeIndexYZ/2;
+	imgPos.z = z - gpuC.cMaxVolumeIndexYZ/2;
+	if (imgPos.x*imgPos.x + imgPos.y*imgPos.y + imgPos.z*imgPos.z > space->maxDistanceSqr) {
+		return; // discard iterations that would access pixel with too high frequency
+	}
+	// rotate around center
+	multiply(space->transformInv, imgPos);
+	if (imgPos.x < 0.f) return; // reading outside of the image boundary. Z is always correct and Y is checked by the condition above
+
+	// transform back and round
+	// just Y coordinate needs adjusting, since X now matches to picture and Z is irrelevant
+	int imgX = clamp((int)(imgPos.x + 0.5f), 0, xSize - 1);
+	int imgY = clamp((int)(imgPos.y + 0.5f + gpuC.cMaxVolumeIndexYZ / 2), 0, ySize - 1);
+
+	int index3D = z * (gpuC.cMaxVolumeIndexYZ+1) * (gpuC.cMaxVolumeIndexX+1) + y * (gpuC.cMaxVolumeIndexX+1) + x;
+	int index2D = imgY * xSize + imgX;
+
+	float weight = wBlob * dataWeight;
+
+	// use atomic as two blocks can write to same voxel
+	atomicAdd(&tempVolumeGPU[index3D].x, FFT[index2D].x * weight);
+	atomicAdd(&tempVolumeGPU[index3D].y, FFT[index2D].y * weight);
+	atomicAdd(&tempWeightsGPU[index3D], weight);
+}
+
+/**
+ * Method will map one voxel from the temporal
+ * spaces to the given projection and update temporal spaces
+ * using the pixel values of the projection withing the blob distance.
+ */
+template<int blobOrder, bool useFastKaiser>
+__device__
+void processVoxelBlob(
+		float2* tempVolumeGPU, float *tempWeightsGPU,
+		const int x, const int y, const int z,
+		const int xSize, const int ySize,
+		const float2* __restrict__ FFT,
+		const RecFourierProjectionTraverseSpace* const space,
+		const float* blobTableSqrt,
+		const int imgCacheDim)
+{
+	Point3D<float> imgPos;
+	// transform current point to center
+	imgPos.x = x - gpuC.cMaxVolumeIndexX/2;
+	imgPos.y = y - gpuC.cMaxVolumeIndexYZ/2;
+	imgPos.z = z - gpuC.cMaxVolumeIndexYZ/2;
+	if ((imgPos.x*imgPos.x + imgPos.y*imgPos.y + imgPos.z*imgPos.z) > space->maxDistanceSqr) {
+		return; // discard iterations that would access pixel with too high frequency
+	}
+	// rotate around center
+	multiply(space->transformInv, imgPos);
+	if (imgPos.x < -gpuC.cBlobRadius) return; // reading outside of the image boundary. Z is always correct and Y is checked by the condition above
+	// transform back just Y coordinate, since X now matches to picture and Z is irrelevant
+	imgPos.y += gpuC.cMaxVolumeIndexYZ / 2;
+
+	// check that we don't want to collect data from far far away ...
+	float radiusSqr = gpuC.cBlobRadius * gpuC.cBlobRadius;
+	float zSqr = imgPos.z * imgPos.z;
+	if (zSqr > radiusSqr) return;
+
+	// create blob bounding box
+	int minX = ceilf(imgPos.x - gpuC.cBlobRadius);
+	int maxX = floorf(imgPos.x + gpuC.cBlobRadius);
+	int minY = ceilf(imgPos.y - gpuC.cBlobRadius);
+	int maxY = floorf(imgPos.y + gpuC.cBlobRadius);
+	minX = fmaxf(minX, 0);
+	minY = fmaxf(minY, 0);
+	maxX = fminf(maxX, xSize-1);
+	maxY = fminf(maxY, ySize-1);
+
+	int index3D = z * (gpuC.cMaxVolumeIndexYZ+1) * (gpuC.cMaxVolumeIndexX+1) + y * (gpuC.cMaxVolumeIndexX+1) + x;
+	float2 vol;
+	float w;
+	vol.x = vol.y = w = 0.f;
+	float dataWeight = space->weight;
+
+	// check which pixel in the vicinity should contribute
+	for (int i = minY; i <= maxY; i++) {
+		float ySqr = (imgPos.y - i) * (imgPos.y - i);
+		float yzSqr = ySqr + zSqr;
+		if (yzSqr > radiusSqr) continue;
+		for (int j = minX; j <= maxX; j++) {
+			float xD = imgPos.x - j;
+			float distanceSqr = xD*xD + yzSqr;
+			if (distanceSqr > radiusSqr) continue;
+
+#if SHARED_IMG
+			int index2D = (i - SHARED_AABB[0].y) * imgCacheDim + (j-SHARED_AABB[0].x); // position in img - offset of the AABB
+#else
+			int index2D = i * xSize + j;
+#endif
+
+#if PRECOMPUTE_BLOB_VAL
+			int aux = (int) ((distanceSqr * gpuC.cIDeltaSqrt + 0.5f));
+#if SHARED_BLOB_TABLE
+			float wBlob = BLOB_TABLE[aux];
+#else
+			float wBlob = blobTableSqrt[aux];
+#endif
+#else
+			float wBlob;
+				if (useFastKaiser) {
+					wBlob = kaiserValueFast(distanceSqr);
+				}
+				else {
+					wBlob = kaiserValue<blobOrder>(sqrtf(distanceSqr), gpuC.cBlobRadius) * gpuC.cIw0;
+				}
+#endif
+			float weight = wBlob * dataWeight;
+			w += weight;
+#if SHARED_IMG
+			vol += IMG[index2D] * weight;
+#else
+			vol += FFT[index2D] * weight;
+#endif
+		}
+	}
+
+	// use atomic as two blocks can write to same voxel
+	atomicAdd(&tempVolumeGPU[index3D].x, vol.x);
+	atomicAdd(&tempVolumeGPU[index3D].y, vol.y);
+	atomicAdd(&tempWeightsGPU[index3D], w);
+}
+
+/**
+  * Method will process one projection image and add result to temporal
+  * spaces.
+  */
+template<bool useFast, int blobOrder, bool useFastKaiser>
+__device__
+void processProjection(
+		float2* tempVolumeGPU, float *tempWeightsGPU,
+		const int xSize, const int ySize,
+		const float2* __restrict__ FFT,
+		const RecFourierProjectionTraverseSpace* const tSpace,
+		const float* blobTableSqrt,
+		const int imgCacheDim)
+{
+	// map thread to each (2D) voxel
+#if TILE > 1
+	int id = threadIdx.y * blockDim.x + threadIdx.x;
+	int tidX = threadIdx.x % TILE + (id / (blockDim.y * TILE)) * TILE;
+	int tidY = (id / TILE) % blockDim.y;
+	int idx = blockIdx.x * blockDim.x + tidX;
+	int idy = blockIdx.y * blockDim.y + tidY;
+#else
+	// map thread to each (2D) voxel
+	volatile int idx = blockIdx.x*blockDim.x + threadIdx.x;
+	volatile int idy = blockIdx.y*blockDim.y + threadIdx.y;
+#endif
+
+	if (tSpace->XY == tSpace->dir) { // iterate XY plane
+		if (idy >= tSpace->minY && idy <= tSpace->maxY) {
+			if (idx >= tSpace->minX && idx <= tSpace->maxX) {
+				if (useFast) {
+					float hitZ = getZ(idx, idy, tSpace->unitNormal, tSpace->bottomOrigin);
+					int z = (int)(hitZ + 0.5f); // rounding
+					processVoxel(tempVolumeGPU, tempWeightsGPU, idx, idy, z, xSize, ySize, FFT, tSpace);
+				} else {
+					float z1 = getZ(idx, idy, tSpace->unitNormal, tSpace->bottomOrigin); // lower plane
+					float z2 = getZ(idx, idy, tSpace->unitNormal, tSpace->topOrigin); // upper plane
+					z1 = clamp(z1, 0, gpuC.cMaxVolumeIndexYZ);
+					z2 = clamp(z2, 0, gpuC.cMaxVolumeIndexYZ);
+					int lower = static_cast<int>(floorf(fminf(z1, z2)));
+					int upper = static_cast<int>(ceilf(fmaxf(z1, z2)));
+					for (int z = lower; z <= upper; z++) {
+						processVoxelBlob<blobOrder, useFastKaiser>(tempVolumeGPU, tempWeightsGPU, idx, idy, z, xSize, ySize, FFT, tSpace, blobTableSqrt, imgCacheDim);
+					}
+				}
+			}
+		}
+	} else if (tSpace->XZ == tSpace->dir) { // iterate XZ plane
+		if (idy >= tSpace->minZ && idy <= tSpace->maxZ) { // map z -> y
+			if (idx >= tSpace->minX && idx <= tSpace->maxX) {
+				if (useFast) {
+					float hitY =getY(idx, idy, tSpace->unitNormal, tSpace->bottomOrigin);
+					int y = (int)(hitY + 0.5f); // rounding
+					processVoxel(tempVolumeGPU, tempWeightsGPU, idx, y, idy, xSize, ySize, FFT, tSpace);
+				} else {
+					float y1 = getY(idx, idy, tSpace->unitNormal, tSpace->bottomOrigin); // lower plane
+					float y2 = getY(idx, idy, tSpace->unitNormal, tSpace->topOrigin); // upper plane
+					y1 = clamp(y1, 0, gpuC.cMaxVolumeIndexYZ);
+					y2 = clamp(y2, 0, gpuC.cMaxVolumeIndexYZ);
+					int lower = static_cast<int>(floorf(fminf(y1, y2)));
+					int upper = static_cast<int>(ceilf(fmaxf(y1, y2)));
+					for (int y = lower; y <= upper; y++) {
+						processVoxelBlob<blobOrder, useFastKaiser>(tempVolumeGPU, tempWeightsGPU, idx, y, idy, xSize, ySize, FFT, tSpace, blobTableSqrt, imgCacheDim);
+					}
+				}
+			}
+		}
+	} else { // iterate YZ plane
+		if (idy >= tSpace->minZ && idy <= tSpace->maxZ) { // map z -> y
+			if (idx >= tSpace->minY && idx <= tSpace->maxY) { // map y > x
+				if (useFast) {
+					float hitX = getX(idx, idy, tSpace->unitNormal, tSpace->bottomOrigin);
+					int x = (int)(hitX + 0.5f); // rounding
+					processVoxel(tempVolumeGPU, tempWeightsGPU, x, idx, idy, xSize, ySize, FFT, tSpace);
+				} else {
+					float x1 = getX(idx, idy, tSpace->unitNormal, tSpace->bottomOrigin); // lower plane
+					float x2 = getX(idx, idy, tSpace->unitNormal, tSpace->topOrigin); // upper plane
+					x1 = clamp(x1, 0, gpuC.cMaxVolumeIndexX);
+					x2 = clamp(x2, 0, gpuC.cMaxVolumeIndexX);
+					int lower = static_cast<int>(floorf(fminf(x1, x2)));
+					int upper = static_cast<int>(ceilf(fmaxf(x1, x2)));
+					for (int x = lower; x <= upper; x++) {
+						processVoxelBlob<blobOrder, useFastKaiser>(tempVolumeGPU, tempWeightsGPU, x, idx, idy, xSize, ySize, FFT, tSpace, blobTableSqrt, imgCacheDim);
+					}
+				}
+			}
+		}
+	}
+}
+
+/**
+ * Method will load data from image at position tXindex, tYindex
+ * and return them.
+ * In case the data lies outside of the image boundaries, zeros (0,0)
+ * are returned
+ */
+__device__
+void getImgData(const Point3D<float> AABB[2],
+                const int tXindex, const int tYindex,
+                const float2* FFTs, const int fftSizeX, const int fftSizeY, const int imgIndex,
+                float2& vComplex) {
+	int imgXindex = tXindex + static_cast<int>(AABB[0].x);
+	int imgYindex = tYindex + static_cast<int>(AABB[0].y);
+	if ((imgXindex >= 0)
+	    && (imgXindex < fftSizeX)
+	    && (imgYindex >=0)
+	    && (imgYindex < fftSizeY))	{
+		int index = imgYindex * fftSizeX + imgXindex; // copy data from image
+		vComplex = (FFTs + fftSizeX * fftSizeY * imgIndex)[index];
+	} else {
+		vComplex = {0.f, 0.f}; // out of image bound, so return zero
+	}
+}
+
+/**
+ * Method will copy imgIndex(th) data from buffer
+ * to given destination (shared memory).
+ * Only data within AABB will be copied.
+ * Destination is expected to be continuous array of sufficient
+ * size (imgCacheDim^2)
+ */
+__device__
+void copyImgToCache(float2* dest, const Point3D<float> AABB[2],
+                    const float2* FFTs, const int fftSizeX, const int fftSizeY, const int imgIndex,
+                    const int imgCacheDim) {
+	for (int y = threadIdx.y; y < imgCacheDim; y += blockDim.y) {
+		for (int x = threadIdx.x; x < imgCacheDim; x += blockDim.x) {
+			int memIndex = y * imgCacheDim + x;
+			getImgData(AABB, x, y, FFTs, fftSizeX, fftSizeY, imgIndex, dest[memIndex]);
+		}
+	}
+}
+
+/**
+ * Method will use data stored in the buffer and update temporal
+ * storages appropriately.
+ */
+template<bool fastLateBlobbing, int blobOrder, bool useFastKaiser>
+__global__
+void processBufferKernel(
+		float2* outVolumeBuffer, float *outWeightsBuffer,
+		const int fftSizeX, const int fftSizeY,
+		const int traverseSpaceCount, const RecFourierProjectionTraverseSpace* traverseSpaces,
+		const float2* FFTs,
+		const float* blobTableSqrt,
+		int imgCacheDim) {
+
+#if SHARED_BLOB_TABLE
+	if ( ! fastLateBlobbing) {
+		// copy blob table to shared memory
+		volatile int id = threadIdx.y*blockDim.x + threadIdx.x;
+		volatile int blockSize = blockDim.x * blockDim.y;
+		for (int i = id; i < BLOB_TABLE_SIZE_SQRT; i+= blockSize)
+			BLOB_TABLE[i] = blobTableSqrt[i];
+		__syncthreads();
+	}
+#endif
+
+	for (int i = blockIdx.z; i < traverseSpaceCount; i += gridDim.z) {
+		const RecFourierProjectionTraverseSpace& space = traverseSpaces[i];
+
+#if SHARED_IMG
+		if ( ! fastLateBlobbing) {
+			// make sure that all threads start at the same time
+			// as they can come from previous iteration
+			__syncthreads();
+			if ((threadIdx.x == 0) && (threadIdx.y == 0)) {
+				// first thread calculates which part of the image should be shared
+				calculateAABB(&space, SHARED_AABB);
+			}
+			__syncthreads();
+			// check if the block will have to copy data from image
+			if (isWithin(SHARED_AABB, fftSizeX, fftSizeY)) {
+				// all threads copy image data to shared memory
+				copyImgToCache(IMG, SHARED_AABB, FFTs, fftSizeX, fftSizeY, space.projectionIndex, imgCacheDim);
+				__syncthreads();
+			} else {
+				continue; // whole block can exit, as it's not reading from image
+			}
+		}
+#endif
+
+		processProjection<fastLateBlobbing, blobOrder, useFastKaiser>(
+				outVolumeBuffer, outWeightsBuffer,
+				fftSizeX, fftSizeY,
+				FFTs + fftSizeX * fftSizeY * space.projectionIndex,
+				&space,
+				blobTableSqrt,
+				imgCacheDim);
+
+		__syncthreads(); // sync threads to avoid write after read problems
+	}
+}
+
+/**
+ * Method will use data stored in the buffer and update temporal
+ * storages appropriately.
+ * Actual calculation is done asynchronously, but 'buffer' can be reused
+ * once the method returns.
+ */
+template<int blobOrder, bool useFastKaiser>
+void processBufferGPU(
+		float2 *outVolumeBuffer, float *outWeightsBuffer,
+		const int fftSizeX, const int fftSizeY,
+		const int traverseSpaceCount, const RecFourierProjectionTraverseSpace *traverseSpaces,
+		const float2 *inFFTs,
+		const float *blobTableSqrt,
+		const bool fastLateBlobbing,
+		const float blobRadius, const int maxVolIndexYZ) {
+
+	// enqueue kernel and return control
+	const int imgCacheDim = static_cast<int>(ceil(sqrt(2.f) * sqrt(3.f) * (BLOCK_DIM + 2 * blobRadius)));
+	dim3 dimBlock(BLOCK_DIM, BLOCK_DIM);
+
+	const int size2D = maxVolIndexYZ + 1;
+	dim3 dimGrid(static_cast<unsigned int>(ceil(size2D / (float)dimBlock.x)),
+	             static_cast<unsigned int>(ceil(size2D / (float)dimBlock.y)),
+	             GRID_DIM_Z);
+
+	// by using templates, we can save some registers, especially for 'fast' version
+	if (fastLateBlobbing) {
+		processBufferKernel<true, blobOrder,useFastKaiser><<<dimGrid, dimBlock, 0, starpu_cuda_get_local_stream()>>>(
+				outVolumeBuffer, outWeightsBuffer,
+				fftSizeX, fftSizeY,
+				traverseSpaceCount, traverseSpaces,
+				inFFTs,
+				blobTableSqrt,
+				imgCacheDim);
+	} else {
+		// if making copy of the image in shared memory, allocate enough space
+		int sharedMemSize = SHARED_IMG ? (imgCacheDim*imgCacheDim*sizeof(float2)) : 0;
+		processBufferKernel<false, blobOrder,useFastKaiser><<<dimGrid, dimBlock, sharedMemSize, starpu_cuda_get_local_stream()>>>(
+				outVolumeBuffer, outWeightsBuffer,
+				fftSizeX, fftSizeY,
+				traverseSpaceCount, traverseSpaces,
+				inFFTs,
+				blobTableSqrt,
+				imgCacheDim);
+	}
+	gpuErrchk(cudaPeekAtLastError());
+}
+
+void func_reconstruct_cuda(void* buffers[], void* cl_arg) {
+	const ReconstructFftArgs& arg = *(ReconstructFftArgs*) cl_arg;
+	const float2* inFFTs = (float2*)STARPU_VECTOR_GET_PTR(buffers[0]);
+	const RecFourierProjectionTraverseSpace* inSpaces = (RecFourierProjectionTraverseSpace*)STARPU_MATRIX_GET_PTR(buffers[1]);
+	const float* inBlobTableSqrt = (float*)(STARPU_VECTOR_GET_PTR(buffers[2]));
+	float2* outVolumeBuffer = (float2*)(STARPU_VECTOR_GET_PTR(buffers[3])); // Actually std::complex<float>
+	float* outWeightsBuffer = (float*)(STARPU_VECTOR_GET_PTR(buffers[4]));
+	const uint32_t noOfImages = ((LoadedImagesBuffer*) STARPU_VARIABLE_GET_PTR(buffers[5]))->noOfImages;
+
+	switch (arg.blobOrder) {
+		case 0:
+			if (arg.blobAlpha <= 15.0) {
+				processBufferGPU<0, true>(outVolumeBuffer, outWeightsBuffer,
+				                          arg.fftSizeX, arg.fftSizeY,
+				                          arg.noOfSymmetries * noOfImages, inSpaces,
+				                          inFFTs,
+				                          inBlobTableSqrt,
+				                          arg.fastLateBlobbing,
+				                          arg.blobRadius, arg.maxVolIndexYZ);
+			} else {
+				processBufferGPU<0, false>(outVolumeBuffer, outWeightsBuffer,
+				                           arg.fftSizeX, arg.fftSizeY,
+				                           arg.noOfSymmetries * noOfImages, inSpaces,
+				                           inFFTs,
+				                           inBlobTableSqrt,
+				                           arg.fastLateBlobbing,
+				                           arg.blobRadius, arg.maxVolIndexYZ);
+			}
+			break;
+		case 1:
+			processBufferGPU<1, false>(outVolumeBuffer, outWeightsBuffer,
+			                           arg.fftSizeX, arg.fftSizeY,
+			                           arg.noOfSymmetries * noOfImages, inSpaces,
+			                           inFFTs,
+			                           inBlobTableSqrt,
+			                           arg.fastLateBlobbing,
+			                           arg.blobRadius, arg.maxVolIndexYZ);
+			break;
+		case 2:
+			processBufferGPU<2, false>(outVolumeBuffer, outWeightsBuffer,
+			                           arg.fftSizeX, arg.fftSizeY,
+			                           arg.noOfSymmetries * noOfImages, inSpaces,
+			                           inFFTs,
+			                           inBlobTableSqrt,
+			                           arg.fastLateBlobbing,
+			                           arg.blobRadius, arg.maxVolIndexYZ);
+			break;
+		case 3:
+			processBufferGPU<3, false>(outVolumeBuffer, outWeightsBuffer,
+			                           arg.fftSizeX, arg.fftSizeY,
+			                           arg.noOfSymmetries * noOfImages, inSpaces,
+			                           inFFTs,
+			                           inBlobTableSqrt,
+			                           arg.fastLateBlobbing,
+			                           arg.blobRadius, arg.maxVolIndexYZ);
+			break;
+		case 4:
+			processBufferGPU<4, false>(outVolumeBuffer, outWeightsBuffer,
+			                           arg.fftSizeX, arg.fftSizeY,
+			                           arg.noOfSymmetries * noOfImages, inSpaces,
+			                           inFFTs,
+			                           inBlobTableSqrt,
+			                           arg.fastLateBlobbing,
+			                           arg.blobRadius, arg.maxVolIndexYZ);
+			break;
+		default:
+			REPORT_ERROR(ERR_VALUE_INCORRECT, "m out of range [0..4] in kaiser_value()");
+	}
+
+	// gpuErrchk(cudaStreamSynchronize(starpu_cuda_get_local_stream())); disabled because codelet is async
+}
+
+//------------------------------------------------ CPU -----------------------------------------------------------------
+// uses copies of the GPU functions, rewritten for single thread runtime
+
+/** Atomically increments the value pointed at by ptr by value.
+ * Uses relaxed memory model with no reordering guarantees. */
+void atomicAddFloat(volatile float* ptr, float addedValue) {
+	static_assert(sizeof(float) == sizeof(uint32_t), "atomicAddFloat requires floats to be 32bit");
+
+	// This is probably fine, since the constructor/destructor should be trivial
+	// (As of C++11, this is guaranteed only for integral type specializations, but it is probably reasonably safe to assume
+	// that this will hold for floats as well. C++20 requies that by spec.)
+	volatile std::atomic<float>& atomicPtr = *reinterpret_cast<volatile std::atomic<float>*>(ptr);
+	float current = atomicPtr.load(std::memory_order::memory_order_relaxed);
+	while (true) {
+		const float newValue = current + addedValue;
+		// Since x86 does not allow atomic add of floats (only integers), we have to implement it through CAS
+		if (atomicPtr.compare_exchange_weak(current, newValue, std::memory_order::memory_order_relaxed)) {
+			// Current was still current and was replaced with the newValue. Done.
+			return;
+		}
+		// Comparison failed. current now contains the new value and we try again.
+	}
+}
+
+void processVoxelCPU(
+		float2* const tempVolumeGPU, float* const tempWeightsGPU,
+		const int x, const int y, const int z,
+		const int xSize, const int ySize,
+		const float2* const __restrict__ FFT,
+		const RecFourierProjectionTraverseSpace* const space)
+{
+	Point3D<float> imgPos;
+	float wBlob = 1.f;
+
+	float dataWeight = space->weight;
+
+	// transform current point to center
+	imgPos.x = x - cpuC.cMaxVolumeIndexX/2;
+	imgPos.y = y - cpuC.cMaxVolumeIndexYZ/2;
+	imgPos.z = z - cpuC.cMaxVolumeIndexYZ/2;
+	if (imgPos.x*imgPos.x + imgPos.y*imgPos.y + imgPos.z*imgPos.z > space->maxDistanceSqr) {
+		return; // discard iterations that would access pixel with too high frequency
+	}
+	// rotate around center
+	multiply(space->transformInv, imgPos);
+	if (imgPos.x < 0.f) return; // reading outside of the image boundary. Z is always correct and Y is checked by the condition above
+
+	// transform back and round
+	// just Y coordinate needs adjusting, since X now matches to picture and Z is irrelevant
+	int imgX = clamp((int)(imgPos.x + 0.5f), 0, xSize - 1);
+	int imgY = clamp((int)(imgPos.y + 0.5f + cpuC.cMaxVolumeIndexYZ / 2), 0, ySize - 1);
+
+	int index3D = z * (cpuC.cMaxVolumeIndexYZ+1) * (cpuC.cMaxVolumeIndexX+1) + y * (cpuC.cMaxVolumeIndexX+1) + x;
+	int index2D = imgY * xSize + imgX;
+
+	float weight = wBlob * dataWeight;
+
+	// use atomic as two blocks can write to same voxel
+	atomicAddFloat(&tempVolumeGPU[index3D].x, FFT[index2D].x * weight);
+	atomicAddFloat(&tempVolumeGPU[index3D].y, FFT[index2D].y * weight);
+	atomicAddFloat(&tempWeightsGPU[index3D], weight);
+	//tempVolumeGPU[index3D].x += FFT[index2D].x * weight;
+	//tempVolumeGPU[index3D].y += FFT[index2D].y * weight;
+	//tempWeightsGPU[index3D] += weight;
+}
+
+template<int blobOrder, bool useFastKaiser, bool usePrecomputedInterpolation>
+void processVoxelBlobCPU(
+		float2* const tempVolumeGPU, float* const tempWeightsGPU,
+		const int x, const int y, const int z,
+		const int xSize, const int ySize,
+		const float2* const __restrict__ FFT,
+		const RecFourierProjectionTraverseSpace* const space,
+		const float* blobTableSqrt)
+{
+	Point3D<float> imgPos;
+	// transform current point to center
+	imgPos.x = x - cpuC.cMaxVolumeIndexX/2;
+	imgPos.y = y - cpuC.cMaxVolumeIndexYZ/2;
+	imgPos.z = z - cpuC.cMaxVolumeIndexYZ/2;
+	if ((imgPos.x*imgPos.x + imgPos.y*imgPos.y + imgPos.z*imgPos.z) > space->maxDistanceSqr) {
+		return; // discard iterations that would access pixel with too high frequency
+	}
+	// rotate around center
+	multiply(space->transformInv, imgPos);
+	if (imgPos.x < -cpuC.cBlobRadius) return; // reading outside of the image boundary. Z is always correct and Y is checked by the condition above
+	// transform back just Y coordinate, since X now matches to picture and Z is irrelevant
+	imgPos.y += cpuC.cMaxVolumeIndexYZ / 2;
+
+	// check that we don't want to collect data from far far away ...
+	float radiusSqr = cpuC.cBlobRadius * cpuC.cBlobRadius;
+	float zSqr = imgPos.z * imgPos.z;
+	if (zSqr > radiusSqr) return;
+
+	// create blob bounding box
+	int minX = ceilf(imgPos.x - cpuC.cBlobRadius);
+	int maxX = floorf(imgPos.x + cpuC.cBlobRadius);
+	int minY = ceilf(imgPos.y - cpuC.cBlobRadius);
+	int maxY = floorf(imgPos.y + cpuC.cBlobRadius);
+	minX = fmaxf(minX, 0);
+	minY = fmaxf(minY, 0);
+	maxX = fminf(maxX, xSize-1);
+	maxY = fminf(maxY, ySize-1);
+
+	int index3D = z * (cpuC.cMaxVolumeIndexYZ+1) * (cpuC.cMaxVolumeIndexX+1) + y * (cpuC.cMaxVolumeIndexX+1) + x;
+	float2 vol;
+	float w;
+	vol.x = vol.y = w = 0.f;
+	float dataWeight = space->weight;
+
+	// check which pixel in the vicinity should contribute
+	for (int i = minY; i <= maxY; i++) {
+		float ySqr = (imgPos.y - i) * (imgPos.y - i);
+		float yzSqr = ySqr + zSqr;
+		if (yzSqr > radiusSqr) continue;
+		for (int j = minX; j <= maxX; j++) {
+			float xD = imgPos.x - j;
+			float distanceSqr = xD*xD + yzSqr;
+			if (distanceSqr > radiusSqr) continue;
+
+			int index2D = i * xSize + j;
+
+			float wBlob;
+			if (usePrecomputedInterpolation) {
+				int aux = (int) ((distanceSqr * cpuC.cIDeltaSqrt + 0.5f));
+				wBlob = blobTableSqrt[aux];
+			} else if (useFastKaiser) {
+				wBlob = kaiserValueFast(distanceSqr);
+			} else {
+				wBlob = kaiserValue<blobOrder>(sqrtf(distanceSqr), cpuC.cBlobRadius) * cpuC.cIw0;
+			}
+
+			float weight = wBlob * dataWeight;
+			w += weight;
+			vol += FFT[index2D] * weight;
+		}
+	}
+
+	atomicAddFloat(&tempVolumeGPU[index3D].x, vol.x);
+	atomicAddFloat(&tempVolumeGPU[index3D].y, vol.y);
+	atomicAddFloat(&tempWeightsGPU[index3D], w);
+	//tempVolumeGPU[index3D].x += vol.x;
+	//tempVolumeGPU[index3D].y += vol.y;
+	//tempWeightsGPU[index3D] += w;
+}
+
+template<bool useFast, int blobOrder, bool useFastKaiser, bool usePrecomputedInterpolation>
+void processProjectionCPU(
+		float2* tempVolumeGPU, float *tempWeightsGPU,
+		const int xSize, const int ySize,
+		const float2* __restrict__ FFT,
+		const RecFourierProjectionTraverseSpace* const tSpace,
+		const float* blobTableSqrt) {
+
+	if (tSpace->XY == tSpace->dir) { // iterate XY plane
+		for (int idy = tSpace->minY; idy <= tSpace->maxY; idy++) {
+			for (int idx = tSpace->minX; idx <= tSpace->maxX; idx++) {
+				if (useFast) {
+					float hitZ = getZ(idx, idy, tSpace->unitNormal, tSpace->bottomOrigin);
+					int z = (int)(hitZ + 0.5f); // rounding
+					processVoxelCPU(tempVolumeGPU, tempWeightsGPU, idx, idy, z, xSize, ySize, FFT, tSpace);
+				} else {
+					float z1 = getZ(idx, idy, tSpace->unitNormal, tSpace->bottomOrigin); // lower plane
+					float z2 = getZ(idx, idy, tSpace->unitNormal, tSpace->topOrigin); // upper plane
+					z1 = clamp(z1, 0, cpuC.cMaxVolumeIndexYZ);
+					z2 = clamp(z2, 0, cpuC.cMaxVolumeIndexYZ);
+					int lower = static_cast<int>(floorf(fminf(z1, z2)));
+					int upper = static_cast<int>(ceilf(fmaxf(z1, z2)));
+					for (int z = lower; z <= upper; z++) {
+						processVoxelBlobCPU<blobOrder, useFastKaiser, usePrecomputedInterpolation>(tempVolumeGPU, tempWeightsGPU, idx, idy, z, xSize, ySize, FFT, tSpace, blobTableSqrt);
+					}
+				}
+			}
+		}
+	} else if (tSpace->XZ == tSpace->dir) { // iterate XZ plane
+		for (int idy = tSpace->minZ; idy <= tSpace->maxZ; idy++) { // map z -> y
+			for (int idx = tSpace->minX; idx <= tSpace->maxX; idx++) {
+				if (useFast) {
+					float hitY =getY(idx, idy, tSpace->unitNormal, tSpace->bottomOrigin);
+					int y = (int)(hitY + 0.5f); // rounding
+					processVoxelCPU(tempVolumeGPU, tempWeightsGPU, idx, y, idy, xSize, ySize, FFT, tSpace);
+				} else {
+					float y1 = getY(idx, idy, tSpace->unitNormal, tSpace->bottomOrigin); // lower plane
+					float y2 = getY(idx, idy, tSpace->unitNormal, tSpace->topOrigin); // upper plane
+					y1 = clamp(y1, 0, cpuC.cMaxVolumeIndexYZ);
+					y2 = clamp(y2, 0, cpuC.cMaxVolumeIndexYZ);
+					int lower = static_cast<int>(floorf(fminf(y1, y2)));
+					int upper = static_cast<int>(ceilf(fmaxf(y1, y2)));
+					for (int y = lower; y <= upper; y++) {
+						processVoxelBlobCPU<blobOrder, useFastKaiser, usePrecomputedInterpolation>(tempVolumeGPU, tempWeightsGPU, idx, y, idy, xSize, ySize, FFT, tSpace, blobTableSqrt);
+					}
+				}
+			}
+		}
+	} else { // iterate YZ plane
+		for (int idy = tSpace->minZ; idy <= tSpace->maxZ; idy++) { // map z -> y
+			for (int idx = tSpace->minY; idx <= tSpace->maxY; idx++) { // map y > x
+				if (useFast) {
+					float hitX = getX(idx, idy, tSpace->unitNormal, tSpace->bottomOrigin);
+					int x = (int)(hitX + 0.5f); // rounding
+					processVoxelCPU(tempVolumeGPU, tempWeightsGPU, x, idx, idy, xSize, ySize, FFT, tSpace);
+				} else {
+					float x1 = getX(idx, idy, tSpace->unitNormal, tSpace->bottomOrigin); // lower plane
+					float x2 = getX(idx, idy, tSpace->unitNormal, tSpace->topOrigin); // upper plane
+					x1 = clamp(x1, 0, cpuC.cMaxVolumeIndexX);
+					x2 = clamp(x2, 0, cpuC.cMaxVolumeIndexX);
+					int lower = static_cast<int>(floorf(fminf(x1, x2)));
+					int upper = static_cast<int>(ceilf(fmaxf(x1, x2)));
+					for (int x = lower; x <= upper; x++) {
+						processVoxelBlobCPU<blobOrder, useFastKaiser, usePrecomputedInterpolation>(tempVolumeGPU, tempWeightsGPU, x, idx, idy, xSize, ySize, FFT, tSpace, blobTableSqrt);
+					}
+				}
+			}
+		}
+	}
+}
+
+template<int blobOrder, bool useFastKaiser, bool usePrecomputedInterpolation>
+void processBufferCPU(
+		float2 *outVolumeBuffer, float *outWeightsBuffer,
+		const int fftSizeX, const int fftSizeY,
+		const int traverseSpaceCount, const RecFourierProjectionTraverseSpace *traverseSpaces,
+		const float2 *inFFTs,
+		const float *blobTableSqrt,
+		const bool fastLateBlobbing) {
+
+	const int groupSize = starpu_combined_worker_get_size();
+	const int groupRank = starpu_combined_worker_get_rank();
+
+	for (int i = groupRank; i < traverseSpaceCount; i += groupSize) {
+		const RecFourierProjectionTraverseSpace &space = traverseSpaces[i];
+
+		const float2* spaceFFT = inFFTs + fftSizeX * fftSizeY * space.projectionIndex;
+
+		// by using templates, we can save some registers, especially for 'fast' version
+		if (fastLateBlobbing) {
+			processProjectionCPU<true, blobOrder, useFastKaiser, usePrecomputedInterpolation>(
+					outVolumeBuffer, outWeightsBuffer,
+					fftSizeX, fftSizeY,
+					spaceFFT,
+					&space,
+					blobTableSqrt);
+		} else {
+			processProjectionCPU<false, blobOrder, useFastKaiser, usePrecomputedInterpolation>(
+					outVolumeBuffer, outWeightsBuffer,
+					fftSizeX, fftSizeY,
+					spaceFFT,
+					&space,
+					blobTableSqrt);
+		}
+	}
+}
+
+template<bool usePrecomputedInterpolation>
+void func_reconstruct_cpu_template(void* buffers[], void* cl_arg) {
+	const ReconstructFftArgs& arg = *(ReconstructFftArgs*) cl_arg;
+	const float2* inFFTs = (float2*)STARPU_VECTOR_GET_PTR(buffers[0]);
+	const RecFourierProjectionTraverseSpace* inSpaces = (RecFourierProjectionTraverseSpace*)STARPU_MATRIX_GET_PTR(buffers[1]);
+	const float* inBlobTableSqrt = (float*)(STARPU_VECTOR_GET_PTR(buffers[2]));
+	float2* outVolumeBuffer = (float2*)(STARPU_VECTOR_GET_PTR(buffers[3])); // Actually std::complex<float>
+	float* outWeightsBuffer = (float*)(STARPU_VECTOR_GET_PTR(buffers[4]));
+	const uint32_t noOfImages = ((LoadedImagesBuffer*) STARPU_VARIABLE_GET_PTR(buffers[5]))->noOfImages;
+
+	switch (arg.blobOrder) {
+		case 0:
+			if (arg.blobAlpha <= 15.0) {
+				processBufferCPU<0, true, usePrecomputedInterpolation>(outVolumeBuffer, outWeightsBuffer,
+				                          arg.fftSizeX, arg.fftSizeY,
+				                          arg.noOfSymmetries * noOfImages, inSpaces,
+				                          inFFTs,
+				                          inBlobTableSqrt,
+				                          arg.fastLateBlobbing);
+			} else {
+				processBufferCPU<0, false, usePrecomputedInterpolation>(outVolumeBuffer, outWeightsBuffer,
+				                           arg.fftSizeX, arg.fftSizeY,
+				                           arg.noOfSymmetries * noOfImages, inSpaces,
+				                           inFFTs,
+				                           inBlobTableSqrt,
+				                           arg.fastLateBlobbing);
+			}
+			break;
+		case 1:
+			processBufferCPU<1, false, usePrecomputedInterpolation>(outVolumeBuffer, outWeightsBuffer,
+			                           arg.fftSizeX, arg.fftSizeY,
+			                           arg.noOfSymmetries * noOfImages, inSpaces,
+			                           inFFTs,
+			                           inBlobTableSqrt,
+			                           arg.fastLateBlobbing);
+			break;
+		case 2:
+			processBufferCPU<2, false, usePrecomputedInterpolation>(outVolumeBuffer, outWeightsBuffer,
+			                           arg.fftSizeX, arg.fftSizeY,
+			                           arg.noOfSymmetries * noOfImages, inSpaces,
+			                           inFFTs,
+			                           inBlobTableSqrt,
+			                           arg.fastLateBlobbing);
+			break;
+		case 3:
+			processBufferCPU<3, false, usePrecomputedInterpolation>(outVolumeBuffer, outWeightsBuffer,
+			                           arg.fftSizeX, arg.fftSizeY,
+			                           arg.noOfSymmetries * noOfImages, inSpaces,
+			                           inFFTs,
+			                           inBlobTableSqrt,
+			                           arg.fastLateBlobbing);
+			break;
+		case 4:
+			processBufferCPU<4, false, usePrecomputedInterpolation>(outVolumeBuffer, outWeightsBuffer,
+			                           arg.fftSizeX, arg.fftSizeY,
+			                           arg.noOfSymmetries * noOfImages, inSpaces,
+			                           inFFTs,
+			                           inBlobTableSqrt,
+			                           arg.fastLateBlobbing);
+			break;
+		default:
+			REPORT_ERROR(ERR_VALUE_INCORRECT, "m out of range [0..4] in kaiser_value()");
+	}
+}
+
+void func_reconstruct_cpu_lookup_interpolation(void* buffers[], void* cl_arg) {
+	func_reconstruct_cpu_template<true>(buffers, cl_arg);
+}
+
+void func_reconstruct_cpu_dynamic_interpolation(void* buffers[], void* cl_arg) {
+	func_reconstruct_cpu_template<false>(buffers, cl_arg);
+}

--- a/src/xmipp/libraries/reconstruction_starpu/reconstruct_fourier_codelet_redux.cpp
+++ b/src/xmipp/libraries/reconstruction_starpu/reconstruct_fourier_codelet_redux.cpp
@@ -1,0 +1,136 @@
+/***************************************************************************
+ *
+ * Authors:     Jan Polak (456647@mail.muni.cz)
+ *
+ * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ * 02111-1307  USA
+ *
+ *  All comments concerning this program package may be sent to the
+ *  e-mail address 'xmipp@cnb.csic.es'
+ ***************************************************************************/
+
+#include <starpu.h>
+#include <cuda_runtime.h>
+#include <cuda_runtime_api.h>
+#include <reconstruction_cuda/cuda_asserts.h>
+#include "reconstruct_fourier_codelets.h"
+#include "reconstruct_fourier_util.h"
+
+// Implementation of redux methods
+
+inline void memset_to_zero_cuda(void * buffer) {
+	uintptr_t cudaPtr = STARPU_VECTOR_GET_PTR(buffer);
+	size_t size = STARPU_VECTOR_GET_NX(buffer) * STARPU_VECTOR_GET_ELEMSIZE(buffer);
+
+	gpuErrchk(cudaMemsetAsync((void *) cudaPtr, 0, size, starpu_cuda_get_local_stream()));
+	// gpuErrchk(cudaStreamSynchronize(starpu_cuda_get_local_stream())); disabled because codelet is async
+}
+
+void func_redux_init_volume_cuda(void* buffers[], void* cl_arg) {
+	(void)cl_arg;
+	memset_to_zero_cuda(buffers[0]);
+}
+
+void func_redux_init_weights_cuda(void* buffers[], void* cl_arg) {
+	(void)cl_arg;
+	memset_to_zero_cuda(buffers[0]);
+}
+
+inline void memset_to_zero_cpu(void * buffer) {
+	uintptr_t ptr = STARPU_VECTOR_GET_PTR(buffer);
+	size_t size = STARPU_VECTOR_GET_NX(buffer) * STARPU_VECTOR_GET_ELEMSIZE(buffer);
+	memset((void *) ptr, 0, size);
+}
+
+void func_redux_init_volume_cpu(void* buffers[], void* cl_arg) {
+	(void)cl_arg;
+	memset_to_zero_cpu(buffers[0]);
+}
+
+void func_redux_init_weights_cpu(void* buffers[], void* cl_arg) {
+	(void)cl_arg;
+	memset_to_zero_cpu(buffers[0]);
+}
+
+__global__
+void sum_floats(float4 * target, float4 * source, uint length) {
+	uint i = blockIdx.x * blockDim.x + threadIdx.x;
+	if (i < length) {
+		target[i].x += source[i].x;
+		target[i].y += source[i].y;
+		target[i].z += source[i].z;
+		target[i].w += source[i].w;
+	}
+}
+
+inline void sum_floats_on_cuda(uintptr_t targetCudaPtr, uintptr_t sourceCudaPtr, size_t noOfFloats) {
+	// Note: When initializing data in reconstruct_fourier_starpu.cpp#run(),
+	// buffer size was padded to multiple of 4, so we can leverage that.
+
+	assert(noOfFloats % 4 == 0);
+	size_t noOfFloat4 = noOfFloats / 4;
+
+	dim3 threadsPerBlock(512);
+	// Rounding up, we don't know whether noOfFloats is also a multiple of 512 (unlikely), additional checking is done in kernel
+	dim3 numBlocks(static_cast<unsigned int>((noOfFloat4 + threadsPerBlock.x - 1) / threadsPerBlock.x));
+
+	sum_floats<<<numBlocks, threadsPerBlock, 0, starpu_cuda_get_local_stream()>>>((float4*) targetCudaPtr, (float4*)(sourceCudaPtr), noOfFloat4);
+	gpuErrchk(cudaPeekAtLastError());
+	// gpuErrchk(cudaStreamSynchronize(starpu_cuda_get_local_stream())); disabled because codelet is async
+}
+
+void func_redux_sum_volume_cuda(void* buffers[], void* cl_arg) {
+	(void)cl_arg;
+	uintptr_t targetCudaPtr = STARPU_VECTOR_GET_PTR(buffers[0]);
+	uintptr_t sourceCudaPtr = STARPU_VECTOR_GET_PTR(buffers[1]);
+	size_t size = STARPU_VECTOR_GET_NX(buffers[0]) * 2; // *2 because complex
+	sum_floats_on_cuda(targetCudaPtr, sourceCudaPtr, size);
+}
+
+void func_redux_sum_weights_cuda(void* buffers[], void* cl_arg) {
+	(void)cl_arg;
+	uintptr_t targetCudaPtr = STARPU_VECTOR_GET_PTR(buffers[0]);
+	uintptr_t sourceCudaPtr = STARPU_VECTOR_GET_PTR(buffers[1]);
+	size_t size = STARPU_VECTOR_GET_NX(buffers[0]);
+	sum_floats_on_cuda(targetCudaPtr, sourceCudaPtr, size);
+}
+
+inline void sum_floats_on_cpu(float* __restrict targetPtr, float* __restrict sourcePtr, size_t noOfFloats) {
+	// Should get vectorized
+	targetPtr = (float*)XMIPP_ASSUME_ALIGNED(targetPtr, ALIGNMENT);
+	sourcePtr = (float*)XMIPP_ASSUME_ALIGNED(sourcePtr, ALIGNMENT);
+
+	for (size_t i = 0; i < noOfFloats; i++) {
+		targetPtr[i] += sourcePtr[i];
+	}
+}
+
+void func_redux_sum_volume_cpu(void* buffers[], void* cl_arg) {
+	(void)cl_arg;
+	uintptr_t targetPtr = STARPU_VECTOR_GET_PTR(buffers[0]);
+	uintptr_t sourcePtr = STARPU_VECTOR_GET_PTR(buffers[1]);
+	size_t size = STARPU_VECTOR_GET_NX(buffers[0]) * 2; // *2 because complex
+	sum_floats_on_cpu((float*) targetPtr, (float*) sourcePtr, size);
+}
+
+void func_redux_sum_weights_cpu(void* buffers[], void* cl_arg) {
+	(void)cl_arg;
+	uintptr_t targetPtr = STARPU_VECTOR_GET_PTR(buffers[0]);
+	uintptr_t sourcePtr = STARPU_VECTOR_GET_PTR(buffers[1]);
+	size_t size = STARPU_VECTOR_GET_NX(buffers[0]);
+	sum_floats_on_cpu((float*) targetPtr, (float*) sourcePtr, size);
+}

--- a/src/xmipp/libraries/reconstruction_starpu/reconstruct_fourier_codelets.cpp
+++ b/src/xmipp/libraries/reconstruction_starpu/reconstruct_fourier_codelets.cpp
@@ -1,0 +1,195 @@
+/***************************************************************************
+ *
+ * Authors:     Jan Polak (456647@mail.muni.cz)
+ *
+ * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ * 02111-1307  USA
+ *
+ *  All comments concerning this program package may be sent to the
+ *  e-mail address 'xmipp@cnb.csic.es'
+ ***************************************************************************/
+
+#include "reconstruct_fourier_codelets.h"
+#include "reconstruct_fourier_timing.h"
+#include "reconstruct_fourier_scheduler.h"
+
+double rfs_arch_cost_function(starpu_task * task, starpu_perfmodel_arch * arch, unsigned nimpl) {
+	auto* data = (rfs_data*)starpu_sched_ctx_get_policy_data(task->sched_ctx);
+	assert(data);
+
+	size_t size = 0;
+	if (task->cl->model && task->cl->model->size_base) {
+		size = task->cl->model->size_base(task, nimpl);
+	}
+
+	double estimate = 0;
+	for (int device = 0; device < arch->ndevices; ++device) {
+		double newEstimate = data->timing.estimate(task->cl, nimpl, arch->devices[device].type, arch->devices[device].devid, size);
+		estimate = STARPU_MAX(estimate, newEstimate);
+	}
+
+	return estimate;
+}
+
+starpu_perfmodel create_common_perfmodel(const char* symbol) {
+	starpu_perfmodel model = {};
+	model.type = STARPU_PER_ARCH;
+	model.arch_cost_function = rfs_arch_cost_function;
+	model.symbol = symbol;
+	return model;
+}
+
+static size_t load_projections_size_base(starpu_task * task, unsigned nimpl) {
+	auto imageDataHandle = STARPU_TASK_GET_HANDLE(task, 1);
+	return starpu_vector_get_elemsize(imageDataHandle) * starpu_vector_get_nx(imageDataHandle);
+}
+
+static size_t padded_image_to_fft_size_base(starpu_task * task, unsigned nimpl) {
+	auto imageDataHandle = STARPU_TASK_GET_HANDLE(task, 0);
+	return starpu_vector_get_elemsize(imageDataHandle) * starpu_vector_get_nx(imageDataHandle);
+}
+
+static size_t reconstruct_fft_size_base(starpu_task * task, unsigned nimpl) {
+	auto fftHandle = STARPU_TASK_GET_HANDLE(task, 0);
+	auto traverseSpacesHandle = STARPU_TASK_GET_HANDLE(task, 1);
+	return starpu_vector_get_elemsize(fftHandle) * starpu_vector_get_nx(fftHandle) * starpu_matrix_get_nx(traverseSpacesHandle);
+}
+
+Codelets::Codelets() {
+	// NOTE(jp): This used to be in designated initializers and this whole cpp wasn't necessary.
+	// But C++ does not have them, so it has to be done through this ugly circus.
+
+	// Load Projections Codelet
+	load_projections.where = STARPU_CPU;
+	load_projections.cpu_funcs[0] = func_load_projections;
+	load_projections.cpu_funcs_name[0] = "combine_image_func";
+	load_projections.nbuffers = 3;
+	load_projections.modes[0] = STARPU_W; // LoadedImagesBuffer
+	load_projections.modes[1] = STARPU_W; // Image Data Buffer
+	load_projections.modes[2] = STARPU_W; // Spaces Buffer
+	load_projections.name = "codelet_load_projections";
+	static struct starpu_perfmodel load_projections_model = create_common_perfmodel("load_projections_model");
+	load_projections_model.size_base = load_projections_size_base;
+	load_projections.model = &load_projections_model;
+	// cl_arg: LoadProjectionArgs - MUST NOT BE COPIED!!!
+
+
+	// Padded Image to FFT Codelet
+	padded_image_to_fft.where = STARPU_CPU | STARPU_CUDA;
+	padded_image_to_fft.cpu_funcs[0] = func_padded_image_to_fft_cpu;
+	padded_image_to_fft.cpu_funcs_name[0] = "func_padded_image_to_fft_cpu";
+	padded_image_to_fft.cuda_funcs[0] = func_padded_image_to_fft_cuda;
+	padded_image_to_fft.cuda_flags[0] = STARPU_CUDA_ASYNC;
+	padded_image_to_fft.nbuffers = 4;
+	padded_image_to_fft.modes[0] = STARPU_R; // Padded Image Data Buffer
+	padded_image_to_fft.modes[1] = STARPU_W; // FFT Buffer
+	padded_image_to_fft.modes[2] = STARPU_SCRATCH; // Raw FFT Scratch Area
+	padded_image_to_fft.modes[3] = STARPU_R; // LoadedImagesBuffer
+	padded_image_to_fft.specific_nodes = 1;
+	padded_image_to_fft.nodes[0] = STARPU_SPECIFIC_NODE_LOCAL;
+	padded_image_to_fft.nodes[1] = STARPU_SPECIFIC_NODE_LOCAL;
+	padded_image_to_fft.nodes[2] = STARPU_SPECIFIC_NODE_LOCAL;
+	padded_image_to_fft.nodes[3] = STARPU_SPECIFIC_NODE_CPU;
+	padded_image_to_fft.name = "codelet_padded_image_to_fft";
+	static struct starpu_perfmodel padded_image_to_fft_model = create_common_perfmodel("padded_image_to_fft_model");
+	padded_image_to_fft_model.size_base = padded_image_to_fft_size_base;
+	padded_image_to_fft.model = &padded_image_to_fft_model;
+	// cl_arg: PaddedImageToFftArgs
+
+
+	// Reconstruct FFT Codelet
+	reconstruct_fft.where = STARPU_CPU | STARPU_CUDA;
+	// NOTE: From StarPU/examples/cg/cg_kernels.c it seems that STARPU_SPMD applies only to CPU implementations,
+	//       which we rely on. However, the documentation does not say that explicitly, so beware.
+	reconstruct_fft.type = starpu_codelet_type::STARPU_SEQ; // starpu_codelet_type::STARPU_SPMD; Disabled for now due to a bug in StarPU 1.3.2 (memory handles are not correctly copied to all SPMD nodes)
+	reconstruct_fft.max_parallelism = 1 << 10;// Large number, we don't really care
+	reconstruct_fft.cpu_funcs[0] = func_reconstruct_cpu_lookup_interpolation;
+	reconstruct_fft.cpu_funcs[1] = func_reconstruct_cpu_dynamic_interpolation; // (Typically about 2x slower than lookup interpolation)
+	reconstruct_fft.cpu_funcs_name[0] = "func_reconstruct_cpu_lookup_interpolation";
+	reconstruct_fft.cpu_funcs_name[1] = "func_reconstruct_cpu_dynamic_interpolation";
+	reconstruct_fft.cuda_funcs[0] = func_reconstruct_cuda;
+	reconstruct_fft.cuda_flags[0] = STARPU_CUDA_ASYNC;
+	reconstruct_fft.nbuffers = 6;
+	reconstruct_fft.modes[0] = STARPU_R; // FFT Buffer
+	reconstruct_fft.modes[1] = STARPU_R; // Traverse Spaces Buffer
+	reconstruct_fft.modes[2] = STARPU_R; // Blob Table Squared Buffer (only present if fastLateBlobbing is false)
+	reconstruct_fft.modes[3] = STARPU_REDUX; // Result Volume Buffer
+	reconstruct_fft.modes[4] = STARPU_REDUX; // Result Weights Buffer
+	reconstruct_fft.modes[5] = STARPU_R; // LoadedImagesBuffer
+	reconstruct_fft.specific_nodes = 1;
+	reconstruct_fft.nodes[0] = STARPU_SPECIFIC_NODE_LOCAL;
+	reconstruct_fft.nodes[1] = STARPU_SPECIFIC_NODE_LOCAL;
+	reconstruct_fft.nodes[2] = STARPU_SPECIFIC_NODE_LOCAL;
+	reconstruct_fft.nodes[3] = STARPU_SPECIFIC_NODE_LOCAL;
+	reconstruct_fft.nodes[4] = STARPU_SPECIFIC_NODE_LOCAL;
+	reconstruct_fft.nodes[5] = STARPU_SPECIFIC_NODE_CPU;
+	reconstruct_fft.name = "codelet_reconstruct_fft";
+	static struct starpu_perfmodel reconstruct_fft_model = create_common_perfmodel("reconstruct_fft_model");
+	reconstruct_fft_model.size_base = reconstruct_fft_size_base;
+	reconstruct_fft.model = &reconstruct_fft_model;
+	// cl_arg: ReconstructFftArgs
+
+	// Redux volume & weights
+	// Init volume
+	redux_init_volume.where = STARPU_CPU | STARPU_CUDA;
+	redux_init_volume.cpu_funcs[0] = func_redux_init_volume_cpu;
+	redux_init_volume.cpu_funcs_name[0] = "func_redux_init_volume_cpu";
+	redux_init_volume.cuda_funcs[0] = func_redux_init_volume_cuda;
+	redux_init_volume.cuda_flags[0] = STARPU_CUDA_ASYNC;
+	redux_init_volume.nbuffers = 1;
+	redux_init_volume.modes[0] = STARPU_W;
+	redux_init_volume.name = "redux_init_volume";
+	static struct starpu_perfmodel redux_init_volume_model = create_common_perfmodel("redux_init_volume_model");
+	redux_init_volume.model = &redux_init_volume_model;
+	// Init weight
+	redux_init_weights.where = STARPU_CPU | STARPU_CUDA;
+	redux_init_weights.cpu_funcs[0] = func_redux_init_weights_cpu;
+	redux_init_weights.cpu_funcs_name[0] = "func_redux_init_weights_cpu";
+	redux_init_weights.cuda_funcs[0] = func_redux_init_weights_cuda;
+	redux_init_weights.cuda_flags[0] = STARPU_CUDA_ASYNC;
+	redux_init_weights.nbuffers = 1;
+	redux_init_weights.modes[0] = STARPU_W;
+	redux_init_weights.name = "redux_init_weights";
+	static struct starpu_perfmodel redux_init_weights_model = create_common_perfmodel("redux_init_weights_model");
+	redux_init_weights.model = &redux_init_weights_model;
+	// Sum volume
+	redux_sum_volume.where = STARPU_CPU | STARPU_CUDA;
+	redux_sum_volume.cpu_funcs[0] = func_redux_sum_volume_cpu;
+	redux_sum_volume.cpu_funcs_name[0] = "func_redux_sum_volume_cpu";
+	redux_sum_volume.cuda_funcs[0] = func_redux_sum_volume_cuda;
+	redux_sum_volume.cuda_flags[0] = STARPU_CUDA_ASYNC;
+	redux_sum_volume.nbuffers = 2;
+	redux_sum_volume.modes[0] = STARPU_RW;
+	redux_sum_volume.modes[1] = STARPU_R;
+	redux_sum_volume.name = "redux_sum_volume";
+	static struct starpu_perfmodel redux_sum_volume_model = create_common_perfmodel("redux_sum_volume_model");
+	redux_sum_volume.model = &redux_sum_volume_model;
+	// Sum weight
+	redux_sum_weights.where = STARPU_CPU | STARPU_CUDA;
+	redux_sum_weights.cpu_funcs[0] = func_redux_sum_weights_cpu;
+	redux_sum_weights.cpu_funcs_name[0] = "func_redux_sum_weights_cpu";
+	redux_sum_weights.cuda_funcs[0] = func_redux_sum_weights_cuda;
+	redux_sum_weights.cuda_flags[0] = STARPU_CUDA_ASYNC;
+	redux_sum_weights.nbuffers = 2;
+	redux_sum_weights.modes[0] = STARPU_RW;
+	redux_sum_weights.modes[1] = STARPU_R;
+	redux_sum_weights.name = "redux_sum_weights";
+	static struct starpu_perfmodel redux_sum_weights_model = create_common_perfmodel("redux_sum_weights_model");
+	redux_sum_weights.model = &redux_sum_weights_model;
+}
+
+Codelets codelets;

--- a/src/xmipp/libraries/reconstruction_starpu/reconstruct_fourier_codelets.h
+++ b/src/xmipp/libraries/reconstruction_starpu/reconstruct_fourier_codelets.h
@@ -1,0 +1,173 @@
+/***************************************************************************
+ *
+ * Authors:     Jan Polak (456647@mail.muni.cz)
+ *
+ * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ * 02111-1307  USA
+ *
+ *  All comments concerning this program package may be sent to the
+ *  e-mail address 'xmipp@cnb.csic.es'
+ ***************************************************************************/
+
+#ifndef XMIPP_LIBRARIES_RECONSTRUCT_FOURIER_STARPU_CODELETS_H_
+#define XMIPP_LIBRARIES_RECONSTRUCT_FOURIER_STARPU_CODELETS_H_
+
+#include <vector>
+#include <cstdint>
+#include <core/metadata.h>
+#include <core/matrix2d.h>
+#include <starpu.h>
+
+/* Contains StarPU codelets and associated structures */
+
+// ============================== Used buffers ==============================
+
+/*  FFTs Buffer
+ *  ===========
+ *          float['batchSize' * ('fftSizeX' * 'fftSizeY') * 2]
+ *              but only 'noOfImages' is valid (*2 since it's complex)
+ *  Holds 'right side of the centered FFT', i.e. only unique values, with high frequencies in the corners
+ */
+
+/* Spaces Buffer
+ *      RecFourierProjectionTraverseSpace['batchSize' * 'noOfSymmetries']
+ *          but only 'noOfImages' is valid
+ * Traverse spaces for each FFT, 'describing' the FFTs/paddedImages
+ * NOTE: RecFourierProjectionTraverseSpace is a trivial POD struct from <reconstruction/reconstruct_fourier_projection_traverse_space.h>
+ */
+
+/* Image Data Buffer (only before FFTs Buffer is ready)
+ * =================
+ *      double[`batchSize` * (`paddedImageSize` * `paddedImageSize`)]
+ *          but only 'noOfImages' is valid
+ * Contains  images to be transformed into FFTs.
+ */
+
+
+/* Result Volume Buffer
+ * ====================
+ * std::complex<float>[maxVolumeIndexYZ+1][maxVolumeIndexYZ+1][maxVolumeIndexYZ+1]
+ */
+
+/* Result Weights Buffer
+ * =====================
+ * float[maxVolumeIndexYZ+1][maxVolumeIndexYZ+1][maxVolumeIndexYZ+1]
+ */
+
+/* Blob Table Squared Buffer
+ * =========================
+ * float[BLOB_TABLE_SIZE_SQRT]
+ */
+
+/** Content of a buffer, which holds information about the amount of images in other buffers, which can be variable. */
+struct LoadedImagesBuffer {
+	/** Amount of valid images in buffers.
+	 * 'noOfImages' <= 'batchSize' */
+	uint32_t noOfImages;
+};
+
+// ============================== Argument structures ==============================
+
+/** MUST NOT BE COPIED!!! */
+struct LoadProjectionArgs {
+	const uint32_t batchStart, batchEnd;
+	const MetaData& selFile;
+	const std::vector<size_t>& imageObjectIndices;
+
+	const bool useWeights;
+	const std::vector <Matrix2D<double> >& rSymmetries;
+	const uint32_t maxVolumeIndexX, maxVolumeIndexYZ;
+	const float blobRadius;
+	const bool fastLateBlobbing;
+
+	/** Size of source bitmap images. (Regardless of their actual size, they are all padded to this size) */
+	uint32_t paddedImageSize;
+	/** Dimensions of FFTs. */
+	uint32_t fftSizeX, fftSizeY;
+};
+
+struct PaddedImageToFftArgs {
+	float maxResolutionSqr;
+
+	/** Size of source bitmap images. (Regardless of their actual size, they are all padded to this size) */
+	uint32_t paddedImageSize;
+	/** Dimensions of FFTs. */
+	uint32_t fftSizeX, fftSizeY;
+};
+
+struct ReconstructFftArgs {
+	float blobRadius;
+	uint32_t maxVolIndexYZ;
+	bool fastLateBlobbing;
+	int blobOrder;
+	float blobAlpha;
+
+	/** Amount of symmetries in the image. See Spaces Buffer. */
+	uint32_t noOfSymmetries;
+	/** Dimensions of FFTs. */
+	uint32_t fftSizeX, fftSizeY;
+};
+
+// ============================== Codelets ==============================
+
+extern void func_load_projections(void* buffers[], void* cl_arg);
+
+extern void func_padded_image_to_fft_cpu(void **buffers, void *cl_arg);
+extern void func_padded_image_to_fft_cuda(void **buffers, void *cl_arg);
+
+/** Copy constants used for calculation to GPU memory. Blocking operation. */
+void reconstruct_cuda_initialize_constants(
+		int maxVolIndexX, int maxVolIndexYZ,
+		float blobRadius, float blobAlpha,
+		float iDeltaSqrt, float iw0, float oneOverBessiOrderAlpha);
+extern void func_reconstruct_cuda(void* buffers[], void* cl_arg);
+
+extern void func_reconstruct_cpu_lookup_interpolation(void* buffers[], void* cl_arg);
+extern void func_reconstruct_cpu_dynamic_interpolation(void* buffers[], void* cl_arg);
+
+
+extern void func_redux_sum_volume_cuda(void* buffers[], void* cl_arg);
+extern void func_redux_init_volume_cuda(void* buffers[], void* cl_arg);
+extern void func_redux_sum_weights_cuda(void* buffers[], void* cl_arg);
+extern void func_redux_init_weights_cuda(void* buffers[], void* cl_arg);
+
+extern void func_redux_sum_volume_cpu(void* buffers[], void* cl_arg);
+extern void func_redux_init_volume_cpu(void* buffers[], void* cl_arg);
+extern void func_redux_sum_weights_cpu(void* buffers[], void* cl_arg);
+extern void func_redux_init_weights_cpu(void* buffers[], void* cl_arg);
+
+struct Codelets {
+
+	/** Initial data loading. Loads data for a single batch. */
+	starpu_codelet load_projections{0};
+	/** Crops and shifts loaded and fourier-transformed images. */
+	starpu_codelet padded_image_to_fft{0};
+	/** Reconstructs FFTs into volume field. */
+	starpu_codelet reconstruct_fft{0};
+
+	/** Redux-init for reconstruct_fft volume and weights */
+	starpu_codelet redux_init_volume{0}, redux_init_weights{0};
+	/** Redux for reconstruct_fft volume and weights (sum) */
+	starpu_codelet redux_sum_volume{0}, redux_sum_weights{0};
+
+	/** Initializes the codelets. */
+	Codelets();
+};
+
+extern Codelets codelets;
+
+#endif //XMIPP_LIBRARIES_RECONSTRUCT_FOURIER_STARPU_CODELETS_H_

--- a/src/xmipp/libraries/reconstruction_starpu/reconstruct_fourier_defines.h
+++ b/src/xmipp/libraries/reconstruction_starpu/reconstruct_fourier_defines.h
@@ -1,0 +1,64 @@
+/***************************************************************************
+ *
+ * Authors:     David Strelak (davidstrelak@gmail.com)
+ *
+ * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ * 02111-1307  USA
+ *
+ *  All comments concerning this program package may be sent to the
+ *  e-mail address 'xmipp@cnb.csic.es'
+ ***************************************************************************/
+
+#ifndef XMIPP_LIBRARIES_DATA_RECONSTRUCT_FOURIER_DEFINES_H_
+#define XMIPP_LIBRARIES_DATA_RECONSTRUCT_FOURIER_DEFINES_H_
+
+#define BLOB_TABLE_SIZE_SQRT 10000
+#define ACCURACY 0.001
+
+#define PASCAL
+
+#ifdef KEPLER
+// GPU specific
+#define BLOCK_DIM 16
+#define SHARED_BLOB_TABLE 0
+#define SHARED_IMG 0
+#define PRECOMPUTE_BLOB_VAL 0
+#define TILE 8
+#define GRID_DIM_Z 1
+#endif
+
+#ifdef MAXWELL
+// GPU specific
+#define BLOCK_DIM 8
+#define SHARED_BLOB_TABLE 0
+#define SHARED_IMG 0
+#define PRECOMPUTE_BLOB_VAL 1
+#define TILE 4
+#define GRID_DIM_Z 8
+#endif
+
+#ifdef PASCAL
+// GPU specific
+#define BLOCK_DIM 16
+#define SHARED_BLOB_TABLE 1
+#define SHARED_IMG 0
+#define PRECOMPUTE_BLOB_VAL 1
+#define TILE 2
+#define GRID_DIM_Z 1
+#endif
+
+#endif /* XMIPP_LIBRARIES_DATA_RECONSTRUCT_FOURIER_DEFINES_H_ */

--- a/src/xmipp/libraries/reconstruction_starpu/reconstruct_fourier_scheduler.cpp
+++ b/src/xmipp/libraries/reconstruction_starpu/reconstruct_fourier_scheduler.cpp
@@ -1,0 +1,586 @@
+/***************************************************************************
+ *
+ * Authors:    Jan Polák (456647@mail.muni.cz)
+ *
+ * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ * 02111-1307  USA
+ *
+ *  All comments concerning this program package may be sent to the
+ *  e-mail address 'xmipp@cnb.csic.es'
+ ***************************************************************************/
+
+#include "reconstruct_fourier_scheduler.h"
+#include "reconstruct_fourier_codelets.h"
+#include <starpu.h>
+#include <cassert>
+#include <cstdio>
+#include <cinttypes>
+#include <atomic>
+#include <algorithm>
+
+#if RFS_LOGGING
+// FOR DEBUGING (pid_t x = syscall(__NR_gettid);)
+#include <sys/types.h>
+#include <sys/syscall.h>
+#define RFS_LOG(message, ...) do{\
+	FILE* file = ((rfs_data*)starpu_sched_ctx_get_policy_data(sched_ctx_id))->log;\
+    fprintf(file, "[%s : %zu : %d] " message "\n", __FUNCTION__, (size_t) syscall(SYS_gettid), sched_ctx_id, ##__VA_ARGS__);\
+    fflush(file);\
+    } while(0)
+#else
+#define RFS_LOG(message, ...) ((void)(message))
+#endif
+
+void task_data::recompute_metrics(const std::bitset<STARPU_NMAXWORKERS> &available_workers, unsigned sched_ctx_id) {
+	for (int workerid = 0; workerid < STARPU_NMAXWORKERS; ++workerid) {
+		best_implementation_by_worker[workerid] = -1;
+		best_implementation_time_by_worker[workerid] = MAX_TIME;
+
+		if (!available_workers[workerid]) {
+			continue;
+		}
+
+		unsigned mask;
+		if (!starpu_worker_can_execute_task_impl(workerid, task, &mask)) {
+			continue;
+		}
+
+		unsigned pickedImpl = 0;
+		uint64_t pickedImplTime = std::numeric_limits<uint64_t>::max();
+		const auto perfArchetype = starpu_worker_get_perf_archtype(workerid, sched_ctx_id);
+
+		for (unsigned impl = 0; impl < sizeof(unsigned) && mask != 0; ++impl) {
+			unsigned bit = 1u << impl;
+			if (mask & bit) {
+				mask &= ~bit;
+
+				uint64_t implTime = sanitize_time(starpu_task_expected_data_transfer_time_for(task, workerid))
+						+ sanitize_time(starpu_task_expected_length(task, perfArchetype, impl));
+
+				if (implTime < pickedImplTime) {
+					pickedImpl = impl;
+					pickedImplTime = implTime;
+				}
+			}
+		}
+
+		best_implementation_by_worker[workerid] = pickedImpl;
+		best_implementation_time_by_worker[workerid] = pickedImplTime;
+	}
+}
+
+int task_data::find_best_worker(const std::bitset<STARPU_NMAXWORKERS> &available_workers) {
+	int pickedWorkerIds[STARPU_NMAXWORKERS];
+	unsigned pickedWorkerIdsCount = 0;
+	double pickedWorkerIdFinishTime = INFINITY;
+
+	for (int workerId = 0; workerId < STARPU_NMAXWORKERS; ++workerId) {
+		if (!available_workers[workerId] || best_implementation_by_worker[workerId] == -1) {
+			continue;
+		}
+
+		double finishTime = best_implementation_time_by_worker[workerId];
+		if (finishTime < pickedWorkerIdFinishTime) {
+			pickedWorkerIds[0] = workerId;
+			pickedWorkerIdsCount = 1;
+			pickedWorkerIdFinishTime = finishTime;
+		} else if (finishTime == pickedWorkerIdFinishTime) {
+			pickedWorkerIds[pickedWorkerIdsCount++] = workerId;
+		}
+	}
+
+	assert(pickedWorkerIdsCount > 0 && "No worker to schedule task to");
+
+	// It is not very important what this value is, it just should be somewhat unique for each run, so that most tasks
+	// are uniformly distributed across available workers.
+	static std::atomic<unsigned> roundRobinNext { 0 };
+	unsigned pickedWorkerIndex = roundRobinNext++ % pickedWorkerIdsCount;
+
+	return pickedWorkerIds[pickedWorkerIndex];
+}
+
+static void rfs_init_sched(unsigned sched_ctx_id) {
+	auto* data = new rfs_data;
+	assert(data);
+#if RFS_LOGGING
+	data->log = fopen("rec_fou_scheduler.log", "wa");
+	assert(data->log);
+#endif
+	starpu_sched_ctx_set_policy_data(sched_ctx_id, data);
+
+	data->timing.load("rfs_timings.txt");
+
+	RFS_LOG("");
+}
+
+static void rfs_deinit_sched(unsigned sched_ctx_id) {
+	RFS_LOG("");
+
+	auto* data = (rfs_data*)starpu_sched_ctx_get_policy_data(sched_ctx_id);
+	assert(data);
+#if RFS_LOGGING
+	fclose(data->log);
+#endif
+
+	data->timing.save("rfs_timings.txt");
+
+	delete data;
+	starpu_sched_ctx_set_policy_data(sched_ctx_id, nullptr);
+}
+
+static void rfs_add_workers(unsigned sched_ctx_id, int *workerids, unsigned nworkers) {
+	auto* data = (rfs_data*)starpu_sched_ctx_get_policy_data(sched_ctx_id);
+
+	for (unsigned i = 0; i < nworkers; ++i) {
+		const int worker = workerids[i];
+		if (starpu_worker_is_combined_worker(worker)) {
+			continue;// Just in case
+		}
+		data->workers_mask.set(worker);
+		data->workers[worker].deviceKey = timing_device_key(starpu_worker_get_type(worker), starpu_worker_get_devid(worker));
+		data->workers[worker].busy = true;
+		RFS_LOG("%d", worker);
+	}
+
+	// Recreate next-worker cycles
+	for (int worker = 0; worker < STARPU_NMAXWORKERS; ++worker) {
+		if (!data->workers_mask[worker])
+			continue;
+
+		// (reset captains for next step)
+		data->workers[worker].combinedWorkerCaptain = -1;
+
+		data->workers[worker].nextSimilarWorker = worker;
+		for (int nextWorkerOffset = 1; nextWorkerOffset < STARPU_NMAXWORKERS; ++nextWorkerOffset) {
+			int nextWorker = (worker + nextWorkerOffset) % STARPU_NMAXWORKERS;
+			if (!data->workers_mask[nextWorker] || data->workers[worker].deviceKey != data->workers[nextWorker].deviceKey)
+				continue;
+			data->workers[worker].nextSimilarWorker = nextWorker;
+			break;
+		}
+	}
+
+	// Find combined workers
+	const unsigned workerCount = starpu_worker_get_count();
+	const unsigned combinedWorkerCount = starpu_combined_worker_get_count();
+	for (int combinedWorker = (int) workerCount; combinedWorker < workerCount + combinedWorkerCount; ++combinedWorker) {
+		int size = 0;
+		int* workers = nullptr;
+		starpu_combined_worker_get_description(combinedWorker, &size, &workers);
+		if (size <= 1) {
+			continue;
+		}
+
+		bool valid = true;
+		starpu_worker_archtype combinedType = starpu_worker_get_type(workers[0]);
+		for (int i = 0; i < size; ++i) {
+			if (!data->workers_mask[workers[i]]) {
+				valid = false;
+				break;
+			}
+			auto type = starpu_worker_get_type(workers[i]);
+			if (type != combinedType) {
+				RFS_LOG("Mixed type worker not supported %d", combinedWorker);
+				valid = false;
+				break;
+			}
+		}
+
+		if (!valid) {
+			continue;
+		}
+
+		// We can use this combined worker!
+		bool used = false;
+		for (int i = 0; i < size; ++i) {
+			auto& wData = data->workers[workers[i]];
+			if (wData.combinedWorkerCaptain == -1) {
+				wData.combinedWorkerCaptain = combinedWorker;
+				used = true;
+				break;
+			}
+		}
+
+		if (!used) {
+			RFS_LOG("Can't use combined worker %d, no available captain", combinedWorker);
+			continue;
+		}
+
+		RFS_LOG("Registered combined worker %d (%d workers)", combinedWorker, size);
+	}
+}
+
+static void rfs_remove_workers(unsigned sched_ctx_id, int *workerids, unsigned nworkers) {
+	auto* data = (rfs_data*)starpu_sched_ctx_get_policy_data(sched_ctx_id);
+
+	for (unsigned i = 0; i < nworkers; ++i) {
+		const int worker = workerids[i];
+		data->workers_mask.reset(worker);
+		RFS_LOG("%d (load error: %" PRIu64 ")", worker, data->workers[worker].queued_load);
+	}
+}
+
+/** The amount of tasks in a queue which are to be prefetched for the worker.
+ * Prefetch happens when adding to a queue or when removing from a queue.
+ * Stealing workers should aim to steal those tasks, which are not prefetched. */
+static const int PREFETCH_TASK_COUNT = 2;
+
+static int rfs_push_task(starpu_task * task) {
+	const unsigned sched_ctx_id = task->sched_ctx;
+	//RFS_LOG("%s (%s)", task->name, task->cl->name);
+
+	auto* data = (rfs_data*)starpu_sched_ctx_get_policy_data(sched_ctx_id);
+
+	task_data taskData(task);
+	taskData.recompute_metrics(data->workers_mask, sched_ctx_id);
+
+	// Find best worker
+	int pickedWorkerId = taskData.find_best_worker(data->workers_mask);
+
+	starpu_task_set_implementation(task, taskData.best_implementation_by_worker[pickedWorkerId]);
+
+	starpu_worker_lock(pickedWorkerId);
+	worker_data& pickedWorkerData = data->workers[pickedWorkerId];
+
+	pickedWorkerData.workerMutex.lock();
+	pickedWorkerData.queue.addLast(taskData);
+	auto queuedTaskCount = pickedWorkerData.queue.getSize();
+	pickedWorkerData.queued_load += taskData.best_implementation_time_by_worker[pickedWorkerId];
+#if RFS_LOGGING
+	assert(pickedWorkerData.isQueuedLoadCorrect(pickedWorkerId));
+#endif
+	uint64_t finishTime = pickedWorkerData.current_load + pickedWorkerData.queued_load;
+	pickedWorkerData.workerMutex.unlock();
+
+	starpu_push_task_end(task);
+	if (queuedTaskCount <= PREFETCH_TASK_COUNT) {
+		starpu_idle_prefetch_task_input_for(task, pickedWorkerId);
+	}
+	starpu_wake_worker_locked(pickedWorkerId);
+	starpu_worker_unlock(pickedWorkerId);
+
+
+	RFS_LOG("Scheduled onto %d (%" PRIu64 " us)", pickedWorkerId, finishTime);
+	return 0;
+}
+
+static void rfs_push_task_notify(STARPU_ATTRIBUTE_UNUSED starpu_task * task, int workerid, STARPU_ATTRIBUTE_UNUSED int perf_workerid, unsigned sched_ctx_id) {
+	//RFS_LOG("%s (%s) %d %d", task->name, task->cl->name, workerid, perf_workerid);
+	auto* data = (rfs_data*)starpu_sched_ctx_get_policy_data(sched_ctx_id);
+	data->workers[workerid].busy = true;
+}
+
+static starpu_task* steal_single_parallel_job(unsigned thiefWorkerId, unsigned combinedWorkerThiefId, unsigned thiefWorkerGroupSize,
+                                              unsigned victimWorkerId, worker_data &victimWorkerData,
+                                              uint32_t &workerJobLength) {
+	uint64_t& victimWorkerLoad = victimWorkerData.queued_load;
+	starpu_task* stolenTask = nullptr;
+	rfs::removeMatching(victimWorkerData.queue, [thiefWorkerId, combinedWorkerThiefId, thiefWorkerGroupSize, victimWorkerId, &victimWorkerLoad, &stolenTask, &workerJobLength](task_data& task){
+		if (task.task->cl == nullptr) {
+			// Synchronization task, better not
+			return rfs::RemoveResult::KeepContinue;
+		}
+
+		if (task.best_implementation_by_worker[thiefWorkerId] == -1) {
+			// Can't run this, can't steal
+			return rfs::RemoveResult::KeepContinue;
+		}
+
+		if (task.task->cl->type == starpu_codelet_type::STARPU_SEQ) {
+			// We want only parallel tasks
+			return rfs::RemoveResult::KeepContinue;
+		}
+
+		if (task.task->cl->max_parallelism < thiefWorkerGroupSize) {
+			// This thief is too big for this job
+			return rfs::RemoveResult::KeepContinue;
+		}
+
+		uint32_t totalThiefLoadAfterSteal = task.best_implementation_time_by_worker[thiefWorkerId] / thiefWorkerGroupSize;
+		uint64_t totalVictimLoadAfterSteal = victimWorkerLoad - task.best_implementation_time_by_worker[victimWorkerId];
+		if (totalThiefLoadAfterSteal >= totalVictimLoadAfterSteal) {
+			// We can steal it, but it won't be helpful
+			return rfs::RemoveResult::KeepContinue;
+		}
+
+		if (!starpu_combined_worker_can_execute_task(combinedWorkerThiefId, task.task, task.best_implementation_by_worker[thiefWorkerId])) {
+			// But it turns out, that we can't run it
+			return rfs::RemoveResult::KeepContinue;
+		}
+
+		// It's payday fellas
+		workerJobLength = totalThiefLoadAfterSteal;
+		starpu_task_set_implementation(task.task, task.best_implementation_by_worker[thiefWorkerId]);
+		victimWorkerLoad = totalVictimLoadAfterSteal;
+		stolenTask = task.task;
+		return rfs::RemoveResult::RemoveBreak;
+	});
+
+	return stolenTask;
+}
+
+static unsigned steal_jobs_until_equilibrium(int thiefWorkerId, int victimWorkerId, worker_data &thiefWorkerData, worker_data &victimWorkerData) {
+	auto thiefIsCPU = starpu_worker_get_type(thiefWorkerId) == starpu_worker_archtype::STARPU_CPU_WORKER;
+	unsigned stolen = 0;
+
+	uint64_t& victimWorkerLoad = victimWorkerData.queued_load;
+	rfs::removeMatching(victimWorkerData.queue, [&thiefWorkerData, thiefWorkerId, victimWorkerId, &victimWorkerLoad, &stolen, thiefIsCPU](task_data& task){
+		if (task.best_implementation_by_worker[thiefWorkerId] == -1) {
+			// Can't steal this
+			return rfs::RemoveResult::KeepContinue;
+		}
+
+		if (thiefIsCPU && task.task->cl->type != starpu_codelet_type::STARPU_SEQ) {
+			// CPU's should not steal tasks that are parallel on CPU - not yet
+			return rfs::RemoveResult::KeepContinue;
+		}
+
+		uint64_t totalThiefLoadAfterSteal = thiefWorkerData.queued_load + task.best_implementation_time_by_worker[thiefWorkerId];
+		//assert(victimWorkerData.queued_load >= task.best_implementation_time_by_worker[victimWorkerId]);
+		uint64_t totalVictimLoadAfterSteal = victimWorkerLoad - task.best_implementation_time_by_worker[victimWorkerId];
+		if (totalThiefLoadAfterSteal >= totalVictimLoadAfterSteal) {
+			// We can steal it, but it won't be helpful
+			return rfs::RemoveResult::KeepContinue;
+		}
+
+		// It's payday fellas
+		starpu_task_set_implementation(task.task, task.best_implementation_by_worker[thiefWorkerId]);
+		thiefWorkerData.queue.addLast(task);
+		thiefWorkerData.queued_load = totalThiefLoadAfterSteal;
+		victimWorkerLoad = totalVictimLoadAfterSteal;
+		stolen++;
+
+		return rfs::RemoveResult::RemoveContinue;
+	});
+
+#if RFS_LOGGING
+	assert(thiefWorkerData.isQueuedLoadCorrect(thiefWorkerId));
+	assert(victimWorkerData.isQueuedLoadCorrect(victimWorkerId));
+#endif
+
+#if RFS_LOGGING
+	if (stolen > 0)
+		fprintf(stderr, "%d steals from %d: %d tasks\n", thiefWorkerId, victimWorkerId, stolen);
+#endif
+
+	return stolen;
+}
+
+static starpu_task * rfs_pop_task(unsigned sched_ctx_id) {
+	auto* data = (rfs_data*)starpu_sched_ctx_get_policy_data(sched_ctx_id);
+	int workerId = starpu_worker_get_id_check();
+	assert(!starpu_worker_is_combined_worker(workerId));
+
+	auto& ourWorkerData = data->workers[workerId];
+	std::lock_guard<std::mutex> lock(ourWorkerData.workerMutex);
+
+	ourWorkerData.current_load = 0;
+
+	if (ourWorkerData.queue.empty()) {
+		assert(ourWorkerData.queued_load == 0);
+		// Fill up the queue first
+
+		// Tracking which workers were already tried to not bother them again.
+		// Considering all workers that are not present as already checked, to simplify logic down the line.
+		std::bitset<STARPU_NMAXWORKERS> checked = ~data->workers_mask;
+		checked[workerId] = true; // Don't check self
+
+		// 1. Steal from similar workers
+
+		int nextSimilarWorkerId = ourWorkerData.nextSimilarWorker;
+		while (nextSimilarWorkerId != workerId /* this is cyclic */) {
+			auto& nextSimilarWorkerData = data->workers[nextSimilarWorkerId];
+
+			// Only try_lock instead of hard lock to prevent deadlocks
+			if (nextSimilarWorkerData.workerMutex.try_lock()) {
+				checked[nextSimilarWorkerId] = true;
+				steal_jobs_until_equilibrium(workerId, nextSimilarWorkerId, ourWorkerData, nextSimilarWorkerData);
+				nextSimilarWorkerData.workerMutex.unlock();
+			}
+
+			if (!ourWorkerData.queue.empty()) {
+				goto stealingDone;
+			}
+
+			nextSimilarWorkerId = nextSimilarWorkerData.nextSimilarWorker;
+		}
+
+		// 2. Steal from all workers
+
+		// Using own id as offset to distribute stealing in a round robin fashion
+		for (int stealI = 0; stealI < STARPU_NMAXWORKERS; ++stealI) {
+			const int victimWorker = (workerId + stealI) % STARPU_NMAXWORKERS;
+			if (checked[victimWorker]) {
+				continue;
+			}
+
+			auto &victimWorkerData = data->workers[victimWorker];
+			if (victimWorkerData.workerMutex.try_lock()) {
+				steal_jobs_until_equilibrium(workerId, victimWorker, ourWorkerData, victimWorkerData);
+				victimWorkerData.workerMutex.unlock();
+
+				if (!ourWorkerData.queue.empty()) {
+					goto stealingDone;
+				}
+			} // else: Lock failed, worker busy, spare them
+		}
+
+		// 3. If combined worker captain and no sub-workers are busy, try to steal something combined.
+		if (ourWorkerData.combinedWorkerCaptain >= 0) {
+			// We are a captain! See if companions are free to do some work.
+			int combinedWorkerThiefId = ourWorkerData.combinedWorkerCaptain;
+			int groupSize = 0;
+			int* groupMembers = nullptr;
+			starpu_combined_worker_get_description(combinedWorkerThiefId, &groupSize, &groupMembers);
+
+			bool allFree = true;
+			for (int i = 0; i < groupSize; ++i) {
+				if (groupMembers[i] != workerId && data->workers[groupMembers[i]].busy) {
+					allFree = false;
+					break;
+				}
+			}
+
+			if (allFree) {
+				// There is a real chance of a parallel race, but lets not think about that for now.
+
+				// Pick a task to steal!
+				uint32_t stolenJobPerWorkerLength = 0;
+				starpu_task* stolenJob = nullptr;
+				// Same worker-checking logic as case 2
+				for (int stealI = 0; stealI < STARPU_NMAXWORKERS; ++stealI) {
+					const int victimWorker = (workerId + stealI) % STARPU_NMAXWORKERS;
+					if (checked[victimWorker]) {
+						continue;
+					}
+
+					auto &victimWorkerData = data->workers[victimWorker];
+					if (victimWorkerData.workerMutex.try_lock()) {
+						stolenJob = steal_single_parallel_job(workerId, combinedWorkerThiefId, groupSize, victimWorker, victimWorkerData,
+						                                      stolenJobPerWorkerLength);
+						victimWorkerData.workerMutex.unlock();
+
+						break;
+					} // else: Lock failed, worker busy, spare them
+				}
+
+				if (stolenJob != nullptr) {
+					// Got something, use it!
+					starpu_parallel_task_barrier_init(stolenJob, combinedWorkerThiefId);
+
+					for (int i = 0; i < groupSize; i++) {
+						const int groupMember = groupMembers[i];
+						data->workers[groupMember].busy = true;
+						// Not setting current_load in case of race condition, in which case it would be wrong.
+						// But not setting it up is probably not a big deal.
+
+						if (groupMember == workerId) {
+							continue;
+						}
+
+						struct starpu_task *alias = starpu_task_dup(stolenJob);
+						alias->destroy = 1;
+						starpu_push_local_task(groupMembers[i], alias, 1 /* take this first */);
+					}
+
+					// Not sure wtf, but both StarPU parallel schedulers do it
+					struct starpu_task *masterAlias = starpu_task_dup(stolenJob);
+					masterAlias->destroy = 1;
+
+					ourWorkerData.current_load = stolenJobPerWorkerLength;
+					fprintf(stderr, "Stolen %s and distributed it over %d workers\n", stolenJob->cl->name, groupSize);
+					return masterAlias;
+				}
+			}
+		}
+	}
+
+	stealingDone:
+
+	if (ourWorkerData.queue.empty()) {
+		// And we still didn't find anything
+		data->workers[workerId].busy = false;
+		return nullptr;
+	}
+
+	// Normal operation, taking tasks from own queue
+	auto& taskData = ourWorkerData.queue.first();
+	starpu_task* task = taskData.task;
+	auto taskTime = taskData.best_implementation_time_by_worker[workerId];
+	ourWorkerData.queued_load -= taskTime;
+	ourWorkerData.current_load = taskTime;
+	ourWorkerData.queue.removeFirst();
+
+	// Prefetch more
+	for (int t = 0; t < PREFETCH_TASK_COUNT && t < ourWorkerData.queue.getSize(); ++t) {
+		starpu_idle_prefetch_task_input_for(ourWorkerData.queue[t].task, workerId);
+	}
+
+#if RFS_LOGGING
+	assert(ourWorkerData.isQueuedLoadCorrect(workerId));
+#endif
+	data->workers[workerId].busy = true;
+	return task;
+}
+
+static void rfs_pre_exec_hook(starpu_task * task, unsigned sched_ctx_id) {
+	//RFS_LOG("%s (%s)", task->name, task->cl->name);
+	if (!task->cl) {
+		return;
+	}
+
+	auto* data = (rfs_data*)starpu_sched_ctx_get_policy_data(sched_ctx_id);
+	data->workers[starpu_worker_get_id_check()].execStartTimeUs = starpu_timing_now();
+}
+
+static void rfs_post_exec_hook(starpu_task * task, unsigned sched_ctx_id) {
+	//RFS_LOG("%s (%s)", task->name, task->cl->name);
+	if (!task->cl) {
+		return;
+	}
+
+	auto* data = (rfs_data*)starpu_sched_ctx_get_policy_data(sched_ctx_id);
+	auto workerId = starpu_worker_get_id_check();
+	auto& workerData = data->workers[workerId];
+
+	// Measure task time
+	double timeElapsed = starpu_timing_now() - workerData.execStartTimeUs;
+	unsigned impl = starpu_task_get_implementation(task);
+
+	size_t size = 0;
+	if (task->cl->model && task->cl->model->size_base) {
+		size = task->cl->model->size_base(task, impl);
+	}
+
+	data->timing.record(task->cl, impl, starpu_worker_get_type(workerId), starpu_worker_get_devid(workerId), size, timeElapsed);
+}
+
+Schedulers::Schedulers() noexcept : reconstruct_fourier{} {
+	reconstruct_fourier.init_sched = rfs_init_sched;
+	reconstruct_fourier.deinit_sched = rfs_deinit_sched;
+	reconstruct_fourier.push_task = rfs_push_task;
+	reconstruct_fourier.push_task_notify = rfs_push_task_notify;
+	reconstruct_fourier.pop_task = rfs_pop_task;
+	reconstruct_fourier.pre_exec_hook = rfs_pre_exec_hook;
+	reconstruct_fourier.post_exec_hook = rfs_post_exec_hook;
+	reconstruct_fourier.add_workers = rfs_add_workers;
+	reconstruct_fourier.remove_workers = rfs_remove_workers;
+	reconstruct_fourier.policy_name = "reconstruct_fourier";
+	reconstruct_fourier.policy_description = "Specialized scheduler for Fourier reconstruction";
+}
+
+Schedulers schedulers;

--- a/src/xmipp/libraries/reconstruction_starpu/reconstruct_fourier_scheduler.h
+++ b/src/xmipp/libraries/reconstruction_starpu/reconstruct_fourier_scheduler.h
@@ -1,0 +1,132 @@
+/***************************************************************************
+ *
+ * Authors:    Jan Polák (456647@mail.muni.cz)
+ *
+ * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ * 02111-1307  USA
+ *
+ *  All comments concerning this program package may be sent to the
+ *  e-mail address 'xmipp@cnb.csic.es'
+ ***************************************************************************/
+
+#ifndef XMIPP_RECONSTRUCT_FOURIER_SCHEDULER_H
+#define XMIPP_RECONSTRUCT_FOURIER_SCHEDULER_H
+
+#include <starpu.h>
+#include <bitset>
+#include <deque>
+#include <mutex>
+#include <atomic>
+
+#include "reconstruct_fourier_timing.h"
+#include "util/queue_bag.h"
+
+#ifndef STARPU_NMAXWORKERS
+// FOR EDITING ONLY (should not be needed when compiling)
+#define STARPU_NMAXWORKERS 10
+#endif
+
+#define RFS_LOGGING 1
+
+struct Schedulers {
+
+	/** Specialized scheduler for fourier reconstruction. */
+	starpu_sched_policy reconstruct_fourier;
+
+	/** Initializes the schedulers. */
+	Schedulers() noexcept;
+};
+
+extern Schedulers schedulers;
+
+struct task_data {
+	/** The task this relates to. */
+	starpu_task* task;
+
+	/** Which implementation is best for given worker. -1 if no such implementation. */
+	int8_t best_implementation_by_worker[STARPU_NMAXWORKERS] = {};
+	/** Time it will take to execute this task on this worker given the best implementation. */
+	uint32_t best_implementation_time_by_worker[STARPU_NMAXWORKERS] = {};
+
+	explicit task_data(starpu_task * task):task(task) {}
+
+	void recompute_metrics(const std::bitset<STARPU_NMAXWORKERS>& available_workers, unsigned sched_ctx_id);
+
+	int find_best_worker(const std::bitset<STARPU_NMAXWORKERS>& available_workers);
+};
+
+struct worker_data {
+
+	/** Timing device key, used for finding out nextSimilarWorker */
+	timing_device_key deviceKey;
+
+	/** Index of the next worker, with the same deviceKey. May be own deviceId -> following these should be cyclic.
+	 * Used for queue sharing (basically a lightweight version of stealing). */
+	int nextSimilarWorker;
+
+	/** If this worker is a captain of a combined worker, this is an worker id fo that combined worker. */
+	int combinedWorkerCaptain = -1;
+
+	/** Flag checking whether the worker is available for any combined worker fun. */
+	std::atomic_bool busy;
+
+	/** Lock this before manipulating queued_load or queue */
+	std::mutex workerMutex;
+
+	/** Amount of time in queue. */
+	uint64_t queued_load = 0;
+
+	/** Queue of tasks to be completed by this worker */
+	rfs::queue_bag<task_data> queue;
+
+	// Following fields may be modified only by the worker itself!
+	/** Load of the task that is being evaluated right now. */
+	uint32_t current_load = 0;
+	/** When did the task execution start. For custom time measurements, because StarPU won't expose this info to us. */
+	double execStartTimeUs = 0;
+
+	bool isQueuedLoadCorrect(unsigned workerId) {
+		uint64_t load = 0;
+		rfs::forEach(queue, [&load, workerId](const task_data& task) {
+			uint64_t loadBefore = load;
+			load += task.best_implementation_time_by_worker[workerId];
+			assert(loadBefore < load);
+			return true;
+		});
+		if (load != queued_load) {
+			fprintf(stderr, "Expected load %llu, got %llu\n", (unsigned long long) queued_load,
+			        (unsigned long long) load);
+			return false;
+		}
+		return true;
+	}
+};
+
+struct rfs_data {
+
+	/** Information about which workers are enabled. */
+	std::bitset<STARPU_NMAXWORKERS> workers_mask;
+	worker_data workers[STARPU_NMAXWORKERS];
+
+	timing timing;
+
+#if RFS_LOGGING
+	FILE* log = nullptr;
+#endif
+};
+
+#endif //XMIPP_RECONSTRUCT_FOURIER_SCHEDULER_H

--- a/src/xmipp/libraries/reconstruction_starpu/reconstruct_fourier_starpu.cpp
+++ b/src/xmipp/libraries/reconstruction_starpu/reconstruct_fourier_starpu.cpp
@@ -1,0 +1,622 @@
+/***************************************************************************
+ *
+ * Authors:     Jan Polak (456647@mail.muni.cz)
+ *              Roberto Marabini (roberto@cnb.csic.es)
+ *              Carlos Oscar S. Sorzano (coss@cnb.csic.es)
+ *              Jose Roman Bilbao-Castro (jrbcast@ace.ual.es)
+ *              Vahid Abrishami (vabrishami@cnb.csic.es)
+ *              David Strelak (davidstrelak@gmail.com)
+ *
+ * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ * 02111-1307  USA
+ *
+ *  All comments concerning this program package may be sent to the
+ *  e-mail address 'xmipp@cnb.csic.es'
+ ***************************************************************************/
+
+#include <cstdint>
+#include <iostream>
+#include <limits>
+#include <sys/time.h>
+
+#include <core/args.h>
+#include <data/array_2D.h>
+#include <core/metadata.h>
+#include <data/projection.h>
+#include <data/symmetries.h>
+#include <core/xmipp_fftw.h>
+#include <core/xmipp_funcs.h>
+#include <core/xmipp_image.h>
+#include <core/xmipp_threads.h>
+
+#include "reconstruct_fourier_starpu.h"
+
+#include <starpu.h>
+
+#include "reconstruct_fourier_codelets.h"
+#include "reconstruct_fourier_scheduler.h"
+#include "reconstruct_fourier_util.h"
+#include "reconstruct_fourier_starpu_util.h"
+
+const int DEBUG_SYNCHRONOUS_TASKS = 0;
+
+// Define params
+void ProgRecFourierStarPU::defineParams() {
+	//usage
+	addUsageLine("Generate 3D reconstructions from projections using direct Fourier interpolation with arbitrary geometry.");
+	addUsageLine("Kaisser-windows are used for interpolation in Fourier space.");
+	//params
+	addParamsLine("   -i <md_file>                  : Metadata file with input projections");
+	addParamsLine("  [-o <volume_file=\"rec_fourier.vol\">] : Filename for output volume");
+	addParamsLine("  [--sym <symfile=c1>]           : Enforce symmetry in projections");
+	addParamsLine("  [--padding <proj=2.0> <vol=2.0>] : Padding used for projections and volume");
+	addParamsLine("  [--max_resolution <p=0.5>]     : Max resolution (Nyquist=0.5)");
+	addParamsLine("  [--weight]                     : Use weights stored in the image metadata");
+	addParamsLine("  [--blob <radius=1.9> <order=0> <alpha=15>] : Blob parameters");
+	addParamsLine("                                 : radius in pixels, order of Bessel function in blob and parameter alpha");
+	addParamsLine("  [--fast]                       : Do the blobbing at the end of the computation.");
+	addParamsLine("                                 : Gives slightly different results, but is faster.");
+	addParamsLine("  [--batchSize <size=25>]        : Amount of images in single batch. Too many won't fit in memory and will not be able to run as fast, too few will have large overhead.");
+	addParamsLine("                                 : Each additional image in batch will require at least imageSide^2 * 32 bytes, e.g.");
+	addParamsLine("                                 : cca 52MB per batch of 25 256x256 images or 210MB for 512x512 images.");
+	addParamsLine("  [--fourierThreads <num=0>]     : Number of threads used for final fourier transformation. Zero means all available.");
+	addExampleLine("For reconstruct enforcing i3 symmetry and using stored weights:", false);
+	addExampleLine("   xmipp_starpu_reconstruct_fourier  -i reconstruction.sel --sym i3 --weight");
+
+	/* Buffer sizes:
+	 *  paddedImages:
+	 *      batchSize * paddedImgSize * paddedImgSize * sizeof(float)
+	 *      batchSize * symmetryCount * sizeof(TraverseSpace)       <- Typically in order of few kB per batch
+	 *  fft:
+	 *      batchSize * fftSizeX * fftSizeY * 2 * sizeof(float)
+	 *  fftWorkSpace:
+	 *      paddedImgSize * paddedImgSize/2 * sizeof(float) * 2     <- Does not scale with batchSize
+	 */
+}
+
+// Read arguments ==========================================================
+void ProgRecFourierStarPU::readParams() {
+	fn_in = getParam("-i");
+	fn_out = getParam("-o");
+	fn_sym = getParam("--sym");
+
+	params.padding_factor_proj = getDoubleParam("--padding", 0);
+	params.padding_factor_vol = getDoubleParam("--padding", 1);
+	params.maxResolution = (float)getDoubleParam("--max_resolution");
+	params.do_weights = checkParam("--weight");
+	params.blob.radius = getDoubleParam("--blob", 0);
+	params.blob.order  = getIntParam("--blob", 1);
+	params.blob.alpha  = getDoubleParam("--blob", 2);
+	params.fastLateBlobbing = checkParam("--fast");
+
+	int batchSize = getIntParam("--batchSize");
+	params.batchSize = batchSize <= 0 ? 25 : static_cast<uint32_t>(batchSize);
+
+	{// Number of threads of final fourier transformation
+		int fourierThreads = getIntParam("--fourierThreads");
+		if (fourierThreads <= 0) {
+			fourierThreads = (int)sysconf(_SC_NPROCESSORS_ONLN); // Default to all
+		}
+		if (fourierThreads <= 0) {
+			fourierThreads = 1;
+			std::cerr << "--fourierThreads: Cannot obtain number of cores. Defaulting to one." << std::endl;
+		}
+		params.fourierTransformThreads = static_cast<uint32_t>(fourierThreads);
+	}
+}
+
+void ProgRecFourierStarPU::prepareMetaData(const FileName& fn_in, MetaData& SF) {
+	// Read the input images
+	SF.read(fn_in);
+	SF.removeDisabled();
+	SF.getDatabase()->activateThreadMuting();
+}
+
+uint32_t ProgRecFourierStarPU::computeBatchCount(const ProgRecFourierStarPU::Params &params, const MetaData &SF) {
+	return (static_cast<uint32_t>(SF.size()) + params.batchSize - 1) / params.batchSize;
+}
+
+void ProgRecFourierStarPU::prepareConstants(const Params& params, const MetaData& SF, const FileName& fn_sym, ComputeConstants& constants) {
+	// Ask for memory for the output volume and its Fourier transform
+	size_t imageSize;
+	{
+		size_t objId = SF.firstObject();
+		FileName fnImg;
+		SF.getValue(MDL_IMAGE, fnImg, objId);
+		Image<double> I;
+		I.read(fnImg, HEADER);
+
+		imageSize = I().xdim;
+		if (imageSize != I().ydim)
+			REPORT_ERROR(ERR_MULTIDIM_SIZE, "This algorithm only works for squared images");
+	}
+
+	constants.imgSize = static_cast<int>(imageSize);
+	constants.paddedImgSize = static_cast<uint32_t>(imageSize * params.padding_factor_vol);
+	{
+		uint32_t conserveRows = (uint32_t) ceil(2.0f * constants.paddedImgSize * params.maxResolution);
+		// Round up to nearest even number (i.e. divisible by 2)
+		constants.maxVolumeIndex = conserveRows + (conserveRows & 1); // second term is 1 iff conserveRows is odd, 0 otherwise
+	}
+
+	// Build a table of blob values
+	blobtype blobFourier = params.blob;
+	blobtype blobNormalized = params.blob;
+	blobFourier.radius /= params.padding_factor_vol * imageSize;
+	blobNormalized.radius /= params.padding_factor_proj / params.padding_factor_vol;
+
+	double deltaSqrt     = (params.blob.radius * params.blob.radius) / (BLOB_TABLE_SIZE_SQRT - 1);
+	double deltaFourier  = (sqrt(3.0) * imageSize / 2.0) / (BLOB_TABLE_SIZE_SQRT-1);
+	constants.iDeltaSqrt    = static_cast<float>(1 / deltaSqrt);
+	constants.iDeltaFourier = static_cast<float>(1 / deltaFourier);
+
+	// The interpolation kernel must integrate to 1
+	constants.iw0 = 1.0 / blob_Fourier_val(0.0, blobNormalized);
+	double padXdim3 = params.padding_factor_vol * imageSize;
+	padXdim3 = padXdim3 * padXdim3 * padXdim3;
+	double blobTableSize = params.blob.radius * sqrt(1.0 / (BLOB_TABLE_SIZE_SQRT-1));
+	for (int i = 0; i < BLOB_TABLE_SIZE_SQRT; i++) {
+		//use a r*r sample instead of r
+		constants.blobTableSqrt[i] = static_cast<float>(blob_val(blobTableSize*sqrt((double)i), params.blob) * constants.iw0);
+		constants.fourierBlobTable[i] = blob_Fourier_val(deltaFourier * i, blobFourier) * padXdim3 * constants.iw0;
+	}
+
+	{// Get symmetries
+		Matrix2D<double> Identity(3, 3);
+		Identity.initIdentity();
+		constants.R_symmetries.push_back(Identity);
+		if (!fn_sym.isEmpty()) {
+			SymList SL;
+			SL.readSymmetryFile(fn_sym);
+			constants.R_symmetries.reserve(constants.R_symmetries.size() + SL.symsNo());
+			for (int isym = 0; isym < SL.symsNo(); isym++) {
+				Matrix2D<double> L(4, 4), R(4, 4);
+				SL.getMatrices(isym, L, R);
+				R.resize(3, 3);
+				constants.R_symmetries.push_back(R);
+			}
+		}
+	}
+}
+
+void ProgRecFourierStarPU::setIO(const FileName &fn_in, const FileName &fn_out) {
+	this->fn_in = fn_in;
+	this->fn_out = fn_out;
+}
+
+// Show ====================================================================
+void ProgRecFourierStarPU::show() const {
+	std::cout << " =====================================================================" << std::endl;
+	std::cout << " Direct 3D reconstruction method using Kaiser windows as interpolators" << std::endl;
+	std::cout << " =====================================================================" << std::endl;
+	std::cout << " Input selfile             : "  << fn_in << std::endl;
+	std::cout << " padding_factor_proj       : "  << params.padding_factor_proj << std::endl;
+	std::cout << " padding_factor_vol        : "  << params.padding_factor_vol << std::endl;
+	std::cout << " Output volume             : "  << fn_out << std::endl;
+	if (!fn_sym.isEmpty())
+		std::cout << " Symmetry file for projections : "  << fn_sym << std::endl;
+	if (params.do_weights)
+		std::cout << " Use weights stored in the image headers or doc file" << std::endl;
+	else
+		std::cout << " Do NOT use weights" << std::endl;
+	std::cout << "\n Interpolation Function"
+	          << "\n   blrad                 : "  << params.blob.radius
+	          << "\n   blord                 : "  << params.blob.order
+	          << "\n   blalpha               : "  << params.blob.alpha
+	          << "\n max_resolution          : "  << params.maxResolution
+	          << "\n -----------------------------------------------------------------" << std::endl;
+}
+
+// Main routine ------------------------------------------------------------
+
+struct ProgRecFourierStarPU::SimpleBatchProvider : ProgRecFourierStarPU::BatchProvider {
+	const uint32_t batchCount;
+	const bool enableProgressBar;
+	uint32_t givenBatches = 0;
+	/** Tracked only if enableProgressBar == true */
+	uint32_t completedBatches = 0;
+
+	SimpleBatchProvider(const uint32_t batchCount, const bool enableProgressBar)
+			: batchCount(batchCount)
+			, enableProgressBar(enableProgressBar) {
+		if (enableProgressBar) {
+			init_progress_bar(batchCount);
+		}
+	}
+
+	uint32_t maxBatches() override {
+		return batchCount;
+	}
+
+	int32_t nextBatch() override {
+		if (givenBatches >= batchCount) {
+			return -1;
+		} else {
+			return givenBatches++;
+		}
+	}
+
+	void batchCompleted() override {
+		if (!enableProgressBar)
+			return; // Disabled
+
+		static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+		pthread_mutex_lock(&mutex);
+		progress_bar(++completedBatches);
+		pthread_mutex_unlock(&mutex);
+	}
+
+	virtual ~SimpleBatchProvider() {
+		if (enableProgressBar && completedBatches != batchCount) {
+			// To end with pretty progress bar even if we omitted some batches (which shouldn't probably happen?)
+			progress_bar(batchCount);
+		}
+	}
+};
+
+void ProgRecFourierStarPU::run() {
+	if (verbose) {
+		show();
+	}
+
+	prepareMetaData(fn_in, SF);
+	prepareConstants(params, SF, fn_sym, computeConstants);
+	initStarPU();
+
+	SimpleBatchProvider batchProvider(computeBatchCount(params, SF), (bool) verbose);
+
+	ComputeStarPUResult result = computeStarPU(params, SF, computeConstants, batchProvider, (bool) verbose);
+
+	// We won't need StarPU anymore
+	shutdownStarPU();
+
+	// TODO(jp): This step seems unnecessary (later steps would have to be rewritten to work with flat arrays) (also in MPI version)
+	// Convert flat volume and weight arrays into multidimensional arrays and destroy originals
+	std::complex<float>*** tempVolume = result.createXmippStyleVolume(computeConstants.maxVolumeIndex);
+	float*** tempWeights = result.createXmippStyleWeights(computeConstants.maxVolumeIndex);
+	result.destroy();
+
+	// Adjust and save the resulting volume
+	postProcessAndSave(params, computeConstants, fn_out, tempVolume, tempWeights);
+}
+
+void ProgRecFourierStarPU::initStarPU() {
+	// Request more workers per CUDA-capable GPU
+	setenv("STARPU_NWORKER_PER_CUDA",
+	       "2" /* seems to work best, 1 leaves GPU idle for fractions of a second (but shouldn't) */,
+	       false /* don't overwrite user specified value */);
+	// Be more reluctant to discard calibration data
+	setenv("STARPU_HISTORY_MAX_ERROR", "200" /*%*/, false);
+
+	starpu_conf starpu_configuration;
+	starpu_conf_init(&starpu_configuration);
+	starpu_configuration.sched_policy = &schedulers.reconstruct_fourier;
+	CHECK_STARPU(starpu_init(&starpu_configuration));
+
+	int cpuWorkers[STARPU_NMAXWORKERS];
+	unsigned cpuWorkerCount = starpu_worker_get_ids_by_type(starpu_worker_archtype::STARPU_CPU_WORKER, cpuWorkers, STARPU_NMAXWORKERS);
+	if (cpuWorkerCount > 1) {
+		int combinedWorker = starpu_combined_worker_assign_workerid(cpuWorkerCount, cpuWorkers);
+		starpu_sched_ctx_add_workers(&combinedWorker, 1, 0);
+
+		schedulers.reconstruct_fourier.add_workers(0, nullptr, 0);// Just force a refresh, not a very clean solution
+	}
+
+	starpu_malloc_set_align(ALIGNMENT);
+}
+
+ProgRecFourierStarPU::ComputeStarPUResult ProgRecFourierStarPU::computeStarPU(
+		const Params& params, const MetaData& SF, const ComputeConstants& computeConstants, BatchProvider& batches,
+		bool verbose) {
+
+	uint32_t maxVolumeIndex = computeConstants.maxVolumeIndex;
+	uint32_t paddedImgSize = computeConstants.paddedImgSize;
+
+	// Initialize GPU
+	reconstruct_cuda_initialize_constants(maxVolumeIndex, maxVolumeIndex,
+	                                      static_cast<float>(params.blob.radius),
+	                                      static_cast<float>(params.blob.alpha),
+	                                      computeConstants.iDeltaSqrt, static_cast<float>(computeConstants.iw0),
+	                                      1.f / getBessiOrderAlpha(params.blob));
+
+	std::vector<size_t> selFileObjectIds;
+	SF.findObjects(selFileObjectIds);
+	const uint32_t fftSizeX = maxVolumeIndex / 2;
+	const uint32_t fftSizeY = maxVolumeIndex;
+
+	PaddedImageToFftArgs imageToFftArg = {
+			params.maxResolution * params.maxResolution,
+			paddedImgSize,
+			fftSizeX, fftSizeY
+	};
+
+	ReconstructFftArgs reconstructFftArg = {
+			static_cast<float>(params.blob.radius),
+			maxVolumeIndex,
+			params.fastLateBlobbing,
+			params.blob.order,
+			static_cast<float>(params.blob.alpha),
+			static_cast<uint32_t>(computeConstants.R_symmetries.size()),
+			fftSizeX, fftSizeY
+	};
+
+	starpu_data_handle_t resultVolumeHandle = {0};
+	starpu_data_handle_t resultWeightsHandle = {0};
+
+	ComputeStarPUResult result;
+
+	{
+		/*
+		 * Allocate 3D array (continuous) of given size^3.
+		 * Allocated array is cleared (to zero)
+		 */
+		uint32_t dim = static_cast<uint32_t>(maxVolumeIndex + 1);
+		uint32_t dim3 = align(dim * dim * dim, 4); // Make the array size always a multiple of 4, for faster redux operations
+		size_t volumeDataSize = dim3 * sizeof(std::complex<float>);
+		size_t weightDataSize = dim3 * sizeof(float);
+		CHECK_STARPU(starpu_malloc((void **) &result.volumeData, volumeDataSize));
+		CHECK_STARPU(starpu_malloc((void **) &result.weightsData, weightDataSize));
+		// As a final step, StarPU will redux the data created on GPU into this
+		memset(result.volumeData, 0, volumeDataSize);
+		memset(result.weightsData, 0, weightDataSize);
+
+		starpu_vector_data_register(&resultVolumeHandle, STARPU_MAIN_RAM, (uintptr_t) result.volumeData, dim3, sizeof(std::complex<float>));
+		starpu_vector_data_register(&resultWeightsHandle, STARPU_MAIN_RAM, (uintptr_t) result.weightsData, dim3, sizeof(float));
+		starpu_data_set_reduction_methods(resultVolumeHandle, &codelets.redux_sum_volume, &codelets.redux_init_volume);
+		starpu_data_set_reduction_methods(resultWeightsHandle, &codelets.redux_sum_weights, &codelets.redux_init_weights);
+		starpu_data_set_name(resultVolumeHandle, "Result Volume Data");
+		starpu_data_set_name(resultWeightsHandle, "Result Weights Data");
+	}
+
+	starpu_data_handle_t blobTableSquaredHandle = {0};
+	if (params.fastLateBlobbing) {
+		// Blob Table is not used on GPU, but we need to register empty regardless
+		starpu_variable_data_register(&blobTableSquaredHandle, -1, 0, 1);
+	} else {
+		starpu_variable_data_register(&blobTableSquaredHandle, STARPU_MAIN_RAM,
+		                              reinterpret_cast<uintptr_t>(&computeConstants.blobTableSqrt), sizeof(computeConstants.blobTableSqrt));
+	}
+	starpu_data_set_name(blobTableSquaredHandle, "Blob Table Squared");
+
+	const uint32_t totalImages = static_cast<uint32_t>(SF.size());
+	const uint32_t maxBatches = batches.maxBatches();
+
+	std::vector<LoadProjectionArgs> loadProjectionArgs;
+	// WARNING: Backing arrays of this vector must never reallocate, as we use pointers into it for codelet arguments
+	loadProjectionArgs.reserve(maxBatches);
+
+	// Used in a STARPU_SCRATCH mode, so the handle can be shared between all relevant tasks,
+	// as the all will get a different memory to work with.
+	starpu_data_handle_t fftScratchMemoryHandle = {0};
+	// As documented in http://fftw.org/fftw3_doc/Multi_002dDimensional-DFTs-of-Real-Data.html#Multi_002dDimensional-DFTs-of-Real-Data
+	uint32_t fftResultX = paddedImgSize/2+1;
+	starpu_matrix_data_register(&fftScratchMemoryHandle, -1, 0, fftResultX /* no padding */, fftResultX, paddedImgSize, sizeof(float) * 2);
+	starpu_data_set_name(fftScratchMemoryHandle, "Scratch for raw FFT");
+
+	int32_t batch;
+	while ((batch = batches.nextBatch()) != -1) {
+		const uint32_t batchStart = batch * params.batchSize;
+		const uint32_t batchEnd = XMIPP_MIN(batchStart + params.batchSize, totalImages);
+		const uint32_t currentBatchSize = static_cast<uint32_t>(batchEnd - batchStart);
+
+		starpu_data_handle_t amountLoadedHandle = {0};
+		starpu_variable_data_register(&amountLoadedHandle, -1, 0, sizeof(LoadedImagesBuffer));
+		starpu_data_set_name(amountLoadedHandle, "Batch Meta Data");
+
+		starpu_data_handle_t paddedImagesDataHandle = {0};
+		starpu_vector_data_register(&paddedImagesDataHandle, -1, 0, currentBatchSize, align(paddedImgSize * paddedImgSize * sizeof(float), ALIGNMENT));
+		starpu_data_set_name(paddedImagesDataHandle, "Batch Padded Image Data");
+
+		starpu_data_handle_t traverseSpacesHandle = {0};
+		starpu_matrix_data_register(&traverseSpacesHandle, -1, 0, computeConstants.R_symmetries.size(), computeConstants.R_symmetries.size(), currentBatchSize, sizeof(RecFourierProjectionTraverseSpace));
+		starpu_data_set_name(traverseSpacesHandle, "Batch Traverse Spaces");
+
+		// Submit the task to load the projections
+		{
+			const size_t argIndex = loadProjectionArgs.size();
+
+			// Create new LoadProjectionArgs for this batch
+			loadProjectionArgs.push_back(LoadProjectionArgs {
+					batchStart, batchEnd,
+					SF,
+					selFileObjectIds,
+					params.do_weights,
+					computeConstants.R_symmetries,
+					maxVolumeIndex, maxVolumeIndex,
+					static_cast<float>(params.blob.radius),
+					params.fastLateBlobbing,
+					paddedImgSize,
+					fftSizeX, fftSizeY
+			});
+
+			const LoadProjectionArgs& loadProjectionArg = loadProjectionArgs[argIndex];
+
+			starpu_task *loadProjectionsTask = starpu_task_create();
+			loadProjectionsTask->name = "LoadProjections";
+			loadProjectionsTask->cl = &codelets.load_projections;
+			loadProjectionsTask->cl_arg = (void *) &loadProjectionArg;
+			loadProjectionsTask->cl_arg_size = sizeof(loadProjectionArg);
+			loadProjectionsTask->cl_arg_free = 0; // Do not free! (probably default)
+			loadProjectionsTask->handles[0] = amountLoadedHandle;
+			loadProjectionsTask->handles[1] = paddedImagesDataHandle;
+			loadProjectionsTask->handles[2] = traverseSpacesHandle;
+			loadProjectionsTask->synchronous = DEBUG_SYNCHRONOUS_TASKS;
+
+			CHECK_STARPU(starpu_task_submit(loadProjectionsTask));
+		}
+
+		// Compute FFT of padded image data and adjust it (crop, shift, normalize)
+		starpu_data_handle_t fftHandle = {0};
+		starpu_vector_data_register(&fftHandle, -1, 0, currentBatchSize, fftSizeX * fftSizeY * 2 * sizeof(float));
+		starpu_data_set_name(fftHandle, "Batch FFT Data");
+
+		{
+			starpu_task* paddedImageToFftTask = starpu_task_create();
+			paddedImageToFftTask->name = "PaddedImageToFFT";
+			paddedImageToFftTask->cl = &codelets.padded_image_to_fft;
+			paddedImageToFftTask->handles[0] = paddedImagesDataHandle;
+			paddedImageToFftTask->handles[1] = fftHandle;
+			paddedImageToFftTask->handles[2] = fftScratchMemoryHandle;
+			paddedImageToFftTask->handles[3] = amountLoadedHandle;
+			paddedImageToFftTask->cl_arg = &imageToFftArg;
+			paddedImageToFftTask->cl_arg_size = sizeof(PaddedImageToFftArgs);
+			paddedImageToFftTask->cl_arg_free = 0;
+			paddedImageToFftTask->synchronous = DEBUG_SYNCHRONOUS_TASKS;
+			CHECK_STARPU(starpu_task_submit(paddedImageToFftTask));
+		}
+
+		starpu_data_unregister_submit(paddedImagesDataHandle);
+
+		{// Submit the actual reconstruction
+			starpu_task* reconstructFftTask = starpu_task_create();
+			reconstructFftTask->name = "ReconstructFFT";
+			reconstructFftTask->cl = &codelets.reconstruct_fft;
+			reconstructFftTask->handles[0] = fftHandle;
+			reconstructFftTask->handles[1] = traverseSpacesHandle;
+			reconstructFftTask->handles[2] = blobTableSquaredHandle;
+			reconstructFftTask->handles[3] = resultVolumeHandle;
+			reconstructFftTask->handles[4] = resultWeightsHandle;
+			reconstructFftTask->handles[5] = amountLoadedHandle;
+			reconstructFftTask->cl_arg = &reconstructFftArg;
+			reconstructFftTask->cl_arg_size = sizeof(ReconstructFftArgs);
+			reconstructFftTask->cl_arg_free = 0;
+			reconstructFftTask->callback_func = BatchProvider::batchCompleted;
+			reconstructFftTask->callback_arg = &batches;
+			reconstructFftTask->callback_arg_free = 0;
+			reconstructFftTask->synchronous = DEBUG_SYNCHRONOUS_TASKS;
+
+			CHECK_STARPU(starpu_task_submit(reconstructFftTask));
+		}
+
+		// Mark buffers shared between tasks of a batch for removal
+		starpu_data_unregister_submit(fftHandle);
+		starpu_data_unregister_submit(traverseSpacesHandle);
+		starpu_data_unregister_submit(amountLoadedHandle);
+	}
+
+	// Mark helper buffers that are shared between all tasks for removal
+	starpu_data_unregister_submit(blobTableSquaredHandle);
+	starpu_data_unregister_submit(fftScratchMemoryHandle);
+
+	// Complete all processing
+	/*while (starpu_task_nsubmitted() > 0) {
+		starpu_do_schedule();
+		usleep(100000);//100ms
+	}*/
+	CHECK_STARPU(starpu_task_wait_for_all());
+
+	// Release result buffers synchronously, implicitly causes them to be copied to original memory location
+	starpu_data_unregister(resultVolumeHandle);
+	starpu_data_unregister(resultWeightsHandle);
+
+	return result;
+}
+
+std::complex<float>*** ProgRecFourierStarPU::ComputeStarPUResult::createXmippStyleVolume(uint32_t maxVolumeIndex) {
+	std::complex<float>*** tempVolume = NULL;
+	allocate(tempVolume, maxVolumeIndex + 1, maxVolumeIndex + 1, maxVolumeIndex + 1);
+	copyFlatTo3D(tempVolume, this->volumeData, maxVolumeIndex + 1);
+	return tempVolume;
+}
+
+float*** ProgRecFourierStarPU::ComputeStarPUResult::createXmippStyleWeights(uint32_t maxVolumeIndex) {
+	float*** tempWeights = NULL;
+	allocate(tempWeights, maxVolumeIndex + 1, maxVolumeIndex + 1, maxVolumeIndex + 1);
+	copyFlatTo3D(tempWeights, this->weightsData, maxVolumeIndex + 1);
+	return tempWeights;
+}
+
+void ProgRecFourierStarPU::ComputeStarPUResult::destroy() {
+	CHECK_STARPU(starpu_free(volumeData));
+	CHECK_STARPU(starpu_free(weightsData));
+}
+
+void ProgRecFourierStarPU::shutdownStarPU() {
+	starpu_shutdown();
+}
+
+void ProgRecFourierStarPU::postProcessAndSave(
+		const Params& params, const ComputeConstants& computeConstants, const FileName& fn_out,
+		std::complex<float> ***tempVolume, float ***tempWeights) {
+
+	const uint32_t maxVolumeIndex = computeConstants.maxVolumeIndex;
+
+	// remove complex conjugate of the intermediate result
+	const uint32_t maxVolumeIndexX = maxVolumeIndex/2;// just half of the space is necessary, the rest is complex conjugate
+	const uint32_t maxVolumeIndexYZ = maxVolumeIndex;
+	mirrorAndCropTempSpaces(tempVolume, tempWeights, maxVolumeIndexX, maxVolumeIndexYZ);
+
+	if (params.fastLateBlobbing) {
+		tempVolume = applyBlob(tempVolume, (float) params.blob.radius, (float*)computeConstants.blobTableSqrt, computeConstants.iDeltaSqrt, (int)maxVolumeIndexX, (int)maxVolumeIndexYZ);
+		tempWeights = applyBlob(tempWeights, (float) params.blob.radius, (float*)computeConstants.blobTableSqrt, computeConstants.iDeltaSqrt, (int)maxVolumeIndexX, (int)maxVolumeIndexYZ);
+	}
+
+	const uint32_t paddedImgSize = computeConstants.paddedImgSize;
+	const uint32_t imgSize = computeConstants.imgSize;
+
+	forceHermitianSymmetry(tempVolume, tempWeights, maxVolumeIndexYZ);
+	processWeights(tempVolume, tempWeights, maxVolumeIndexX, maxVolumeIndexYZ, params.padding_factor_proj, params.padding_factor_vol, imgSize);
+	release(tempWeights, maxVolumeIndexYZ+1, maxVolumeIndexYZ+1);
+	MultidimArray< std::complex<double> > VoutFourier(paddedImgSize, paddedImgSize, paddedImgSize/2 + 1); // allocate space for output Fourier transformation
+
+	convertToExpectedSpace(tempVolume, maxVolumeIndexYZ, VoutFourier);
+	release(tempVolume, maxVolumeIndexYZ+1, maxVolumeIndexYZ+1);
+
+	// Output volume
+	Image<double> Vout(paddedImgSize, paddedImgSize, paddedImgSize);
+	MultidimArray<double> &mVout = Vout.data;
+
+	{
+		FourierTransformer transformerVol;
+		transformerVol.setThreadsNumber(params.fourierTransformThreads);
+		transformerVol.fReal = &mVout;
+		transformerVol.setFourierAlias(VoutFourier);
+		transformerVol.recomputePlanR2C();
+		transformerVol.inverseFourierTransform();
+	}
+
+	CenterFFT(mVout, false);
+
+	// Correct by the Fourier transform of the blob
+	mVout.setXmippOrigin();
+	mVout.selfWindow(FIRST_XMIPP_INDEX(imgSize),FIRST_XMIPP_INDEX(imgSize),
+	                  FIRST_XMIPP_INDEX(imgSize),LAST_XMIPP_INDEX(imgSize),
+	                  LAST_XMIPP_INDEX(imgSize),LAST_XMIPP_INDEX(imgSize));
+	double pad_relation = params.padding_factor_proj / params.padding_factor_vol;
+	pad_relation = (pad_relation * pad_relation * pad_relation);
+
+	double ipad_relation = 1.0 / pad_relation;
+	double meanFactor2 = 0;
+	FOR_ALL_ELEMENTS_IN_ARRAY3D(mVout) {
+		double radius = sqrt((double)(k*k + i*i + j*j));
+		double aux = radius * computeConstants.iDeltaFourier;
+		double factor = computeConstants.fourierBlobTable[ROUND(aux)];
+		double factor2 = pow(Sinc(radius / (2*imgSize)), 2);
+		A3D_ELEM(mVout,k,i,j) /= (ipad_relation * factor2 * factor);
+		meanFactor2 += factor2;
+	}
+	meanFactor2 /= MULTIDIM_SIZE(mVout);
+	FOR_ALL_ELEMENTS_IN_ARRAY3D(mVout) {
+		A3D_ELEM(mVout, k, i, j) *= meanFactor2;
+	}
+	Vout.write(fn_out);
+}
+
+void ProgRecFourierStarPU::BatchProvider::batchCompleted(void *batchProvider) {
+	BatchProvider& self = *((BatchProvider*) batchProvider);
+	self.batchCompleted();
+}

--- a/src/xmipp/libraries/reconstruction_starpu/reconstruct_fourier_starpu.h
+++ b/src/xmipp/libraries/reconstruction_starpu/reconstruct_fourier_starpu.h
@@ -1,0 +1,234 @@
+/***************************************************************************
+ *
+ * Authors:     Jan Polak (456647@mail.muni.cz)
+ *              Roberto Marabini (roberto@cnb.csic.es)
+ *              Carlos Oscar S. Sorzano (coss@cnb.csic.es)
+ *              Jose Roman Bilbao-Castro (jrbcast@ace.ual.es)
+ *              Vahid Abrishami (vabrishami@cnb.csic.es)
+ *              David Strelak (davidstrelak@gmail.com)
+ *
+ * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ * 02111-1307  USA
+ *
+ *  All comments concerning this program package may be sent to the
+ *  e-mail address 'xmipp@cnb.csic.es'
+ ***************************************************************************/
+
+#ifndef __RECONSTRUCT_FOURIER_GPU_H
+#define __RECONSTRUCT_FOURIER_GPU_H
+
+#include <cstdint>
+#include <core/metadata.h>
+#include <data/blobs.h>
+#include <core/xmipp_filename.h>
+#include <reconstruction/recons.h> // Used only as a base class for this program's class
+#include "reconstruct_fourier_defines.h"
+
+
+/**@defgroup FourierReconstruction Fourier reconstruction
+   @ingroup ReconsLibrary */
+//@{
+class ProgRecFourierStarPU : public ProgReconsBase {
+protected:
+
+	/** Input file name */
+	FileName fn_in;
+
+	/** Output file name */
+	FileName fn_out;
+
+	/** File with symmetries */
+	FileName fn_sym;
+
+	/** Parameters, always loaded at startup. */
+	struct Params {
+		/** Projection padding Factor */
+		double padding_factor_proj;
+
+		/** Volume padding Factor */
+		double padding_factor_vol;
+
+		/** Max resolution in Angstroms */
+		float maxResolution;
+
+		/** Flag whether to use the weights in the image metadata */
+		bool do_weights;
+
+		/** Definition of the blob */
+		struct blobtype blob;
+
+		/** If true, blobbing is done at the end of the computation. This is less accurate, but faster. */
+		bool fastLateBlobbing;
+
+		/** Number of threads to be used for final fourier transformation */
+		uint32_t fourierTransformThreads;
+
+		/** Size of loading buffer (i.e. max number of projection loaded in one buffer).
+		 * Images are processed in batches of this size. */
+		uint32_t batchSize;
+	} params;
+
+	/** SelFile containing all projections */
+	MetaData SF;
+
+	/** Constants needed to perform computations. (Not loaded for MPI master, which does not do any computations.) */
+	struct ComputeConstants {
+		/** variable used for blob table values calculation */
+		double iw0;
+
+		/** Table with blob values, linear sampling */
+		double fourierBlobTable[BLOB_TABLE_SIZE_SQRT];
+
+		/** Table with blob values, squared sampling */
+		float blobTableSqrt[BLOB_TABLE_SIZE_SQRT];
+
+		/** Inverse of the delta and deltaFourier used in the tables */
+		float iDeltaFourier, iDeltaSqrt;
+
+		/** Vector with R symmetry matrices */
+		std::vector <Matrix2D<double> > R_symmetries;
+
+		/** Size of the original projection, must be a square */
+		uint32_t imgSize;
+
+		/** Size of the image including padding. Image must be a square */
+		uint32_t paddedImgSize;
+
+		/** maximal index in the temporal volumes */
+		uint32_t maxVolumeIndex;
+	} computeConstants;
+
+	/** Internal, here just to have access rights. */
+	struct CompleteBatchTasks;
+
+public:
+	ProgRecFourierStarPU() {
+		// Check that there is no logical problem in the defines used by program. If found, error is thrown.
+		if (!((TILE == 1) || (BLOCK_DIM % TILE == 0))) {
+			REPORT_ERROR(ERR_PARAM_INCORRECT,"TILE has to be set to 1(one) or BLOCK_DIM has to be a multiple of TILE");
+		}
+		if ((SHARED_IMG == 1) && (TILE != 1)) {
+			REPORT_ERROR(ERR_PARAM_INCORRECT,"TILE cannot be used while SHARED_IMG is active");
+		}
+		if (TILE >= BLOCK_DIM) {
+			REPORT_ERROR(ERR_PARAM_INCORRECT,"TILE must be smaller than BLOCK_DIM");
+		}
+		if ((SHARED_BLOB_TABLE == 1) && (PRECOMPUTE_BLOB_VAL == 0)) {
+			REPORT_ERROR(ERR_PARAM_INCORRECT,"PRECOMPUTE_BLOB_VAL must be set to 1(one) when SHARED_BLOB_TABLE is active");
+		}
+	}
+
+	/** Specify supported command line arguments */
+	void defineParams() override;
+
+	/** Read arguments from command line */
+	void readParams() override;
+
+	/** Show basic info to standard output */
+	void show() const override;
+
+	/** Run the image processing.
+	 * Method will load data, process them and store result to final destination. */
+	void run() override;
+
+	/** Functions of common reconstruction interface */
+	void setIO(const FileName &fn_in, const FileName &fn_out) override;
+
+protected:
+
+	/** Implements a potentially lazy collection of batches for computeStarPU.
+	 * Standard, single machine operation will implement this with a simple counter,
+	 * distributed version may retrieve the batches over the network, etc.
+	 *
+	 * Also tracks the progress, via batchCompleted(), possibly showing and updating a progress bar.
+	 * While each batch may take a different amount of time, it is a good and fast approximation. */
+	struct BatchProvider {
+		/** Max amount of batches this source may ever return.
+		 * Can be used to pre-allocate working structures.
+		 * Will always return the same number. */
+		virtual uint32_t maxBatches() = 0;
+		/** Retrieve a next batch to work on.
+		 * This call may block the thread while it waits for some batches to complete.
+		 * @return batch number or -1 to signify that there are no more batches */
+		virtual int32_t nextBatch() = 0;
+		/** Called after each batch is completed. */
+		virtual void batchCompleted() = 0;
+
+		/** StarPU C proxy for batchCompleted().
+		 * @param progressTracker is a pointer to BatchProvider instance. */
+		static void batchCompleted(void *batchProvider);
+	};
+
+	/** Load meta data, selection file with a list of images to process.
+	 * @return total batch count */
+	static void prepareMetaData(const FileName& fn_in, MetaData& SF);
+
+	static uint32_t computeBatchCount(const Params& params, const MetaData& SF);
+
+	/** Load or compute constants needed for the computation. */
+	static void prepareConstants(const Params& params, const MetaData& SF, const FileName& fn_sym, ComputeConstants& constants);
+
+	/** Initialize StarPU. Separate method to allow MPI override */
+	static void initStarPU();
+
+	/** Result of computeStarPU */
+	struct ComputeStarPUResult {
+		/**
+		 * 3D volume holding the cropped (without high frequencies) Fourier space.
+		 * Lowest frequencies are in the center, i.e. Fourier space creates a sphere within a cube.
+		 *
+		 * On GPU reinterpreted as array of `float2`,
+		 * or `float` with each two successive values represent one complex number.
+		 */
+		std::complex<float>* volumeData = nullptr;
+
+		/** 3D volume holding the weights of the Fourier coefficients stored in tempVolume. */
+		float* weightsData = nullptr;
+
+		/** Copies data from volumeData to a new Xmipp-style 3D array
+		 * (accessible by [x][y][z] operator, with each level individually allocated).
+		 * Data must not be destroyed, this does not destroy it. */
+		std::complex<float>*** createXmippStyleVolume(uint32_t maxVolumeIndex);
+
+		/** Copies data from weightsData to a new Xmipp-style 3D array.
+		 * Data must not be destroyed, this does not destroy it. */
+		float*** createXmippStyleWeights(uint32_t maxVolumeIndex);
+
+		/** Must be called to free volumeData and weightsData. */
+		void destroy();
+	};
+
+	static ComputeStarPUResult computeStarPU(
+			const Params& params, const MetaData& SF, const ComputeConstants& computeConstants,
+			BatchProvider& batches, bool verbose);
+
+	/** Shutdown StarPU. Separate method to allow MPI override */
+	static void shutdownStarPU();
+
+	/**
+	 * Method will take data stored in tempVolume and tempWeights,
+	 * crops it in  X axis, calculates IFFT and stores the result
+	 * to final destination.
+	 */
+	static void postProcessAndSave(const Params& params, const ComputeConstants& computeConstants, const FileName& fn_out,
+			std::complex<float> ***tempVolume, float ***tempWeights);
+
+private:
+	struct SimpleBatchProvider;
+};
+//@}
+#endif

--- a/src/xmipp/libraries/reconstruction_starpu/reconstruct_fourier_starpu_util.h
+++ b/src/xmipp/libraries/reconstruction_starpu/reconstruct_fourier_starpu_util.h
@@ -1,0 +1,417 @@
+/***************************************************************************
+ *
+ * Authors:     Jan Polak (456647@mail.muni.cz)
+ *              (some code derived from other Xmipp programs by other authors)
+ *
+ * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ * 02111-1307  USA
+ *
+ *  All comments concerning this program package may be sent to the
+ *  e-mail address 'xmipp@cnb.csic.es'
+ ***************************************************************************/
+
+#ifndef XMIPP_LIBRARIES_RECONSTRUCT_FOURIER_STARPU_UTIL_H_
+#define XMIPP_LIBRARIES_RECONSTRUCT_FOURIER_STARPU_UTIL_H_
+
+#include <data/point3D.h>
+#include <data/blobs.h>
+#include <reconstruction/reconstruct_fourier_projection_traverse_space.h>
+#include "reconstruct_fourier_defines.h"
+
+
+/** Method to allocate 3D array (not continuous) of given size */
+template<typename T>
+static T*** allocate(T***& where, int xSize, int ySize, int zSize) {
+	where = new T**[zSize];
+	for (int z = 0; z < zSize; z++) {
+		where[z] = new T*[ySize];
+		for (int y = 0; y < ySize; y++) {
+			where[z][y] = new T[xSize];
+			for (int x = 0; x < xSize; x++) {
+				where[z][y][x] = (T) 0;
+			}
+		}
+	}
+	return where;
+}
+
+/** Method to release 3D array of given size */
+template<typename T>
+static void release(T***& array, int ySize, int zSize) {
+	for(int z = 0; z < zSize; z++) {
+		for(int y = 0; y < ySize; y++) {
+			delete[] array[z][y];
+		}
+		delete[] array[z];
+	}
+	delete[] array;
+	array = NULL;
+}
+
+/** Method will copy continuous 3D arrays (with each side of `size`) to non-continuous 3D arrays */
+template<typename T>
+void copyFlatTo3D(T*** target, const T* source, const int size) {
+	for (int z = 0; z < size; z++) {
+		for (int y = 0; y < size; y++) {
+			int index = (z * size * size) + (y * size);
+			memcpy(target[z][y], source + index, size * sizeof(T));
+		}
+	}
+}
+
+
+/** Function behaving like an identity, i.e returning passed value */
+template<typename T>
+static T identity(T val) { return val;}; // if used with some big type, use reference
+
+/** Function returning conjugate of a complex number */
+template<typename T>
+static std::complex<T> conjugate(std::complex<T> f) { return conj(f);};
+
+
+/** Do 3x3 x 1x3 matrix-vector multiplication */
+static inline void multiply(const float transform[3][3], Point3D<float>& inOut) {
+	float tmp0 = transform[0][0] * inOut.x + transform[0][1] * inOut.y + transform[0][2] * inOut.z;
+	float tmp1 = transform[1][0] * inOut.x + transform[1][1] * inOut.y + transform[1][2] * inOut.z;
+	float tmp2 = transform[2][0] * inOut.x + transform[2][1] * inOut.y + transform[2][2] * inOut.z;
+	inOut.x = tmp0;
+	inOut.y = tmp1;
+	inOut.z = tmp2;
+}
+
+/**
+*          6____5
+*         2/___1/
+*    +    | |  ||   y
+* [0,0,0] |*|7 ||4
+*    -    |/___|/  z  sizes are padded with blob-radius
+*         3  x  0
+* [0,0] is in the middle of the left side (point [2] and [3]), provided the blobSize is 0
+* otherwise the values can go to negative values
+* origin(point[0]) in in 'high' frequencies so that possible numerical instabilities are moved to high frequencies
+*/
+static void createProjectionCuboid(Point3D<float> (&cuboid)[8], float sizeX, float sizeY, float blobSize) {
+	float halfY = sizeY / 2.0f;
+	cuboid[3].x = cuboid[2].x = cuboid[7].x = cuboid[6].x = 0.f - blobSize;
+	cuboid[0].x = cuboid[1].x = cuboid[4].x = cuboid[5].x = sizeX + blobSize;
+
+	cuboid[3].y = cuboid[0].y = cuboid[7].y = cuboid[4].y = -(halfY + blobSize);
+	cuboid[1].y = cuboid[2].y = cuboid[5].y = cuboid[6].y = halfY + blobSize;
+
+	cuboid[3].z = cuboid[0].z = cuboid[1].z = cuboid[2].z = 0.f + blobSize;
+	cuboid[7].z = cuboid[4].z = cuboid[5].z = cuboid[6].z = 0.f - blobSize;
+}
+
+/** Apply rotation transform to cuboid */
+static inline void rotateCuboid(Point3D<float> (&cuboid)[8], const float transform[3][3]) {
+	for (int i = 0; i < 8; i++) {
+		multiply(transform, cuboid[i]);
+	}
+}
+
+/** Add 'vector' to each element of 'cuboid' */
+static inline void translateCuboid(Point3D<float> (&cuboid)[8], Point3D<float> vector) {
+	for (int i = 0; i < 8; i++) {
+		cuboid[i].x += vector.x;
+		cuboid[i].y += vector.y;
+		cuboid[i].z += vector.z;
+	}
+}
+
+/**
+ * Method will calculate Axis Aligned Bound Box of the cuboid and restrict
+ * its maximum size
+ */
+static void computeAABB(Point3D<float> (&AABB)[2], Point3D<float> (&cuboid)[8],
+                        float minX, float minY, float minZ,
+                        float maxX, float maxY, float maxZ) {
+	AABB[0].x = AABB[0].y = AABB[0].z = std::numeric_limits<float>::max();
+	AABB[1].x = AABB[1].y = AABB[1].z = std::numeric_limits<float>::min();
+	Point3D<float> tmp;
+	for (int i = 0; i < 8; i++) {
+		tmp = cuboid[i];
+		if (AABB[0].x > tmp.x) AABB[0].x = tmp.x;
+		if (AABB[0].y > tmp.y) AABB[0].y = tmp.y;
+		if (AABB[0].z > tmp.z) AABB[0].z = tmp.z;
+		if (AABB[1].x < tmp.x) AABB[1].x = tmp.x;
+		if (AABB[1].y < tmp.y) AABB[1].y = tmp.y;
+		if (AABB[1].z < tmp.z) AABB[1].z = tmp.z;
+	}
+	// limit to max size
+	if (AABB[0].x < minX) AABB[0].x = minX;
+	if (AABB[0].y < minY) AABB[0].y = minY;
+	if (AABB[0].z < minZ) AABB[0].z = minZ;
+	if (AABB[1].x > maxX) AABB[1].x = maxX;
+	if (AABB[1].y > maxY) AABB[1].y = maxY;
+	if (AABB[1].z > maxZ) AABB[1].z = maxZ;
+}
+
+/** DEBUG ONLY method, prints AABB to std::cout. Output can be used in e.g. GNUPLOT */
+static void printAABB(Point3D<float> AABB[]) {
+	std::cout
+			// one base
+			<< AABB[0].x << " " << AABB[0].y << " " << AABB[0].z << "\n"
+			<< AABB[1].x << " " << AABB[0].y << " " << AABB[0].z << "\n"
+			<< AABB[1].x << " " << AABB[1].y << " " << AABB[0].z << "\n"
+			<< AABB[0].x << " " << AABB[1].y << " " << AABB[0].z << "\n"
+			<< AABB[0].x << " " << AABB[0].y << " " << AABB[0].z << "\n"
+			// other base with one connection
+			<< AABB[0].x << " " << AABB[0].y << " " << AABB[1].z << "\n"
+			<< AABB[1].x << " " << AABB[0].y << " " << AABB[1].z << "\n"
+			<< AABB[1].x << " " << AABB[1].y << " " << AABB[1].z << "\n"
+			<< AABB[0].x << " " << AABB[1].y << " " << AABB[1].z << "\n"
+			<< AABB[0].x << " " << AABB[0].y << " " << AABB[1].z << "\n"
+			// lines between bases
+			<< AABB[1].x << " " << AABB[0].y << " " << AABB[1].z << "\n"
+			<< AABB[1].x << " " << AABB[0].y << " " << AABB[0].z << "\n"
+			<< AABB[1].x << " " << AABB[1].y << " " << AABB[0].z << "\n"
+			<< AABB[1].x << " " << AABB[1].y << " " << AABB[1].z << "\n"
+			<< AABB[0].x << " " << AABB[1].y << " " << AABB[1].z << "\n"
+			<< AABB[0].x << " " << AABB[1].y << " " << AABB[0].z
+			<< std::endl;
+}
+
+/** Method to convert temporal space to expected (original) format */
+template<typename T, typename U>
+static void convertToExpectedSpace(T*** input, int size, MultidimArray<U>& VoutFourier) {
+	int halfSize = size / 2;
+	for (int z = 0; z <= size; z++) {
+		for (int y = 0; y <= size; y++) {
+			// shift FFT from center to corners
+			const size_t newY = (y < halfSize) ? VoutFourier.ydim - halfSize + y : y - halfSize;
+			const size_t newZ = (z < halfSize) ? VoutFourier.zdim - halfSize + z : z - halfSize;
+
+			for (int x = 0; x <= halfSize; x++) {
+				// store to output array
+				// += in necessary as VoutFourier might be used multiple times when used with MPI
+				DIRECT_A3D_ELEM(VoutFourier, newZ, newY, x /* no need to move X */) += input[z][y][x];
+			}
+		}
+	}
+}
+
+/**
+ * Method calculates a traversal space information for specific projection
+ * imgSizeX - X size of the projection
+ * imgSizeY - Y size of the projection
+ * transform - forward rotation that should be applied to the projection
+ * transformInv - inverse transformation
+ * space - which will be filled
+ */
+static void computeTraverseSpace(uint32_t imgSizeX, uint32_t imgSizeY,
+                                 const float transform[3][3], const float transformInv[3][3], RecFourierProjectionTraverseSpace& space,
+                                 uint32_t maxVolumeIndexX, uint32_t maxVolumeIndexYZ, bool useFast, float blobRadius) {
+	Point3D<float> cuboid[8];
+	Point3D<float> AABB[2];
+	Point3D<float> origin = {maxVolumeIndexX/2.f, maxVolumeIndexYZ/2.f, maxVolumeIndexYZ/2.f};
+	createProjectionCuboid(cuboid, imgSizeX, imgSizeY, useFast ? 0.f : blobRadius);
+	rotateCuboid(cuboid, transform);
+	translateCuboid(cuboid, origin);
+	computeAABB(AABB, cuboid, 0, 0, 0, maxVolumeIndexX, maxVolumeIndexYZ, maxVolumeIndexYZ);
+
+	// store data
+	space.minZ = floor(AABB[0].z);
+	space.minY = floor(AABB[0].y);
+	space.minX = floor(AABB[0].x);
+	space.maxZ = ceil(AABB[1].z);
+	space.maxY = ceil(AABB[1].y);
+	space.maxX = ceil(AABB[1].x);
+	space.topOrigin = cuboid[4];
+	space.bottomOrigin = cuboid[0];
+	space.maxDistanceSqr = (imgSizeX + (useFast ? 0.f : blobRadius))
+	                       * (imgSizeX + (useFast ? 0.f : blobRadius));
+	for (int i = 0; i < 3; i++) {
+		for (int j = 0; j < 3; j++) {
+			space.transformInv[i][j] = transformInv[i][j];
+		}
+	}
+
+	// calculate best traverse direction
+	space.unitNormal.x = space.unitNormal.y = 0.f;
+	space.unitNormal.z = 1.f;
+	multiply(transform, space.unitNormal);
+	float nX = std::abs(space.unitNormal.x);
+	float nY = std::abs(space.unitNormal.y);
+	float nZ = std::abs(space.unitNormal.z);
+
+	// biggest vector indicates ideal direction
+	if (nX >= nY  && nX >= nZ) { // iterate YZ plane
+		space.dir = RecFourierProjectionTraverseSpace::Direction::YZ;
+	} else if (nY >= nX && nY >= nZ) { // iterate XZ plane
+		space.dir = RecFourierProjectionTraverseSpace::Direction::XZ;
+	} else if (nZ >= nX && nZ >= nY) { // iterate XY plane
+		space.dir = RecFourierProjectionTraverseSpace::Direction::XY;
+	}
+}
+
+/**
+ * Method will take input array (of size
+ * maxVolumeIndexYZ*maxVolumeIndexYZ*maxVolumeIndexYZ
+ * and transfer data to newly created array of size
+ * maxVolumeIndexX*maxVolumeIndexYZ*maxVolumeIndexYZ (i.e. X side is half).
+ * so that data on the 'left side' are mirrored against the origin of the
+ * array, and 'f' function is applied on them.
+ * 'right hand side' is only transfered.
+ * As a result, input will contain an array with X side half of the original
+ * size, with all data transfered from 'missing' side to 'preserved' side
+ */
+template<typename T>
+static void mirrorAndCrop(T***& input,T (*f)(T), uint32_t maxVolumeIndexX, uint32_t maxVolumeIndexYZ) {
+	T*** output;
+	// create new storage, notice that just 'right hand side - X axis' of the input will be preserved, left will be converted to its complex conjugate
+	allocate(output, maxVolumeIndexX+1, maxVolumeIndexYZ+1, maxVolumeIndexYZ+1);
+	// traverse old storage
+	for (int z = 0; z <= maxVolumeIndexYZ; z++) {
+		for (int y = 0; y <= maxVolumeIndexYZ; y++) {
+			for (int x = 0; x <= maxVolumeIndexYZ; x++) {
+				if (x < maxVolumeIndexX) {
+					int newPos[3];
+					// mirror against center of the volume, e.g. [0,0,0]->[size,size,size]. It will fit as the input space is one voxel bigger
+					newPos[0] = maxVolumeIndexYZ - x;
+					newPos[1] = maxVolumeIndexYZ - y;
+					newPos[2] = maxVolumeIndexYZ - z;
+					output[newPos[2]][newPos[1]][newPos[0]-maxVolumeIndexX] += f(input[z][y][x]);
+				} else {
+					// copy with X shifted by (-halfSize)
+					output[z][y][x-maxVolumeIndexX] += input[z][y][x];
+				}
+			}
+		}
+	}
+	// free original data
+	release(input, maxVolumeIndexYZ+1, maxVolumeIndexYZ+1);
+	// set new data
+	input = output;
+}
+
+/**
+ * Method will take temp spaces (containing complex conjugate values
+ * in the 'right X side'), transfer them to 'left X side' and remove
+ * the 'right X side'. As a result, the X dimension of the temp spaces
+ * will be half of the original.
+ */
+static void mirrorAndCropTempSpaces(std::complex<float>***& tempVolume, float***& tempWeights, const uint32_t maxVolumeIndexX, const uint32_t maxVolumeIndexYZ) {
+	mirrorAndCrop(tempWeights, &identity<float>, maxVolumeIndexX, maxVolumeIndexYZ);
+	mirrorAndCrop(tempVolume, &conjugate, maxVolumeIndexX, maxVolumeIndexYZ);
+}
+
+/**
+ * Method will enforce Hermitian symmetry, i.e will make sure
+ * that the values in temporal space at X=0 are complex conjugate of
+ * in respect to center of the space
+ */
+static void forceHermitianSymmetry(std::complex<float>***& tempVolume, float***& tempWeights, int maxVolumeIndexYZ) {
+	const int x = 0;
+	for (int z = 0; z <= maxVolumeIndexYZ; z++) {
+		for (int y = 0; y <= maxVolumeIndexYZ/2; y++) {
+			// mirror against center of the volume, e.g. [0,0,0]->[size,size,size]. It will fit as the input space is one voxel biger
+			const int newX = x;
+			const int newY = maxVolumeIndexYZ - y;
+			const int newZ = maxVolumeIndexYZ - z;
+
+			const std::complex<float> averageVol = 0.5f * (tempVolume[newZ][newY][newX] + conj(tempVolume[z][y][x]));
+			const float averageWeight = 0.5f * (tempWeights[newZ][newY][newX] + tempWeights[z][y][x]);
+
+			tempVolume[newZ][newY][newX] = averageVol;
+			tempVolume[z][y][x] = conj(averageVol);
+			tempWeights[newZ][newY][newX] = tempWeights[z][y][x] = averageWeight;
+		}
+	}
+}
+
+/**
+ * Method will in effect do the point-wise division of
+ * tempVolume and tempWeights
+ * (i.e. correct Fourier coefficients by proper weight)
+ */
+static void processWeights(std::complex<float>***& tempVolume, float***& tempWeights, int maxVolumeIndexX, int maxVolumeIndexYZ, double paddingFactorProj, double paddingFactorVol, int imgSize) {
+	// Get a first approximation of the reconstruction
+	float corr2D_3D = static_cast<float>(pow(paddingFactorProj, 2.0) / (imgSize * pow(paddingFactorVol, 3.0)));
+	for (int z = 0; z <= maxVolumeIndexYZ; z++) {
+		for (int y = 0; y <= maxVolumeIndexYZ; y++) {
+			for (int x = 0; x <= maxVolumeIndexX; x++) {
+				const float weight = tempWeights[z][y][x];
+
+				// TODO(jp): Fix other places that do this operation: https://github.com/I2PC/xmipp/pull/185#discussion_r331810014
+				if (weight > ACCURACY)
+					tempVolume[z][y][x] *= corr2D_3D / weight;
+				else
+					tempVolume[z][y][x] = 0;
+			}
+		}
+	}
+}
+
+
+static float getBessiOrderAlpha(blobtype blob) {
+	switch (blob.order) {
+		case 0: return static_cast<float>(bessi0(blob.alpha));
+		case 1: return static_cast<float>(bessi1(blob.alpha));
+		case 2: return static_cast<float>(bessi2(blob.alpha));
+		case 3: return static_cast<float>(bessi3(blob.alpha));
+		case 4: return static_cast<float>(bessi4(blob.alpha));
+		default:
+			REPORT_ERROR(ERR_VALUE_INCORRECT,"Order must be in interval [0..4]");
+	}
+}
+
+/**
+ * Method will apply blob to input 3D array.
+ * Original array will be released and new (blurred) will be returned
+ */
+template<typename T>
+static T*** applyBlob(T***& input, float blobSize,
+                      float* blobTableSqrt, float iDeltaSqrt,
+                      const int maxVolumeIndexX, const int maxVolumeIndexYZ) {
+	float blobSizeSqr = blobSize * blobSize;
+	int blob = static_cast<int>(floor(blobSize)); // we are using integer coordinates, so we cannot hit anything further
+	T*** output;
+	// create new storage
+	allocate(output, maxVolumeIndexX+1, maxVolumeIndexYZ+1, maxVolumeIndexYZ+1);
+
+	// traverse new storage
+	for (int i = 0; i <= maxVolumeIndexYZ; i++) {
+		for (int j = 0; j <= maxVolumeIndexYZ; j++) {
+			for (int k = 0; k <= maxVolumeIndexX; k++) {
+				// traverse input storage
+				T tmp = (T) 0;
+				for (int z = std::max(0, i-blob); z <= std::min(maxVolumeIndexYZ, i+blob); z++) {
+					float dZSqr = (i - z) * (i - z);
+					for (int y = std::max(0, j-blob); y <= std::min(maxVolumeIndexYZ, j+blob); y++) {
+						float dYSqr = (j - y) * (j - y);
+						for (int x = std::max(0, k-blob); x <= std::min(maxVolumeIndexX, k+blob); x++) {
+							float dXSqr = (k - x) * (k - x);
+							float distanceSqr = dZSqr + dYSqr + dXSqr;
+							if (distanceSqr > blobSizeSqr) {
+								continue;
+							}
+							int aux = (int) ((distanceSqr * iDeltaSqrt + 0.5)); //Same as ROUND but avoid comparison
+							float tmpWeight = blobTableSqrt[aux];
+							tmp += tmpWeight * input[z][y][x];
+						}
+					}
+				}
+				output[i][j][k] = tmp;
+			}
+		}
+	}
+	// free original data
+	release(input, maxVolumeIndexYZ+1, maxVolumeIndexYZ+1);
+	return output;
+}
+
+#endif //XMIPP_LIBRARIES_RECONSTRUCT_FOURIER_STARPU_UTIL_H_

--- a/src/xmipp/libraries/reconstruction_starpu/reconstruct_fourier_timing.cpp
+++ b/src/xmipp/libraries/reconstruction_starpu/reconstruct_fourier_timing.cpp
@@ -1,0 +1,182 @@
+#include "reconstruct_fourier_timing.h"
+#include <algorithm>
+#include <inttypes.h>
+
+void timing::record(starpu_codelet *codelet, unsigned impl, starpu_worker_archtype archtype, int devid, size_t size, double microseconds) {
+	if (codelet == nullptr) {
+		return;
+	}
+
+	std::lock_guard<std::mutex> lg(lock);
+	//fprintf(stderr, "Recording that %s(%d) on %d:%d (%zd bytes) did take %" PRIu64 " us\n", codelet->name, impl, archtype, devid, size, (uint64_t)microseconds);
+	timings[timing_key{codelet->name, size, (uint32_t)impl, archtype, (uint16_t) devid}].add(microseconds);
+}
+
+static uint64_t estimateForNewSize(size_t originalSize, uint64_t originalEstimate, size_t forSize) {
+	const double overhead = 0.5;
+	return (uint64_t) (originalEstimate * overhead + (originalEstimate * (1.0 - overhead)) * (double)forSize / (double)originalSize);
+}
+
+double timing::estimate(starpu_codelet *codelet, unsigned impl, starpu_worker_archtype archtype, int devid, size_t size) {
+	if (codelet == nullptr) {
+		return MIN_TIME;
+	}
+
+	std::lock_guard<std::mutex> lg(lock);
+	if (timings.empty()) {
+		return MIN_TIME;
+	}
+
+	auto key = timing_key{codelet->name, size, (uint32_t) impl, archtype, (uint16_t) devid};
+	auto found = timings.lower_bound(key);
+
+	if (found != timings.end() && found->first == key) {
+		uint64_t result = found->second.average(true);
+		if (result != MIN_TIME) {
+			// This key exists and provides valid estimates, use them
+			return result;
+		}
+	}
+
+	// We need to check around for key with good estimates
+	const size_t maxDistance = std::numeric_limits<size_t>::max();
+	// Check up
+	size_t upDistance = maxDistance;
+	uint64_t upEstimate = 0;
+	{
+		auto up = found;
+		while (up != timings.end() && up->first.equalsExceptSize(key)) {
+			uint64_t result = up->second.average(true);
+			if (result != MIN_TIME) {
+				// We could use it!
+				upDistance = up->first.size - size;
+				upEstimate = estimateForNewSize(up->first.size, result, size);
+				break;
+			}
+			up = std::next(up);
+		}
+	}
+
+	size_t downDistance = maxDistance;
+	uint64_t downEstimate = 0;
+	{
+		auto down = found;
+		while (down != timings.begin()) {
+			down = std::prev(down);
+			if (!down->first.equalsExceptSize(key)) {
+				break;
+			}
+			uint64_t result = down->second.average(true);
+			if (result != MIN_TIME) {
+				downDistance = size - down->first.size;
+				downEstimate = estimateForNewSize(down->first.size, result, size);
+				break;
+			}
+		}
+	}
+
+	if (upDistance == maxDistance && downDistance == maxDistance) {
+		return MIN_TIME;
+	}
+
+	if (downDistance < upDistance) {
+		//fprintf(stderr, "Using close down estimate for %s(%d) on %d:%d (%zd bytes, distance %zd) will take %" PRIu64 " us\n", codelet->name, impl, archtype, devid, size, downDistance, downEstimate);
+		return downEstimate;
+	} else {
+		//fprintf(stderr, "Using close up estimate for %s(%d) on %d:%d (%zd bytes, distance %zd) will take %" PRIu64 " us\n", codelet->name, impl, archtype, devid, size, upDistance, upEstimate);
+		return upEstimate;
+	}
+}
+
+void timing::load(const char *name) noexcept {
+	FILE* file = fopen(name, "r");
+	if (file == nullptr) {
+		return;
+	}
+
+	std::lock_guard<std::mutex> lg(lock);
+	timings.clear();
+
+	int line = 0;
+	while (!feof(file)) {
+		line++;
+		char codeletName[128];
+		size_t size;
+		unsigned impl, archtype, devid;
+		uint32_t timing;
+
+		int read = fscanf(file, "%127s %zd %u %u %u %" PRIu32 "\n", codeletName, &size, &impl, &archtype, &devid, &timing);
+		if (read <= 0) {
+			// ok, normal failure
+			continue;
+		}
+		if (read != 6) {
+			// WEIRD
+			fprintf(stderr, "Invalid format on line %d\n", line);
+			continue;
+		}
+
+		auto key = timing_key { strdup(codeletName), size, (uint32_t) impl, (starpu_worker_archtype) archtype, (uint16_t) devid };
+		timings[key].fill(timing);
+	}
+
+	fclose(file);
+}
+
+void timing::save(const char *name) {
+	FILE* file = fopen(name, "w");
+	if (file == nullptr) {
+		perror("Failed to save timings");
+		return;
+	}
+
+	std::lock_guard<std::mutex> lg(lock);
+	for (auto it: timings) {
+		uint64_t average = it.second.average(false);
+		if (average <= MIN_TIME) {
+			// Don't store anecdotal evidence
+			continue;
+		}
+		fprintf(file, "%s %zd %u %u %u %" PRIu64 "\n", it.first.codelet_name, it.first.size, it.first.impl, it.first.device.device_type, it.first.device.device_id, average);
+	}
+	fclose(file);
+}
+
+void timing_data::add(double us) {
+	timings[next] = sanitize_time(us);
+	if (next + 1 > count) {
+		count = next + 1;
+	}
+	next = (next + 1u) & ((1u << TIMING_COUNT_POW) - 1);
+	dirty = true;
+}
+
+void timing_data::fill(uint32_t us) {
+	// Fill half of the timings only
+	count = 1u << (TIMING_COUNT_POW - 1u);
+	for (int i = 0; i < count; ++i) {
+		timings[i] = us;
+	}
+	next = count;
+	dirty = false;
+}
+
+uint64_t timing_data::average(bool onlyProven) {
+	if (count <= 0) {
+		// No info
+		return MIN_TIME;
+	}
+
+	if (onlyProven && count <= 2) {
+		// Can't be sure yet
+		return MIN_TIME;
+	}
+
+	if (dirty) {
+		dirty = false;
+		std::sort(std::begin(timings), std::begin(timings) + count);
+	}
+
+	// Actually just a mean
+	return timings[count / 2];
+}

--- a/src/xmipp/libraries/reconstruction_starpu/reconstruct_fourier_timing.h
+++ b/src/xmipp/libraries/reconstruction_starpu/reconstruct_fourier_timing.h
@@ -1,0 +1,111 @@
+#ifndef XMIPP_RECONSTRUCT_FOURIER_TIMING_H
+#define XMIPP_RECONSTRUCT_FOURIER_TIMING_H
+
+#include <cstdint>
+#include <limits>
+#include <cmath>
+#include <map>
+#include <mutex>
+
+#define STARPU_DONT_INCLUDE_CUDA_HEADERS
+#include <starpu.h>
+#undef STARPU_DONT_INCLUDE_CUDA_HEADERS
+
+/** A large amount of time (in microseconds) to prevent overflows for ridiculously slow tasks. */
+static const uint32_t MAX_TIME = std::numeric_limits<uint32_t>::max();// little over 1 hour
+static const uint32_t MIN_TIME = 1;
+
+static inline uint64_t sanitize_time(double microseconds) {
+	if (microseconds < MIN_TIME) {
+		return MIN_TIME;
+	} else if (microseconds > MAX_TIME) {
+		return MAX_TIME;
+	} else if (isnan(microseconds)) {
+		// Not calibrated yet: We need a small value to force the calibration to run,
+		// but not zero, because that will cause it to be always used.
+		return MIN_TIME;
+	} else {
+		return (uint64_t) microseconds;
+	}
+}
+
+struct timing_data {
+	static const uint8_t TIMING_COUNT_POW = 6;
+
+	uint32_t timings[1u << TIMING_COUNT_POW] = {0};
+	uint8_t count = 0;
+	uint8_t next = 0;
+	bool dirty = true;
+
+	void add(double us);
+
+	void fill(uint32_t us);
+
+	uint64_t average(bool onlyProven);
+};
+
+struct timing_device_key {
+	uint16_t device_type;
+	uint16_t device_id;
+
+	timing_device_key():device_type(0), device_id(0) {}
+
+	timing_device_key(starpu_worker_archtype device_type, uint16_t device_id)
+	: device_type(device_type), device_id(device_type == starpu_worker_archtype::STARPU_CPU_WORKER ? -1 : device_id) {}
+
+	uint32_t key() const {
+		return ((uint32_t)device_type << 16u) | device_id;
+	}
+};
+
+inline bool operator<(const timing_device_key& a, const timing_device_key& b) {
+	return a.key() < b.key();
+}
+inline bool operator==(const timing_device_key& a, const timing_device_key& b) {
+	return a.key() == b.key();
+}
+inline bool operator!=(const timing_device_key& a, const timing_device_key& b) {
+	return a.key() != b.key();
+}
+
+struct timing_key {
+	const char* const codelet_name;
+	const uint32_t impl;
+	const timing_device_key device;
+	const size_t size;
+
+	timing_key(const char* codelet_name, size_t size, uint32_t impl, starpu_worker_archtype device_type, uint16_t device_id)
+	: codelet_name(codelet_name), size(size), impl(impl), device(device_type, device_id) {}
+
+	uint64_t key() const {
+		return ((uint64_t)impl << 32u) | (uint64_t)device.key();
+	}
+
+	bool equalsExceptSize(const timing_key& other) const {
+		return strcmp(codelet_name, other.codelet_name) == 0 && key() == other.key();
+	}
+};
+inline bool operator<(const timing_key& a, const timing_key& b) {
+	int name = strcmp(a.codelet_name, b.codelet_name);
+	return name < 0
+	|| (name == 0 && a.key() < b.key())
+	|| (name == 0 && a.key() == b.key() && a.size < b.size);
+}
+inline bool operator==(const timing_key& a, const timing_key& b) {
+	return strcmp(a.codelet_name, b.codelet_name) == 0 && a.size == b.size && a.key() == b.key();
+}
+
+struct timing {
+	std::map<timing_key, timing_data> timings;
+	std::mutex lock;
+
+	void record(starpu_codelet* codelet, unsigned impl, starpu_worker_archtype archtype, int devid, size_t size, double microseconds);
+
+	double estimate(starpu_codelet* codelet, unsigned impl, starpu_worker_archtype archtype, int devid, size_t size);
+
+	void load(const char* name) noexcept;
+
+	void save(const char* name);
+};
+
+#endif //XMIPP_RECONSTRUCT_FOURIER_TIMING_H

--- a/src/xmipp/libraries/reconstruction_starpu/reconstruct_fourier_util.h
+++ b/src/xmipp/libraries/reconstruction_starpu/reconstruct_fourier_util.h
@@ -1,0 +1,88 @@
+/***************************************************************************
+ *
+ * Authors:     Jan Polak (456647@mail.muni.cz)
+ *
+ * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ * 02111-1307  USA
+ *
+ *  All comments concerning this program package may be sent to the
+ *  e-mail address 'xmipp@cnb.csic.es'
+ ***************************************************************************/
+
+#ifndef XMIPP_LIBRARIES_RECONSTRUCT_FOURIER_UTIL_H_
+#define XMIPP_LIBRARIES_RECONSTRUCT_FOURIER_UTIL_H_
+
+#include <cstdint>
+
+/**
+ * Default alignment of most StarPU buffers. Required mostly by FFTW, which mentions the need for 16 byte alignment,
+ * but does not specify any upper bound. So, just to be sure, we require 32 byte alignment.
+ * http://fftw.org/fftw3_doc/SIMD-alignment-and-fftw_005fmalloc.html
+ */
+const uint32_t ALIGNMENT = 32;
+
+inline uint32_t alignmentOf(size_t ptr) {
+	uintptr_t p = (uintptr_t) ptr;
+	uint32_t alignment = 1;
+	while (true) {
+		uint32_t nextAlignment = alignment << 1;
+		if (nextAlignment == 0)
+			break;
+		if ((p & nextAlignment) != 0)
+			return nextAlignment;
+		alignment = nextAlignment;
+	}
+	return alignment;
+}
+
+inline uint32_t alignmentOf(void * ptr) {
+	return alignmentOf((size_t) ptr);
+}
+
+template<typename T>
+inline T align(T number, uint32_t alignment) {
+	T off = number % alignment;
+	if (off == 0) {
+		return number;
+	} else {
+		return number + alignment - off;
+	}
+}
+
+#ifdef __GNUC__
+#  define XMIPP_ASSUME_ALIGNED(ptr, bytes) (__builtin_assume_aligned(ptr, bytes))
+#else
+#  define XMIPP_ASSUME_ALIGNED(ptr, bytes) (ptr)
+#endif
+
+/** Wrap calls to error-returning StarPU functions with this to error on non-zero values. */
+#define CHECK_STARPU(operationWithReturnCode) do {\
+	int check_result = (operationWithReturnCode);\
+	STARPU_CHECK_RETURN_VALUE(check_result, #operationWithReturnCode);\
+} while (0)
+
+/** Wrap calls to error-returning MPI functions with this to error on non-zero values. */
+#define CHECK_MPI(operationWithReturnCode) do {\
+	int check_result = (operationWithReturnCode);\
+	if (STARPU_UNLIKELY(check_result != 0)) {\
+        fprintf(stderr, "Unexpected value: <%d> returned for %s\n", check_result, #operationWithReturnCode);\
+        fprintf(stderr, "[abort][%s:%d]\n", __FILE__, __LINE__);\
+        STARPU_DUMP_BACKTRACE(); _starpu_abort();\
+	}}while(0)
+
+
+#endif //XMIPP_LIBRARIES_RECONSTRUCT_FOURIER_UTIL_H_

--- a/src/xmipp/libraries/reconstruction_starpu/util/queue_bag.h
+++ b/src/xmipp/libraries/reconstruction_starpu/util/queue_bag.h
@@ -1,0 +1,307 @@
+#ifndef XMIPP_QUEUE_BAG_H
+#define XMIPP_QUEUE_BAG_H
+
+#include <vector>
+#include <type_traits>
+
+#define RFS_QUEUE_BAG_RUN_TESTS 0
+
+namespace rfs {
+
+	void testQueueBag();
+
+	/**
+	 * A circular queue with relaxed ordering requirements.
+	 * Some operations may change the order of queued elements for performance.
+	 * This is always mentioned in the documentation.
+	 *
+	 * @tparam T any trivially copyable type
+	 */
+	template<typename T>
+	class queue_bag {
+		static_assert(std::is_trivially_copyable<T>::value,
+		              "queue_bag is designed only for trivially copyable elements");
+
+	private:
+		/** Contains the values in the queue. Head and tail indices go in a circle around this array, wrapping at the end. */
+		T *elements = nullptr;
+		size_t elementsCapacity = 0;
+
+		/** Index of first element. Logically smaller than tail. Unless empty, it points to a valid element inside queue. */
+		size_t head = 0;
+		/** Index of last element. Logically bigger than head. Usually points to an empty position, but points to the head when full
+		 * (size == values.length). */
+		size_t tail = 0;
+		/** Number of elements in the queue. */
+		size_t size = 0;
+
+		size_t internalIndex(size_t externalIndex) const {
+			assert(size > 0);
+			assert(externalIndex < size);
+			size_t index = head + externalIndex;
+			if (index >= elementsCapacity) {
+				index -= elementsCapacity;
+			}
+			return index;
+		}
+
+	public:
+
+#if RFS_QUEUE_BAG_RUN_TESTS
+		queue_bag() {
+			testQueueBag();
+		}
+#endif
+
+		/** Append given object to the tail. (enqueue to tail) Unless backing array needs resizing, operates in O(1) time.
+		 * @param object can be null */
+		void addLast(T object) noexcept {
+			if (size == elementsCapacity) {
+				resize(elementsCapacity * 2);
+			}
+
+			elements[tail++] = object;
+			if (tail == elementsCapacity) {
+				tail = 0;
+			}
+			size++;
+		}
+
+		/** Prepend given object to the head. (enqueue to head) Unless backing array needs resizing, operates in O(1) time.
+		 * @see #addLast(Object)
+		 * @param object can be null */
+		void addFirst(T object) noexcept {
+			if (size == elementsCapacity) {
+				resize(elementsCapacity * 2);
+			}
+
+			if (head == 0) {
+				head = elementsCapacity - 1;
+			} else {
+				head--;
+			}
+			elements[head] = object;
+			size++;
+		}
+
+		/** Increases the size of the backing array to accommodate the specified number of additional items.
+		 * Useful before adding many items to avoid multiple backing array resizes. */
+		void ensureCapacity(size_t additional) noexcept {
+			size_t needed = size + additional;
+			if (elementsCapacity < needed) {
+				resize(needed);
+			}
+		}
+
+		/** Resize backing array. newSize must be bigger than current size. */
+		void resize(int newSize) noexcept {
+			if (newSize < 32) {
+				newSize = 32;
+			}
+			assert(newSize > elementsCapacity);
+
+			T *newArray = (T*)malloc(sizeof(T) * newSize);
+			if (head < tail) {
+				// Continuous
+				memcpy(newArray, elements + head, sizeof(T) * size);
+			} else if (size > 0) {
+				// Wrapped
+				size_t rest = elementsCapacity - head;
+				assert(rest + tail == size);
+				memcpy(newArray, elements + head, sizeof(T) * rest);
+				memcpy(newArray + rest, elements, sizeof(T) * tail);
+			}
+
+			free(elements);
+			elements = newArray;
+			elementsCapacity = newSize;
+			head = 0;
+			tail = size;
+		}
+
+		/** Remove the first item from the queue. Always O(1).
+		 * Undefined behavior when empty.
+		 * @return removed object */
+		T removeFirst() noexcept {
+			assert(size > 0);
+
+			size_t index = head;
+			head++;
+			if (head == elementsCapacity) {
+				head = 0;
+			}
+			size--;
+
+			return elements[index];
+		}
+
+		/** Remove the last item from the queue. Always O(1).
+		 * Undefined behavior when empty.
+		 * @return removed object */
+		T removeLast() noexcept {
+			assert(size > 0);
+
+			if (tail == 0) {
+				tail = elementsCapacity - 1;
+			} else {
+				tail--;
+			}
+			size--;
+			return elements[tail];
+		}
+
+		/** Removes and returns the item at the specified index.
+		 * Does not maintain any order - unless the element is first or last, the last element will take its place,
+		 * eliminating copies.
+		 * Undefined behavior when index is out of valid range [0, size). */
+		T removeIndex(int index) noexcept {
+			assert(index >= 0);
+			assert(index < size);
+
+			if (index == 0) {
+				return removeFirst();
+			} else if (index + 1 == size) {
+				return removeLast();
+			} else {
+				// Remove last, put it in place of this one
+				size_t elementsIndex = internalIndex(index);
+				T result = elements[elementsIndex];
+				elements[elementsIndex] = removeLast();
+				return result;
+			}
+		}
+
+		size_t getSize() const noexcept {
+			return size;
+		}
+
+		/** Returns true if the queue is empty. */
+		bool empty() const noexcept {
+			return size == 0;
+		}
+
+		/** Returns the first (head) item in the queue (without removing it).
+		 * Undefined behavior when empty. */
+		const T &first() const noexcept {
+			return elements[internalIndex(0)];
+		}
+
+		T &first() noexcept {
+			return elements[internalIndex(0)];
+		}
+
+		/** Returns the last (tail) item in the queue (without removing it).
+		 * Undefined behavior when empty. */
+		const T &last() const noexcept {
+			return elements[internalIndex(size - 1)];
+		}
+
+		T &last() noexcept {
+			return elements[internalIndex(size - 1)];
+		}
+
+		/** Retrieves the value in queue without removing it. Indexing is from the front to back, zero based. Therefore get(0) is the
+		 * same as {@link #first()}.
+		 * Undefined behavior when index is out of valid range [0, size). */
+		const T &operator[](int index) const noexcept {
+			return elements[internalIndex(index)];
+		}
+
+		T &operator[](int index) noexcept {
+			return elements[internalIndex(index)];
+		}
+
+		~queue_bag() {
+			free(elements);
+		}
+	};
+
+	/** Iterate through queue_bag until all elements are consumed or until consumer returns false. */
+	template<typename T, typename Consumer>
+	void forEach(queue_bag<T>& queue, Consumer consumer) {
+		for (size_t i = 0; i < queue.getSize(); ++i) {
+			if (!consumer(queue[i])) {
+				return;
+			}
+		}
+	}
+
+	enum class RemoveResult {
+		KeepContinue,
+		KeepBreak,
+		RemoveContinue,
+		RemoveBreak
+	};
+
+	/**
+	 * Does bulk removal of elements from queue_bag. Removes only those elements, which match the predicate.
+	 * @tparam Predicate lambda that takes T& and returns RemoveResult
+	 * @return amount of removed items
+	 */
+	template<typename T, typename Predicate>
+	size_t removeMatching(queue_bag<T>& queue, Predicate predicate) {
+		size_t removed = 0;
+		size_t i = 0;
+		while (i < queue.getSize()) {
+			RemoveResult res = predicate(queue[i]);
+			if (res == RemoveResult::RemoveContinue || res == RemoveResult::RemoveBreak) {
+				queue.removeIndex(i);
+			} else {
+				i++;
+			}
+
+			if (res == RemoveResult::KeepBreak || res == RemoveResult::RemoveBreak) {
+				break;
+			}
+		}
+		return removed;
+	}
+
+#if RFS_QUEUE_BAG_RUN_TESTS
+	inline void testQueueBag() {
+		static bool tested = false;
+		if (tested) {
+			return;
+		}
+		tested = true;
+
+		queue_bag<int> queue;
+		queue.addFirst(42);
+		int stairs = 20;
+
+		for (int i = 0; i < stairs; ++i) {
+			queue.addFirst(i);
+			queue.addLast(i);
+			assert(queue.first() == i);
+			assert(queue.last() == i);
+			assert(queue[queue.getSize() / 2] == 42);
+		}
+
+		for (int i = 0; i < stairs; ++i) {
+			assert(queue[i] == stairs - 1 - i);
+			assert(queue[stairs + 1 + i] == i);
+		}
+
+		int stairCheckIndex = 0;
+		forEach(queue, [&stairCheckIndex, stairs](const int value){
+			if (stairCheckIndex < stairs) {
+				assert(value == stairs - 1 - stairCheckIndex);
+			} else if (stairCheckIndex == stairs) {
+				assert(value == 42);
+			} else {
+				assert(stairCheckIndex - stairs - 1 == value);
+			}
+			stairCheckIndex++;
+			return true;
+		});
+
+		for (int i = stairs-1; i >= 0; --i) {
+			assert(queue.removeFirst() == i);
+			assert(queue.removeLast() == i);
+		}
+		assert(queue.removeFirst() == 42);
+	}
+#endif
+}
+
+#endif //XMIPP_QUEUE_BAG_H

--- a/xmipp
+++ b/xmipp
@@ -439,7 +439,9 @@ def createEmptyConfig():
               'LINKFLAGS','PYTHONINCFLAGS','MPI_CC','MPI_CXX','MPI_LINKERFORPROGRAMS','MPI_CXXFLAGS',
               'MPI_LINKFLAGS','NVCC','CXX_CUDA','NVCC_CXXFLAGS','NVCC_LINKFLAGS',
               'MATLAB_DIR','CUDA','DEBUG','MATLAB','OPENCV','OPENCVSUPPORTSCUDA','OPENCV3',
-              'JAVA_HOME','JAVA_BINDIR','JAVAC','JAR','JNI_CPPPATH', 'USE_DL', 'VERIFIED', 'CONFIG_VERSION']
+              'JAVA_HOME','JAVA_BINDIR','JAVAC','JAR','JNI_CPPPATH',
+              'STARPU', 'STARPU_HOME', 'STARPU_INCLUDE', 'STARPU_LIB', 'STARPU_LIBRARY',
+              'USE_DL', 'VERIFIED', 'CONFIG_VERSION']
     configDict = {}
     for label in labels:
         configDict[label]=""
@@ -862,6 +864,54 @@ def checkMatlab(configDict):
         runJob("rm xmipp_mex*")
     return ans
 
+def configStarPU(configDict):
+    # TODO(Jan Polak): This check would be probably better done with pkg-config
+    if configDict["STARPU"]=="":
+        if checkProgram("starpu_sched_display", show=False): # Heuristic only, StarPU has no main executable
+            configDict["STARPU"]="True"
+        else:
+            configDict["STARPU"]="False"
+    if configDict["STARPU"]=="True":
+        if configDict["STARPU_HOME"]=="" and checkProgram("starpu_sched_display"):
+            starpuBinDir = os.path.dirname(os.path.realpath(distutils.spawn.find_executable("starpu_sched_display")))
+            configDict["STARPU_HOME"] = starpuBinDir.replace("/bin","")
+    if configDict["STARPU_INCLUDE"]=="":
+        configDict["STARPU_INCLUDE"] = "%(STARPU_HOME)s/include/starpu/1.3"
+    if configDict["STARPU_LIB"]=="":
+        configDict["STARPU_LIB"] = "%(STARPU_HOME)s/lib"
+    if configDict["STARPU_LIBRARY"]=="":
+        configDict["STARPU_LIBRARY"] = "libstarpu-1.3"
+
+def checkStarPU(configDict):
+    ans = True
+    if configDict["STARPU"] == "True":
+        if configDict["CUDA"] != "True":
+            ans = False
+            print(red("CUDA must be enabled together with STARPU"))
+        if configDict["STARPU_INCLUDE"] == "" or not os.path.isdir(configDict["STARPU_INCLUDE"]):
+            ans = False
+            print(red("Check the STARPU_INCLUDE directory: " + configDict["STARPU_INCLUDE"]))
+        if configDict["STARPU_LIB"] == "" or not os.path.isdir(configDict["STARPU_LIB"]):
+            ans = False
+            print(red("Check the STARPU_LIB directory: " + configDict["STARPU_LIB"]))
+        if configDict["STARPU_LIBRARY"] == "":
+            ans = False
+            print(red("STARPU_LIBRARY must be specified (link library name)"))
+
+        if ans:
+            with open("xmipp_starpu_config_test.cpp", "w") as cppFile:
+                cppFile.write("""
+                #include <starpu.h>
+                int dummy(){}
+                """)
+
+            if not runJob("%s -c -w %s %s -I%s -L%s -l%s xmipp_starpu_config_test.cpp -o xmipp_starpu_config_test.o"% \
+                    (configDict["NVCC"], configDict["NVCC_CXXFLAGS"], configDict["INCDIRFLAGS"],
+                     configDict["STARPU_INCLUDE"], configDict["STARPU_LIB"], configDict["STARPU_LIBRARY"])):
+                print(red("Check STARPU_* settings"))
+                ans = False
+            runJob("rm xmipp_starpu_config_test*")
+    return ans
 
 def writeConfig(configDict):
     with open(CONFIG_FILE_NAME, "w") as configFile:
@@ -911,6 +961,7 @@ def config():
     configJava(new_config_dict)
     configCuda(new_config_dict)
     configMatlab(new_config_dict)
+    configStarPU(new_config_dict)
     config_DL(new_config_dict)
     configConfigVersion(new_config_dict)
 
@@ -948,6 +999,9 @@ def checkConfig():
         if not checkMatlab(configDict):
             print(red("Cannot compile with Matlab, continuing without Matlab"))
             newConf["MATLAB"]="False"
+        if not checkStarPU(configDict):
+            print(red("Cannot compile with StarPU, continuing without StarPU"))
+            newConf["STARPU"]="False"
         newConf['VERIFIED']="True"
         updateConfig(newConf)
     return True


### PR DESCRIPTION
This represents results of my [bachelor's thesis](https://is.muni.cz/th/yd64s/). I still plan to do some cleanups in the code (removing CTF code, etc.), hence this is still a draft.

Feel free to review, especially the configuration code in `./xmipp` and `src/xmipp/SConscipt`.
Code in `./xmipp` has been added to detect installed StarPU through an executable in `PATH`, but this isn't ideal, since there is no requirement to have it in the `PATH` and many users won't, since StarPU is primarily a library and its executables are just minor support tools.

Relying on StarPU from system's package manager could also be possible, but those are often outdated and don't always include CUDA support (and when they do, they are compiled against too recent CUDA versions, i.e. CUDA 9, while `./xmipp` expects CUDA 8 at most). Either way, the support for custom StarPU installation should be kept, as some users/developers will want to use a custom StarPU variant, compiled with different limits, profiling enabled, etc.