### PR TITLE
versioning the config file

### DIFF
--- a/xmipp
+++ b/xmipp
@@ -987,8 +987,9 @@ def compile_cuFFTAdvisor():
 def compile(Nproc):
     ensureConfig()
     ensureConfigVersion(configDict)
-    compileDependencies(Nproc)
-    compileXmipp(Nproc)
+    if not compileDependencies(Nproc):
+        return False
+    return compileXmipp(Nproc)
 
 
 def compileDependencies(Nproc):

--- a/xmipp
+++ b/xmipp
@@ -50,6 +50,7 @@ CUFFTADVISOR = 'cuFFTAdvisor'
 MICROGRAPH_CLEANER= 'micrograph_cleaner_em'
 CTPL = 'CTPL'
 
+XMIPP_SCRIPT_VERSION = ''
 
 REPOSITORIES = {XMIPP: 'https://github.com/I2PC/xmipp.git',
                 XMIPP_CORE : 'https://github.com/I2PC/xmippCore.git',
@@ -438,7 +439,7 @@ def createEmptyConfig():
               'LINKFLAGS','PYTHONINCFLAGS','MPI_CC','MPI_CXX','MPI_LINKERFORPROGRAMS','MPI_CXXFLAGS',
               'MPI_LINKFLAGS','NVCC','CXX_CUDA','NVCC_CXXFLAGS','NVCC_LINKFLAGS',
               'MATLAB_DIR','CUDA','DEBUG','MATLAB','OPENCV','OPENCVSUPPORTSCUDA','OPENCV3',
-              'JAVA_HOME','JAVA_BINDIR','JAVAC','JAR','JNI_CPPPATH', 'USE_DL', 'VERIFIED']
+              'JAVA_HOME','JAVA_BINDIR','JAVAC','JAR','JNI_CPPPATH', 'USE_DL', 'VERIFIED', 'CONFIG_VERSION']
     configDict = {}
     for label in labels:
         configDict[label]=""
@@ -880,6 +881,19 @@ def config_DL(configDict):
         configDict[k] = 'False'
 
 
+def configConfigVersion(configDict):
+    key = 'CONFIG_VERSION'
+    configDict[key] = getScriptVersion()
+
+
+def ensureConfigVersion(configDict):
+    key = 'CONFIG_VERSION'
+    if key not in configDict or configDict[key] != XMIPP_SCRIPT_VERSION:
+        print(red('We did some changes which are not compatible with your current config file. '
+                  'We recommend you to create a backup before regenerating it (use --help for additional info)'))
+        exit(-1)
+
+
 def config():
     print("Configuring -----------------------------------------")
     new_config_dict = createEmptyConfig()
@@ -897,6 +911,7 @@ def config():
     configCuda(new_config_dict)
     configMatlab(new_config_dict)
     config_DL(new_config_dict)
+    configConfigVersion(new_config_dict)
 
     writeConfig(new_config_dict)
 
@@ -969,6 +984,13 @@ def compile_cuFFTAdvisor():
     return ok and runJob("cp " + advisorDir + "build/libcuFFTAdvisor.so" + " " + libDir)
 
 
+def compile(Nproc):
+    ensureConfig()
+    ensureConfigVersion(configDict)
+    compileDependencies(Nproc)
+    compileXmipp(Nproc)
+
+
 def compileDependencies(Nproc):
     print("Building Dependencies -------------------------------------")
     result = True
@@ -979,9 +1001,8 @@ def compileDependencies(Nproc):
     return result
 
 
-def compile(Nproc):
+def compileXmipp(Nproc):
     print("Compiling -------------------------------------------")
-    ensureConfig()
     if not compileModule(Nproc,"xmippCore"):
         return False
     if not compileModule(Nproc,"xmipp"):
@@ -1368,9 +1389,19 @@ def ensureGit():
         return False
     return True
 
+
+def getScriptVersion():
+    scriptName = os.path.basename(__file__)
+    lastCommit = []
+    # get hash of the last commit changing this script
+    runJob('git log -n 1 --pretty=format:%H -- ' + scriptName, '.', False, lastCommit, False)
+    return lastCommit[0].strip()
+
 if __name__ == '__main__':
     # I comment this line to avoid problems if this script is run in XmippBundle/src/xmipp  or directly from XmippBundle/.
     # os.chdir(os.path.dirname(os.path.abspath(__file__)))
+
+    XMIPP_SCRIPT_VERSION = getScriptVersion()
 
     if not ensureGit():
         sys.exit(-1)
@@ -1423,11 +1454,11 @@ if __name__ == '__main__':
             sys.exit(1)
     elif mode=="compile":
         Nproc = 8 if n<3 else sys.argv[2]
-        compileDependencies(Nproc)
         if n<=3:
             ok = compile(Nproc)
             module = 'Xmipp'
         else:
+            compileDependencies(Nproc)
             ok = compileModule(Nproc,sys.argv[3])
             module = sys.argv[3]
         if ok:
@@ -1443,7 +1474,6 @@ if __name__ == '__main__':
             Nproc=sys.argv[2]
         else:
             Nproc=8
-        compileDependencies(Nproc)
         compile(Nproc)
         install("build")
     elif mode=="install":
@@ -1481,7 +1511,6 @@ if __name__ == '__main__':
             and downloadDeepLearningModels('build')
             and getDependencies()
             and getSources(branch)
-            and compileDependencies(Nproc)
             and compile(Nproc)
             and install('build'))
         if ok:


### PR DESCRIPTION
This PR add a versioning to the config file. 
Should it be incompatible to the current version of the xmipp script, the compilation will terminate prematurely and user has to regenerate the config file.
This will ensure that should we add e.g. new compile flag, user will be aware of it.