### PR TITLE
changes in image_odd_even to allow split by image

### DIFF
--- a/src/xmipp/libraries/reconstruction/image_odd_even.cpp
+++ b/src/xmipp/libraries/reconstruction/image_odd_even.cpp
@@ -108,10 +108,24 @@ void ProgOddEven::run()
 	MetaData movieOdd, movieEven;
 
 	FileName fnFrame;
-	size_t objId, objId_odd, objId_even;
+	size_t objId, objId_odd, objId_even, Xdim, Ydim, Zdim, Ndim;
 	Image<double> frame, imgOdd, imgEven;
 
-	int counter=0;
+	frame.read(fnImg);
+	frame.getDimensions(Xdim, Ydim, Zdim, Ndim);
+
+	MultidimArray<double> &img = imgEven();
+
+#ifdef DEBUG
+	std::cout << Xdim << std::endl;
+	std::cout << Ydim << std::endl;
+	std::cout << Zdim << std::endl;
+	std::cout << Ndim << std::endl;
+#endif
+
+	img.initZeros(Xdim, Ydim);
+	imgEven() = img;
+	imgOdd() = img;
 
 	FOR_ALL_OBJECTS_IN_METADATA(movienew)
 	{
@@ -127,22 +141,18 @@ void ProgOddEven::run()
 			objId_even = movieEven.addObject();
 			movieEven.setValue(MDL_IMAGE, fnFrame, objId_even);
 			if (sumFrames)
-				if (counter > 0)
-					imgEven() += frame();
-				else
-					imgEven() = frame();
-			++counter;
+			{
+				imgEven() += frame();
+			}
 		}
 		else
 		{
 			objId_odd = movieOdd.addObject();
 			movieOdd.setValue(MDL_IMAGE, fnFrame, objId_odd);
 			if (sumFrames)
-				if (counter > 0)
-					imgOdd() += frame();
-				else
-					imgOdd() = frame();
-			++counter;
+			{
+				imgOdd() += frame();
+			}
 		}
 	}
 

--- a/src/xmipp/libraries/reconstruction/image_odd_even.cpp
+++ b/src/xmipp/libraries/reconstruction/image_odd_even.cpp
@@ -111,8 +111,7 @@ void ProgOddEven::run()
 	size_t objId, objId_odd, objId_even;
 	Image<double> frame, imgOdd, imgEven;
 
-	imgEven() = frame();
-	imgOdd() = frame();
+	int counter=0;
 
 	FOR_ALL_OBJECTS_IN_METADATA(movienew)
 	{
@@ -128,14 +127,22 @@ void ProgOddEven::run()
 			objId_even = movieEven.addObject();
 			movieEven.setValue(MDL_IMAGE, fnFrame, objId_even);
 			if (sumFrames)
-				imgEven() += frame();
+				if (counter > 0)
+					imgEven() += frame();
+				else
+					imgEven() = frame();
+			++counter;
 		}
 		else
 		{
 			objId_odd = movieOdd.addObject();
 			movieOdd.setValue(MDL_IMAGE, fnFrame, objId_odd);
 			if (sumFrames)
-				imgOdd() += frame();
+				if (counter > 0)
+					imgOdd() += frame();
+				else
+					imgOdd() = frame();
+			++counter;
 		}
 	}
 

--- a/src/xmipp/libraries/reconstruction/image_odd_even.cpp
+++ b/src/xmipp/libraries/reconstruction/image_odd_even.cpp
@@ -111,8 +111,8 @@ void ProgOddEven::run()
 	size_t objId, objId_odd, objId_even;
 	Image<double> frame, imgOdd, imgEven;
 
-
-	int counter=0;
+	imgEven() = frame();
+	imgOdd() = frame();
 
 	FOR_ALL_OBJECTS_IN_METADATA(movienew)
 	{
@@ -128,22 +128,14 @@ void ProgOddEven::run()
 			objId_even = movieEven.addObject();
 			movieEven.setValue(MDL_IMAGE, fnFrame, objId_even);
 			if (sumFrames)
-				if (counter > 0)
-					imgEven() += frame();
-				else
-					imgEven() = frame();
-			++counter;
+				imgEven() += frame();
 		}
 		else
 		{
 			objId_odd = movieOdd.addObject();
 			movieOdd.setValue(MDL_IMAGE, fnFrame, objId_odd);
 			if (sumFrames)
-				if (counter > 0)
-					imgOdd() += frame();
-				else
-					imgOdd() = frame();
-			++counter;
+				imgOdd() += frame();
 		}
 	}
 

--- a/src/xmipp/libraries/reconstruction/image_odd_even.h
+++ b/src/xmipp/libraries/reconstruction/image_odd_even.h
@@ -41,7 +41,7 @@
 
 class ProgOddEven : public XmippProgram
 {
-public:
+private:
 	 /** Filenames */
 	FileName fnOut_odd, fnOut_even, fnImg, splitType;
 	bool sumFrames;
@@ -49,7 +49,7 @@ public:
 public:
     void defineParams();
     void readParams();
-    void produceSideInfo();
+    void fromimageToMd(FileName fnImg, MetaData &movienew);
     void run();
 
 

--- a/src/xmipp/libraries/reconstruction/image_odd_even.h
+++ b/src/xmipp/libraries/reconstruction/image_odd_even.h
@@ -46,9 +46,10 @@ private:
 	FileName fnOut_odd, fnOut_even, fnImg, splitType;
 	bool sumFrames;
 
-public:
+private:
     void defineParams();
     void readParams();
+    // This function generates the metadata associated to the input image stack
     void fromimageToMd(FileName fnImg, MetaData &movienew);
     void run();
 


### PR DESCRIPTION
This PR includes:

- Changes in image_odd_even to allow splitting by image (previously only by frame was available)