### PR TITLE
Introduced MPI version of nma_aligmnemt_vol program 

### DIFF
--- a/src/xmipp/applications/programs/mpi_nma_alignment_vol/mpi_nma_alignment_vol_main.cpp
+++ b/src/xmipp/applications/programs/mpi_nma_alignment_vol/mpi_nma_alignment_vol_main.cpp
@@ -1,0 +1,29 @@
+/***************************************************************************
+ *
+ * Authors:  Mohamad Harastani mohamad.harastani@upmc.fr
+ *	     Slavica Jonic slavica.jonic@upmc.fr
+ *           Carlos Oscar Sanchez Sorzano coss.eps@ceu.es
+ *
+ * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+ * Lab. de Bioingenieria, Univ. San Pablo CEU
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ * 02111-1307  USA
+ *
+ *  All comments concerning this program package may be sent to the
+ *  e-mail address 'xmipp@cnb.uam.es'
+ ***************************************************************************/
+#include <parallel/mpi_nma_alignment_vol.h>
+RUN_XMIPP_PROGRAM(MpiProgNMAVol)

--- a/src/xmipp/libraries/parallel/mpi_nma_alignment_vol.cpp
+++ b/src/xmipp/libraries/parallel/mpi_nma_alignment_vol.cpp
@@ -1,0 +1,106 @@
+/***************************************************************************
+ *
+ * Authors:  Mohamad Harastani mohamad.harastani@upmc.fr
+ *	         Slavica Jonic slavica.jonic@upmc.fr
+ *           Carlos Oscar Sanchez Sorzano coss.eps@ceu.es
+ *
+ * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+ * Lab. de Bioingenieria, Univ. San Pablo CEU
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ * 02111-1307  USA
+ *
+ *  All comments concerning this program package may be sent to the
+ *  e-mail address 'xmipp@cnb.uam.es'
+ ***************************************************************************/
+#include "mpi_nma_alignment_vol.h"
+
+// Redefine read to initialize MPI environment =======================
+void MpiProgNMAVol::read(int argc, char **argv)
+{
+	node = std::make_shared<MpiNode>(argc, argv);
+	if (!node->isMaster())
+		verbose=0;
+	fileMutex = std::make_shared<MpiFileMutex>(node.get());
+	ProgNmaAlignmentVol::read(argc, argv);
+}
+
+
+// Main body ==========================================================
+void MpiProgNMAVol::createWorkFiles()
+{
+	//Master node should prepare some stuff before start working
+	MetaData &mdIn = *getInputMd(); //get a reference to input metadata
+	const char* list_of_volumes = "/nmaTodo.xmd";
+	if (node->isMaster()){
+		ProgNmaAlignmentVol::createWorkFiles();
+		mdIn.write(fnOutDir + list_of_volumes);
+	}
+	node->barrierWait();//Sync all before start working
+	mdIn.read(fnOutDir + list_of_volumes);
+	mdIn.findObjects(imgsId);//get objects ids
+	distributor = std::make_shared<MpiTaskDistributor>(mdIn.size(), 1, node.get());
+}
+
+
+// Only master do starting progress bar stuff
+void MpiProgNMAVol::startProcessing()
+{
+	if (node->isMaster())
+		ProgNmaAlignmentVol::startProcessing();
+}
+
+//Only master show progress
+void MpiProgNMAVol::showProgress()
+{
+	if (node->isMaster())
+		ProgNmaAlignmentVol::showProgress();
+}
+
+// Now use the distributor to grasp images
+bool MpiProgNMAVol::getImageToProcess(size_t &objId, size_t &objIndex)
+{
+	size_t first;
+	size_t last;
+	bool moreTasks = distributor->getTasks(first, last);
+
+	if (moreTasks){
+		time_bar_done = first + 1;
+		objIndex = first;
+		objId = imgsId[first];
+		return true;
+	}
+	time_bar_done = getInputMd()->size();
+	objId = BAD_OBJID;
+	objIndex = BAD_INDEX;
+	return false;
+}
+
+void MpiProgNMAVol::finishProcessing()
+{
+	distributor->wait();
+	//All nodes wait for each other
+	node->barrierWait();
+	if (node->isMaster())
+		ProgNmaAlignmentVol::finishProcessing();
+	node->barrierWait();
+}
+
+void MpiProgNMAVol:: writeVolumeParameters(const FileName &fnImg)
+{
+	fileMutex->lock();
+	ProgNmaAlignmentVol::writeVolumeParameters(fnImg);
+	fileMutex->unlock();
+}

--- a/src/xmipp/libraries/parallel/mpi_nma_alignment_vol.h
+++ b/src/xmipp/libraries/parallel/mpi_nma_alignment_vol.h
@@ -1,0 +1,62 @@
+/***************************************************************************
+ *
+ * Authors:  Mohamad Harastani mohamad.harastani@upmc.fr
+ *	         Slavica Jonic slavica.jonic@upmc.fr
+ *           Carlos Oscar Sanchez Sorzano coss.eps@ceu.es
+ *
+ * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+ * Lab. de Bioingenieria, Univ. San Pablo CEU
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ * 02111-1307  USA
+ *
+ *  All comments concerning this program package may be sent to the
+ *  e-mail address 'xmipp@cnb.uam.es'
+ ***************************************************************************/
+
+#include <parallel/xmipp_mpi.h>
+#include <reconstruction/nma_alignment_vol.h>
+#include <memory>
+
+/** Class to perform the NMA Alignment for volumes with  MPI parallelization */
+class MpiProgNMAVol: public ProgNmaAlignmentVol
+{
+private:
+    std::shared_ptr<MpiNode> node;
+    std::shared_ptr<MpiTaskDistributor> distributor;
+    std::shared_ptr<MpiFileMutex> fileMutex;
+    std::vector<size_t> imgsId;
+
+    // main body
+    void createWorkFiles();
+    
+    //Only master do starting progress bar stuff
+    void startProcessing();
+    
+    //Only master show progress
+    void showProgress();
+    
+    //Now use the distributor to grasp volumes
+    bool getImageToProcess(size_t &objId, size_t &objIndex);
+
+    void finishProcessing();
+
+    void writeVolumeParameters(const FileName &fnImg);
+
+public:
+    // Redefine read to initialize MPI environment
+    void read(int argc, char **argv);
+}
+;//end of class MpiProgNMAVol

--- a/src/xmipp/libraries/reconstruction/nma_alignment_vol.cpp
+++ b/src/xmipp/libraries/reconstruction/nma_alignment_vol.cpp
@@ -26,12 +26,15 @@
 #include <sys/stat.h>
 #include <condor/Solver.h>
 #include <condor/tools.h>
+#include <stdio.h>
 
 #include <core/metadata_extension.h>
 #include <data/filters.h>
 #include "program_extension.h"
 #include "nma_alignment_vol.h"
 
+FILE *AnglesAndShifts;
+float Best_Angles_Shifts[6];
 
 // Empty constructor =======================================================
 ProgNmaAlignmentVol::ProgNmaAlignmentVol() {
@@ -73,6 +76,8 @@ void ProgNmaAlignmentVol::defineParams() {
 	addParamsLine("  [--alignVolumes]                     : Align the deformed volume to the input volume before comparing");
 	addParamsLine("                                       : You need to compile Xmipp with SHALIGNMENT support (see install.sh)");
 	addParamsLine("  [--mask <m=\"\">]                    : 3D masking  of the projections of the deformed volume");
+	addParamsLine("==Mask for compensation for the missing wedge");
+	addParamsLine("  [--m_wedge_mask <filename>]          : File containing a missing wedge mask");
 	addExampleLine("xmipp_nma_alignment_vol -i volumes.xmd --pdb 2tbv.pdb --modes modelist.xmd --sampling_rate 3.2 -o output.xmd --resume");
 }
 
@@ -94,6 +99,10 @@ void ProgNmaAlignmentVol::readParams() {
 	useFixedGaussian = checkParam("--fixed_Gaussian");
 	if (useFixedGaussian)
 		sigmaGaussian = getDoubleParam("--fixed_Gaussian");
+	UseMissingWedgeMask = checkParam("--m_wedge_mask");
+	if (UseMissingWedgeMask)
+		fnMWmask = getParam("--m_wedge_mask");
+
 	alignVolumes=checkParam("--alignVolumes");
 }
 
@@ -129,6 +138,13 @@ void ProgNmaAlignmentVol::createWorkFiles() {
 	{
 		mdDone.addLabel(MDL_IMAGE);
 		mdDone.addLabel(MDL_ENABLED);
+		mdDone.addLabel(MDL_IMAGE);
+		mdDone.addLabel(MDL_ANGLE_ROT);
+		mdDone.addLabel(MDL_ANGLE_TILT);
+		mdDone.addLabel(MDL_ANGLE_PSI);
+		mdDone.addLabel(MDL_SHIFT_X);
+		mdDone.addLabel(MDL_SHIFT_Y);
+		mdDone.addLabel(MDL_SHIFT_Z);
 		mdDone.addLabel(MDL_NMA);
 		mdDone.addLabel(MDL_NMA_ENERGY);
 		mdDone.addLabel(MDL_MAXCC);
@@ -207,11 +223,13 @@ FileName ProgNmaAlignmentVol::createDeformedPDB() const {
 	return fnRandom;
 }
 
-void ProgNmaAlignmentVol::updateBestFit(double fitness, int dim) {
+bool ProgNmaAlignmentVol::updateBestFit(double fitness, int dim) {
 	if (fitness < fitness_min) {
 		fitness_min = fitness;
 		trial_best = trial;
+		return true;
 	}
+	return false;
 }
 
 // Compute fitness =========================================================
@@ -224,10 +242,23 @@ double ObjFunc_nma_alignment_vol::eval(Vector X, int *nerror) {
 
 	FileName fnRandom = global_nma_vol_prog->createDeformedPDB();
 	const char * randStr = fnRandom.c_str();
+	//FileName fnShiftsAngles = formatString("%s_angles_shifts.txt", randStr);
+	FileName fnShiftsAngles = fnRandom + "_angles_shifts.txt" ;
+	const char * shifts_angles = fnShiftsAngles.c_str();
 
-	if (global_nma_vol_prog->alignVolumes)
-		runSystem("xmipp_volume_align",formatString("--i1 %s --i2 %s_deformedPDB.vol --frm --apply -v 0",
-				global_nma_vol_prog->currentVolName.c_str(),fnRandom.c_str()));
+	if (global_nma_vol_prog->alignVolumes){
+		if (global_nma_vol_prog->UseMissingWedgeMask){
+			runSystem("xmipp_volume_align",formatString("--i1 %s --i2 %s_deformedPDB.vol --frm --apply --store %s -v 0 --mask binary_file %s",
+					global_nma_vol_prog->currentVolName.c_str(),fnRandom.c_str(),shifts_angles,global_nma_vol_prog->fnMWmask.c_str()));
+			// Print to check in case of doubt
+			//std::cout << formatString("--i1 %s --i2 %s_deformedPDB.vol --frm --apply --store %s -v 0 --mask binary_file %s",
+			//		global_nma_vol_prog->currentVolName.c_str(),fnRandom.c_str(),shifts_angles,global_nma_vol_prog->fnMWmask.c_str());
+		}
+		else
+			runSystem("xmipp_volume_align",formatString("--i1 %s --i2 %s_deformedPDB.vol --frm --apply --store %s -v 0",
+					global_nma_vol_prog->currentVolName.c_str(),fnRandom.c_str(),shifts_angles));
+	}
+
 	global_nma_vol_prog->Vdeformed.read(formatString("%s_deformedPDB.vol",fnRandom.c_str()));
 	double retval=1e10;
 	if (XSIZE(global_nma_vol_prog->mask)!=0)
@@ -238,9 +269,18 @@ double ObjFunc_nma_alignment_vol::eval(Vector X, int *nerror) {
 	//global_nma_vol_prog->Vdeformed().printStats();
 	//std::cout << correlationIndex(global_nma_vol_prog->V(),global_nma_vol_prog->Vdeformed()) << std::endl;
 
-	runSystem("rm", formatString("-rf %s* &", randStr));
 
-	global_nma_vol_prog->updateBestFit(retval, dim);
+
+
+
+	if(global_nma_vol_prog->updateBestFit(retval, dim)){
+		AnglesAndShifts = fopen(shifts_angles, "r");
+		for (int i = 0; i < 6; i++){
+		       fscanf(AnglesAndShifts, "%f,", &Best_Angles_Shifts[i]);
+		    }
+		fclose(AnglesAndShifts);
+	}
+	runSystem("rm", formatString("-rf %s* &", randStr));
 	//std::cout << global_nma_vol_prog->trial << " -> " << retval << std::endl;
 	return retval;
 }
@@ -303,8 +343,15 @@ void ProgNmaAlignmentVol::writeVolumeParameters(const FileName &fnImg) {
 		vectortemp.push_back(lambdaj);
 		energy+=lambdaj*lambdaj;
 	}
-	energy/=numberOfModes;
 
+
+	energy/=numberOfModes;
+	md.setValue(MDL_ANGLE_ROT, (double)Best_Angles_Shifts[0], objId);
+	md.setValue(MDL_ANGLE_TILT, (double)Best_Angles_Shifts[1], objId);
+	md.setValue(MDL_ANGLE_PSI, (double)Best_Angles_Shifts[2], objId);
+	md.setValue(MDL_SHIFT_X, (double)Best_Angles_Shifts[3], objId);
+	md.setValue(MDL_SHIFT_Y, (double)Best_Angles_Shifts[4], objId);
+	md.setValue(MDL_SHIFT_Z, (double)Best_Angles_Shifts[5], objId);
 	md.setValue(MDL_NMA, vectortemp, objId);
 	md.setValue(MDL_NMA_ENERGY, energy, objId);
 	md.setValue(MDL_MAXCC, 1-parameters(numberOfModes), objId);

--- a/src/xmipp/libraries/reconstruction/nma_alignment_vol.h
+++ b/src/xmipp/libraries/reconstruction/nma_alignment_vol.h
@@ -84,6 +84,13 @@ public:
 
     /// Trust radius scale
     double trustradius_scale;
+
+    /// Use a missing wedge mask
+    bool UseMissingWedgeMask;
+
+    /// Mask file for missing wedge compensation
+    FileName fnMWmask;
+
 public:
 
     // Random generator seed
@@ -145,7 +152,7 @@ public:
     double computeFitness(Matrix1D<double> &trial) const;
 
     /** Update the best fitness and the corresponding best trial*/
-    void updateBestFit(double fitness, int dim);
+    bool updateBestFit(double fitness, int dim);
 
     /** Create the processing working files.
      * The working files are:

--- a/src/xmipp/libraries/reconstruction/volume_align_prog.cpp
+++ b/src/xmipp/libraries/reconstruction/volume_align_prog.cpp
@@ -121,9 +121,9 @@ public:
     double   grey_shift0, grey_shiftF, step_grey_shift;
     int      tell;
     bool     apply;
-    FileName fnOut, fnGeo;
+    FileName fnOut, fnGeo, fnStore;
     bool     mask_enabled;
-    bool     usePowell, onlyShift, useFRM, copyGeo;
+    bool     usePowell, onlyShift, useFRM, copyGeo, store;
     double   maxFreq;
     int      maxShift;
     bool     dontScale;
@@ -158,6 +158,7 @@ public:
         addParamsLine("  [--onlyShift]     : Only shift");
         addParamsLine("  [--dontScale]     : Do not look for scale changes");
         addParamsLine("  [--copyGeo <file=\"\">] : copy transformation matrix in a txt file. ('A' matrix elements)");
+        addParamsLine("  [--store <file=\"\">] : copy angles and shifts to a txt file.");
         addParamsLine(" == Mask Options == ");
         mask.defineParams(this,INT_MASK,NULL,NULL,true);
         addExampleLine("Typically you first look for a rough approximation of the alignment using exhaustive search. For instance, for a global rotational alignment use",false);
@@ -246,6 +247,8 @@ public:
         fnOut = getParam("--apply");
         copyGeo = checkParam("--copyGeo");
         fnGeo = getParam("--copyGeo");
+        store = checkParam("--store");
+        fnStore = getParam("--store");
         dontScale = checkParam("--dontScale");
 
         if (checkParam("--covariance"))
@@ -435,11 +438,12 @@ public:
 
         translation3DMatrix(r,Aaux);
 
-        A = A + Aaux;
-        A(0,0) -= 1;
-        A(1,1) -= 1;
-        A(2,2) -= 1;
-        A(3,3) -= 1;
+        //A = A + Aaux;
+        //A(0,0) -= 1;
+        //A(1,1) -= 1;
+        //A(2,2) -= 1;
+        //A(3,3) -= 1;
+        A = A * Aaux;
 
         scale3DMatrix(vectorR3(best_align(5), best_align(5), best_align(5)),Aaux);
         A = A * Aaux;
@@ -459,6 +463,13 @@ public:
 					  << A(3,0) << "\n" << A(3,1) << "\n" << A(3,2) << "\n" << A(3,3) << "\n"
 					  << std::endl;
         	outputGeo.close();
+        }
+        if (store)
+        {
+        	std::ofstream outputStore (fnStore.c_str());
+        	outputStore << best_align(2)  << ", " << best_align(3) << ", " << best_align(4) << ", " << A(0,3) << ", "
+					  << A(1,3) << ", " << A(2,3) << std::endl;
+        	outputStore.close();
         }
         if (apply)
         {


### PR DESCRIPTION
Additionally some changes were introduced on previous files as follows: 1- On "volume_align_prog" add an option to storing the shifts and angles found by the program. This option stores the shifts and angles that will be later required to align the volume using the program xmipp_transform_geomerty. When the alignment of volumes (rigid body) takes place, now, the 6 alignment parameters (XYZ shifts and 3 Euler angles) are optionally stored in a file. Finally, reverting the change on volume_alignment to display (and store) correct shift parameters. 2- On "nma_alignment_vol" Added an option to use a missing-wedge mask during volume flexible alignment. This option allows to pass this wedge mask to the rigid-body alignment program.