### PR TITLE
Simplify weight processing of reconstruct_fourier variants

### DIFF
--- a/src/xmipp/libraries/reconstruction/reconstruct_fourier_accel.cpp
+++ b/src/xmipp/libraries/reconstruction/reconstruct_fourier_accel.cpp
@@ -950,13 +950,9 @@ void ProgRecFourierAccel::processWeights() {
 		for (int y = 0; y <= maxVolumeIndexYZ; y++) {
 			for (int x = 0; x <= maxVolumeIndexX; x++) {
 				float weight = tempWeights[z][y][x];
-				std::complex<float> val = tempVolume[z][y][x];
-				if (fabs(weight) > 1e-3) {
-					weight = 1.f/weight;
-				}
 
-				if (1.0/weight > ACCURACY)
-					tempVolume[z][y][x] *= corr2D_3D*weight;
+				if (weight > ACCURACY)
+					tempVolume[z][y][x] *= corr2D_3D / weight;
 				else
 					tempVolume[z][y][x] = 0;
 			}

--- a/src/xmipp/libraries/reconstruction_adapt_cuda/reconstruct_fourier_gpu.cpp
+++ b/src/xmipp/libraries/reconstruction_adapt_cuda/reconstruct_fourier_gpu.cpp
@@ -751,12 +751,9 @@ void ProgRecFourierGPU::processWeights() {
 		for (int y = 0; y <= maxVolumeIndexYZ; y++) {
 			for (int x = 0; x <= maxVolumeIndexX; x++) {
 				float weight = tempWeights[z][y][x];
-				if (fabs(weight) > 1e-3) {
-					weight = 1.f/weight;
-				}
 
-				if (1.0/weight > ACCURACY)
-					tempVolume[z][y][x] *= corr2D_3D*weight;
+				if (weight > ACCURACY)
+					tempVolume[z][y][x] *= corr2D_3D / weight;
 				else
 					tempVolume[z][y][x] = 0;
 			}


### PR DESCRIPTION
The original math was unnecessarily convoluted and not obviously correct.

As discussed [here](https://github.com/I2PC/xmipp/pull/185#discussion_r331810014) with @DStrelak.