### PR TITLE
Refactor in conda manager

### DIFF
--- a/src/xmipp/bindings/python/xmipp_base.py
+++ b/src/xmipp/bindings/python/xmipp_base.py
@@ -222,23 +222,33 @@ class CondaEnvManager(object):
 
     @staticmethod
     def getCondaEnv(env, condaEnv):
+        """ Setting the environ (based on 'env')
+            according to the 'condaEnv' name passed.
+            'environDir/bin' is prepended in PATH
+            PYTHONPATH is set/prepend (depending on the 'xmippEnviron' flag)
+               with 'environDir/lib/python*/site-packages'
+            TODO: consider to also prepend the LD_LIBRARY_PATH
+        """
         environDir = CondaEnvManager.getEnvironDir(condaEnv)
         envBin = os.path.join(environDir, "bin")
-        env.update({"PATH": envBin+':'+env["PATH"]})
+        env.update({"PATH": envBin+':'+env["PATH"]})  # <- PATH
 
-        # TODO: Check that 'python*' is allowed in PYTHONPATH
-        # TODO: Is site-packages of the launching conda-python needed?
         sitePackages = os.path.join("lib", "python*", "site-packages")
         newPythonPath= os.path.join(environDir, sitePackages)
         if CondaEnvManager.XMIPP_CONDA_ENVS[condaEnv]["xmippEnviron"]:
             newPythonPath += ":"+env["PYTHONPATH"]
-        env.update({"PYTHONPATH": newPythonPath})
+        env.update({"PYTHONPATH": newPythonPath})  # <- PYTHONPATH
         # print(env["PYTHONPATH"])
-        env['PYTHONWARNINGS'] = 'ignore::FutureWarning'
+        env['PYTHONWARNINGS'] = 'ignore::FutureWarning'  # to skip warnings
         return env
 
     @staticmethod
     def getCondaActivationCmd():
+        """ This method takes the command to activate conda
+            the CONDA_ACTIVATION_CMD present in the environ.
+            If not there or it fails, we construct one from
+            the 'conda' executable if found.
+        """
         condaActCmd = os.environ.get('CONDA_ACTIVATION_CMD', "")
         if (condaActCmd.startswith("'") and condaActCmd.endswith("'") or
             condaActCmd.startswith('"') and condaActCmd.endswith('"')):

--- a/src/xmipp/bindings/python/xmipp_base.py
+++ b/src/xmipp/bindings/python/xmipp_base.py
@@ -319,7 +319,7 @@ class CondaEnvManager(object):
 
         cmd = ' && '.join(cmdList)
         try:
-            cmd = cmd % options  # Why this??
+            cmd = cmd % options
         except KeyError as ex:  # chr(37) = %
             print("Option not found constructing the conda installing commnad:\n"
                   "%s  %s  (%s)" % (cmd, chr(37), ', '.join(options.keys())))

--- a/src/xmipp/bindings/python/xmipp_base.py
+++ b/src/xmipp/bindings/python/xmipp_base.py
@@ -302,7 +302,7 @@ class CondaEnvManager(object):
         cmdList = []
         cmdList.append("export PYTHONPATH=\"\"")  # TODO: consider if from kwargs
         cmdList.append(CondaEnvManager.getCondaActivationCmd())
-        cmdList.append("conda create -q --force --yes -n %s %s %s %s"
+        cmdList.append("conda create --force --yes -n %s %s %s %s"
                        % (environName, python, deps, chFlags))
         cmdList.append("conda activate %s" % environName)
         if pipPack:
@@ -311,7 +311,7 @@ class CondaEnvManager(object):
 
         cmd = ' && '.join(cmdList)
         try:
-            cmd = cmd % options
+            cmd = cmd % options  # Why this??
         except KeyError as ex:  # chr(37) = %
             print("Option not found constructing the conda installing commnad:\n"
                   "%s  %s  (%s)" % (cmd, chr(37), ', '.join(options.keys())))

--- a/src/xmipp/bindings/python/xmipp_base.py
+++ b/src/xmipp/bindings/python/xmipp_base.py
@@ -315,6 +315,7 @@ class CondaEnvManager(object):
         cmdList.append("conda activate %s" % environName)
         if pipPack:
             cmdList.append("pip install %s" % " ".join([dep for dep in pipPack]))
+        cmdList.append("conda env export > %s.yml" % environName)
 
         cmd = ' && '.join(cmdList)
         try:

--- a/src/xmipp/bindings/python/xmipp_base.py
+++ b/src/xmipp/bindings/python/xmipp_base.py
@@ -129,20 +129,17 @@ class XmippScript:
             but employ conda. The class should possess a _conda_env attribute to be used.
             Otherwise  CONDA_DEFAULT_ENVIRON is used. To use xmipp dependent
             programs, runCondaJob within a XmippProtocol is preferred.
-                :param program:str. A program/pythonScript to execute
+                :param program: str. A program/pythonScript to execute
                 :param arguments: str. The arguments for the program
                 :param kwargs: options
                 :return: None
         """
-        condaEnvName = kwargs.get("_conda_env", getattr(cls, "_conda_env", None))
-        if condaEnvName is None:
-            condaEnvName = CondaEnvManager.CONDA_DEFAULT_ENVIRON
-            print("Warning: '_conda_env' not defined in '%s'. "
-                  "Using the default one ('%s')" % (cls, condaEnvName))
+        condaEnvName = kwargs.get("_conda_env",
+                                  getattr(cls, "_conda_env",
+                                          CondaEnvManager.getDefaultEnv()))
 
         kwargs['env'] = CondaEnvManager.getCondaEnv(kwargs.get('env', os.environ),
                                                     condaEnvName)
-
         cmd_args = program + " " + arguments
         print(cmd_args)
         try:
@@ -154,6 +151,15 @@ class XmippScript:
 class CondaEnvManager(object):
     CONDA_DEFAULT_ENVIRON = "xmipp_DLTK_v0.3"
     from xmipp_conda_envs import XMIPP_CONDA_ENVS
+
+    @staticmethod
+    def getDefaultEnv():
+        defaultEnv = CondaEnvManager.CONDA_DEFAULT_ENVIRON
+        print("Warning: using default conda environment '%s'. "
+              "CondaJobs should be run under a specific environment to "
+              "avoid problems. Please, fix it or contact to the developer."
+              % defaultEnv)
+        return defaultEnv
 
     @staticmethod
     def getCondaExe(env=None):

--- a/src/xmipp/bindings/python/xmipp_conda_envs.py
+++ b/src/xmipp/bindings/python/xmipp_conda_envs.py
@@ -12,7 +12,7 @@ XMIPP_CONDA_ENVS = {
 
   "xmipp_MicCleaner": {
     "pythonVersion": "3.6",
-    "dependencies": ["numpy=1.16", "micrograph-cleaner-em", "keras=2.2"],
+    "dependencies": ["micrograph-cleaner-em=0.35"],
     "channels": ["rsanchez1369", "anaconda", "conda-forge"],
     "pipPackages": [],
     "defaultInstallOptions": {},

--- a/xmipp
+++ b/xmipp
@@ -1220,8 +1220,6 @@ def install(dirname):
     createDir(dirname+"/bin")
     ok = ok and runJob(cpCmd+" src/*/bin/* "+dirname+"/bin/")
 
-    createDir(dirname+'/models')
-
     destPathPyModule = os.path.expanduser(os.path.abspath(os.path.join(dirname, "pylib", "xmippPyModules")))
     createDir(destPathPyModule)
     initFn = destPathPyModule + "/__init__.py"

--- a/xmipp
+++ b/xmipp
@@ -1219,6 +1219,9 @@ def install(dirname):
 
     createDir(dirname+"/bin")
     ok = ok and runJob(cpCmd+" src/*/bin/* "+dirname+"/bin/")
+
+    createDir(dirname+'/models')
+
     destPathPyModule = os.path.expanduser(os.path.abspath(os.path.join(dirname, "pylib", "xmippPyModules")))
     createDir(destPathPyModule)
     initFn = destPathPyModule + "/__init__.py"


### PR DESCRIPTION
After this refactor, condaRoot is not needed anymore since the environs home-dir is found via `conda info --env` command.

The reason of this refactoring is due to `conda` can be in a deep path (`/usr/bin` or whatever) and the `CONDA_ACTIVATION_CMD` can be something like `eval '$(path/to/conda shell.bash hook)'`. In that cases our assumptions were incorrect since we constructed the conda root form that activation command.

Another refactor is regarding launching python scripts. Now we don't assert if they are python scripts or binaries, we just launch them with the proper environ since they are executable and have set in the header the interpreter from the environ.