### PR TITLE
Regarding bindings and installation

### DIFF
--- a/src/xmipp/bindings/python/xmipp_base.py
+++ b/src/xmipp/bindings/python/xmipp_base.py
@@ -11,12 +11,12 @@ def getXmippPath(*paths):
     ''' Return the path of the Xmipp installation folder
         if a subfolder is provided, will be concatenated to the path
     '''
-    if 'XMIPP_HOME' in os.environ:  # has_key is not supported in python3
+    if 'XMIPP_HOME' in os.environ:
         return os.path.join(os.environ['XMIPP_HOME'], *paths)
     else:
         # xmipp   =     build      <   bindings    <     python    <     xmipp_base.py
-        xmippHome = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-        if os.path.isdir(xmippHome):
+        xmippHome = os.path.dirname(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
+        if os.path.isfile(os.path.join(xmippHome, 'lib', 'libXmipp.so')):
             print("Warning: XMIPP_HOME not found.\n"
                   "Using an auto-detected directory: " + xmippHome)
             return os.path.join(xmippHome, *paths)

--- a/src/xmipp/bindings/python/xmipp_base.py
+++ b/src/xmipp/bindings/python/xmipp_base.py
@@ -1,4 +1,4 @@
-# TODO: Merge this with scipion-em-xmipp/xmipp3/base.py
+
 
 from xmippLib import *
 import os
@@ -8,14 +8,21 @@ def xmippExists(path):
     return FileName(path).exists()
 
 def getXmippPath(*paths):
-    '''Return the path the the Xmipp installation folder
-    if a subfolder is provided, will be concatenated to the path'''
-    #if os.environ.has_key('XMIPP_HOME'):
+    ''' Return the path of the Xmipp installation folder
+        if a subfolder is provided, will be concatenated to the path
+    '''
     if 'XMIPP_HOME' in os.environ:  # has_key is not supported in python3
-        return os.path.join(os.environ['XMIPP_HOME'], *paths)  
+        return os.path.join(os.environ['XMIPP_HOME'], *paths)
     else:
-        raise Exception('XMIPP_HOME environment variable not set')
-    
+        # xmipp   =     build      <   bindings    <     python    <     xmipp_base.py
+        xmippHome = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        if os.path.isdir(xmippHome):
+            print("Warning: XMIPP_HOME not found.\n"
+                  "Using an auto-detected directory: " + xmippHome)
+            return os.path.join(xmippHome, *paths)
+        else:
+            raise Exception('Error: XMIPP_HOME environment variable not set')
+
 def getMatlabEnviron(*toolPaths):
     """ Return an Environment prepared for launching Matlab
     scripts using the Xmipp binding.
@@ -29,6 +36,7 @@ def getMatlabEnviron(*toolPaths):
             Environ.BEGIN)
     
     return env
+
 
 class XmippScript:
     ''' This class will serve as wrapper around the XmippProgram class
@@ -94,7 +102,12 @@ class XmippScript:
 def createMetaDataFromPattern(pattern, isStack=False, label="image"):
     ''' Create a metadata from files matching pattern'''
     import glob
-    files = glob.glob(pattern)
+    if isinstance(pattern, list):
+        files = []
+        for pat in pattern:
+            files += glob.glob(pat)
+    else:
+        files = glob.glob(pattern)
     files.sort()
 
     label = str2Label(label) #Check for label value

--- a/xmipp
+++ b/xmipp
@@ -761,10 +761,11 @@ def configCuda(configDict):
             if checkProgram("nvcc"):
                 nvccVersion, nvccFullVersion = getCudaVersion("nvcc")
                 print(green('CUDA-' + nvccFullVersion + ' detected.'))
-                if nvccVersion != 8.0 and not 'XMIPP_ALLOW_ANY_CUDA' in os.environ:
+                if nvccVersion != 8.0 and not os.environ.get('XMIPP_ALLOW_ANY_CUDA', 'False') == 'True':
                     print(red('CUDA-8.0 is required.'))
                     print(red("Skipping CUDA compilation. Please, set cuda-8.0 as default "
-                              "to be able to use Xmipp Cuda programs.'"))
+                              "to be able to use Xmipp Cuda programs or "
+                              "'export XMIPP_ALLOW_ANY_CUDA=True' to try with current Cuda."))
                     configDict["CUDA"] = 'False'
                     return
                 configDict["NVCC"] = "nvcc"
@@ -1237,8 +1238,8 @@ def install(dirname):
     ok = ok and runJob(cpCmd+" src/xmipp/bindings/python/xmipp.py " + dirname + "/bindings/python/")
     ok = ok and runJob(cpCmd+" src/xmipp/lib/xmippLib.so "+dirname+"/bindings/python/")
     ok = ok and runJob(cpCmd+" src/xmipp/lib/_swig_frm.so "+dirname+"/bindings/python/")
-    ok = ok and runJob("ln -sf ../../lib/libXmipp.so " + dirname + "/bindings/python/libXmipp.so")
-    ok = ok and runJob("ln -sf ../../lib/libXmippCore.so " + dirname + "/bindings/python/libXmippCore.so")
+    # ok = ok and runJob("ln -sf ../../lib/libXmipp.so " + dirname + "/bindings/python/libXmipp.so")
+    # ok = ok and runJob("ln -sf ../../lib/libXmippCore.so " + dirname + "/bindings/python/libXmippCore.so")
 
     createDir(dirname+"/bindings/python/sh_alignment")
     ok = ok and runJob(cpCmd+" -r src/xmipp/external/sh_alignment/python/* "+dirname+"/bindings/python/sh_alignment/")


### PR DESCRIPTION
- Taking some code from merging duplicated code in `scipion-em-xmipp/xmipp3/base.py` and `xmipp/bindings/python/xmipp-base.py` (see [#199 in plugin's repo](https://github.com/I2PC/scipion-em-xmipp/pull/199)).

- Removing soft links from `lib/libXmipp.so` and `lib/libXmippCore.so` to `bindings/python/` since they are not needed due to that libraries will be linked to `scipion3/software/lib` in plugin's installation time.

- Also a minor with the `XMIPP_ALLOW_ANY_CUDA` env var reading.

