### PR TITLE
Build optimization

### DIFF
--- a/src/xmipp/applications/programs/mpi_write_test/mpi_write_test.cpp
+++ b/src/xmipp/applications/programs/mpi_write_test/mpi_write_test.cpp
@@ -43,6 +43,7 @@
 #include "parallel/xmipp_mpi.h"
 #include <core/args.h>
 #include <core/xmipp_program.h>
+#include "core/xmipp_image_generic.h"
 
 //Some useful macros
 #define CREATE_LOG() FILE * _logML = fopen(formatString("nodo%02d.log", node->rank).c_str(), "w+")

--- a/src/xmipp/applications/programs/transform_mirror/transform_mirror_main.cpp
+++ b/src/xmipp/applications/programs/transform_mirror/transform_mirror_main.cpp
@@ -26,6 +26,7 @@
 #include <core/args.h>
 #include <core/geometry.h>
 #include <core/xmipp_program.h>
+#include "core/xmipp_image_generic.h"
 
 class FlipParameters: public XmippMetadataProgram
 {

--- a/src/xmipp/applications/programs/volume_center/volume_center_main.cpp
+++ b/src/xmipp/applications/programs/volume_center/volume_center_main.cpp
@@ -25,6 +25,7 @@
 
 #include <data/mask.h>
 #include <core/xmipp_program.h>
+#include "core/transformations.h"
 
 class ProgVolumeCenter: public XmippMetadataProgram
 {

--- a/src/xmipp/applications/tests/function_tests/test_funcs_main.cpp
+++ b/src/xmipp/applications/tests/function_tests/test_funcs_main.cpp
@@ -1,6 +1,8 @@
 #include <core/xmipp_funcs.h>
 #include <iostream>
 #include <gtest/gtest.h>
+#include "core/xmipp_filename.h"
+#include "core/xmipp_error.h"
 // MORE INFO HERE: http://code.google.com/p/googletest/wiki/AdvancedGuide
 // This test is named "Size", and belongs to the "MetadataTest"
 // test case.

--- a/src/xmipp/applications/tests/function_tests/test_geometry_main.cpp
+++ b/src/xmipp/applications/tests/function_tests/test_geometry_main.cpp
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 #include <core/geometry.h>
 #include <data/normalize.h>
+#include "core/transformations.h"
 
 // MORE INFO HERE: http://code.google.com/p/googletest/wiki/AdvancedGuide
 class GeometryTest : public ::testing::Test

--- a/src/xmipp/applications/tests/function_tests/test_image_generic_main.cpp
+++ b/src/xmipp/applications/tests/function_tests/test_image_generic_main.cpp
@@ -3,6 +3,8 @@
 #include <iostream>
 #include <gtest/gtest.h>
 #include <data/ctf.h>
+#include "core/xmipp_image_generic.h"
+
 // MORE INFO HERE: http://code.google.com/p/googletest/wiki/AdvancedGuide
 // This test is named "Size", and belongs to the "MetadataTest"
 // test case.

--- a/src/xmipp/applications/tests/function_tests/test_image_main.cpp
+++ b/src/xmipp/applications/tests/function_tests/test_image_main.cpp
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <gtest/gtest.h>
 #include <core/metadata.h>
+#include "core/transformations.h"
 // MORE INFO HERE: http://code.google.com/p/googletest/wiki/AdvancedGuide
 // This test is named "Size", and belongs to the "MetadataTest"
 // test case.

--- a/src/xmipp/applications/tests/function_tests/test_matrix_main.cpp
+++ b/src/xmipp/applications/tests/function_tests/test_matrix_main.cpp
@@ -1,6 +1,9 @@
 #include <core/matrix2d.h>
 #include <iostream>
 #include <gtest/gtest.h>
+#include "core/xmipp_filename.h"
+#include "core/linear_system_helper.h"
+#include "core/xmipp_funcs.h"
 // MORE INFO HERE: http://code.google.com/p/googletest/wiki/AdvancedGuide
 class MatrixTest : public ::testing::Test
 {

--- a/src/xmipp/libraries/classification/ahc_classifier.cpp
+++ b/src/xmipp/libraries/classification/ahc_classifier.cpp
@@ -24,7 +24,7 @@
  ***************************************************************************/
 
 #include <core/alglib/dataanalysis.h>
-
+#include "core/matrix2d.h"
 #include "ahc_classifier.h"
 
 

--- a/src/xmipp/libraries/classification/ahc_classifier.h
+++ b/src/xmipp/libraries/classification/ahc_classifier.h
@@ -27,7 +27,7 @@
 #define XMIPP__AHC_CLASSIFIER_HH__
 
 /* Includes ---------------------------------------------------------------- */
-#include <core/matrix2d.h>
+#include <core/matrix1d.h>
 
 /**@defgroup AHCClassifier Agglomerative Hierarchical Clustering
    @ingroup ClassificationLibrary */

--- a/src/xmipp/libraries/classification/training_vector.cpp
+++ b/src/xmipp/libraries/classification/training_vector.cpp
@@ -28,6 +28,7 @@
 //-----------------------------------------------------------------------------
 
 #include <cmath>
+#include <fstream>
 
 #include "training_vector.h"
 #include <core/args.h>

--- a/src/xmipp/libraries/data/filters.cpp
+++ b/src/xmipp/libraries/data/filters.cpp
@@ -23,12 +23,12 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-#include "filters.h"
+#include <queue>
 #include <list>
-#include <core/xmipp_fftw.h>
+#include "filters.h"
 #include "morphology.h"
-#include "wavelet.h"
 #include <data/fourier_filter.h>
+#include "mask.h"
 
 /* Subtract background ---------------------------------------------------- */
 void substractBackgroundPlane(MultidimArray<double> &I)

--- a/src/xmipp/libraries/data/filters.h
+++ b/src/xmipp/libraries/data/filters.h
@@ -28,12 +28,10 @@
 
 #define LOG2 0.693147181
 
-#include <queue>
 #include <core/xmipp_image.h>
 #include <core/histogram.h>
 #include <core/xmipp_program.h>
 #include <data/numerical_tools.h>
-#include <data/mask.h>
 #include <data/polar.h>
 
 /// @defgroup Filters Filters

--- a/src/xmipp/libraries/data/fourier_projection.cpp
+++ b/src/xmipp/libraries/data/fourier_projection.cpp
@@ -25,6 +25,8 @@
 
 #include "fourier_projection.h"
 #include <core/xmipp_fft.h>
+#include "core/geometry.h"
+#include "core/transformations.h"
 
 /* Empty constructor ======================================================= */
 Projection::Projection(): Image<double>()

--- a/src/xmipp/libraries/data/fourier_projection.h
+++ b/src/xmipp/libraries/data/fourier_projection.h
@@ -28,6 +28,7 @@
 #include <core/xmipp_image.h>
 #include <core/xmipp_program.h>
 #include <core/xmipp_fftw.h>
+#include "core/matrix2d.h"
 
 /**@defgroup FourierProjection Fourier projection
    @ingroup ReconsLibrary */

--- a/src/xmipp/libraries/data/grids.h
+++ b/src/xmipp/libraries/data/grids.h
@@ -34,6 +34,7 @@
 #include <core/xmipp_image.h>
 #include <core/geometry.h>
 #include <core/args.h>
+#include "core/matrix2d.h"
 
 /* Forward declarations ---------------------------------------------------- */
 template <class T>

--- a/src/xmipp/libraries/data/image_operate.cpp
+++ b/src/xmipp/libraries/data/image_operate.cpp
@@ -28,6 +28,7 @@
 #include <core/metadata_extension.h>
 #include <data/numerical_tools.h>
 #include <core/xmipp_fft.h>
+#include "core/transformations.h"
 
 void minus(Image<double> &op1, const Image<double> &op2)
 {

--- a/src/xmipp/libraries/data/mask.cpp
+++ b/src/xmipp/libraries/data/mask.cpp
@@ -25,6 +25,8 @@
 
 #include "mask.h"
 #include <core/xmipp_program.h>
+#include "core/xmipp_image_generic.h"
+#include "core/transformations.h"
 
 /*---------------------------------------------------------------------------*/
 /* Multidim Masks                                                            */

--- a/src/xmipp/libraries/data/pdb.cpp
+++ b/src/xmipp/libraries/data/pdb.cpp
@@ -31,6 +31,7 @@
 #include <data/mask.h>
 #include <data/integration.h>
 #include <data/numerical_tools.h>
+#include "core/transformations.h"
 
 /* Atom charge ------------------------------------------------------------- */
 int atomCharge(const std::string &atom)

--- a/src/xmipp/libraries/data/projection.cpp
+++ b/src/xmipp/libraries/data/projection.cpp
@@ -25,6 +25,7 @@
 
 #include "projection.h"
 #include <core/geometry.h>
+#include "core/transformations.h"
 
 #define x0   STARTINGX(IMGMATRIX(proj))
 #define xF   FINISHINGX(IMGMATRIX(proj))

--- a/src/xmipp/libraries/data/psf_xr.cpp
+++ b/src/xmipp/libraries/data/psf_xr.cpp
@@ -24,7 +24,7 @@
  ***************************************************************************/
 
 #include "psf_xr.h"
-
+#include "core/transformations.h"
 
 XRayPSF::XRayPSF()
 {

--- a/src/xmipp/libraries/data/psf_xr.h
+++ b/src/xmipp/libraries/data/psf_xr.h
@@ -31,6 +31,7 @@
 #include <core/xmipp_fftw.h>
 #include <core/xmipp_program.h>
 #include <data/projection.h>
+#include "core/xmipp_image_generic.h"
 
 /**@defgroup PSFXRSupport X-Ray Microscope PSF class
    @ingroup DataLibrary */

--- a/src/xmipp/libraries/data/sparse_matrix2d.cpp
+++ b/src/xmipp/libraries/data/sparse_matrix2d.cpp
@@ -26,7 +26,6 @@
 
 #include "sparse_matrix2d.h"
 
-
 // Sparse matrices --------------------------------------------------------
 SparseMatrix2D::SparseMatrix2D(){
 	N 		= 0;

--- a/src/xmipp/libraries/data/sparse_matrix2d.h
+++ b/src/xmipp/libraries/data/sparse_matrix2d.h
@@ -28,6 +28,22 @@
 
 #include <core/multidim_array.h>
 
+/** Sparse element.
+ *  This class is used to create the SparseMatrices. */
+class SparseElement
+{
+public:
+    size_t i;
+    size_t j;
+    double value;
+};
+
+/** Function to sort the sparse elements by their i,j position */
+inline bool operator< (const SparseElement& _x, const SparseElement& _y)
+{
+    return ( _x.i < _y.i) || (( _x.i== _y.i) && ( _x.j< _y.j));
+}
+
 /** @ingroup Matrices
  */
 //@{

--- a/src/xmipp/libraries/data/steerable.cpp
+++ b/src/xmipp/libraries/data/steerable.cpp
@@ -29,6 +29,7 @@
 #include <core/histogram.h>
 #include <data/filters.h>
 #include <data/morphology.h>
+#include "core/geometry.h"
 
 // Remove wedge ------------------------------------------------------------
 void MissingWedge::removeWedge(MultidimArray<double> &V) const

--- a/src/xmipp/libraries/data/transform_downsample.cpp
+++ b/src/xmipp/libraries/data/transform_downsample.cpp
@@ -28,6 +28,7 @@
 #include <core/xvsmooth.h>
 #include "transform_downsample.h"
 #include "mask.h"
+#include "core/xmipp_image_generic.h"
 
 // Read --------------------------------------------------------------------
 void ProgTransformDownsample::readParams()

--- a/src/xmipp/libraries/data/transform_downsample.h
+++ b/src/xmipp/libraries/data/transform_downsample.h
@@ -28,6 +28,8 @@
 
 #include <core/xmipp_program.h>
 
+class ImageGeneric;
+
 ///@defgroup MicrographDownsample Micrograph Downsample
 /// @ingroup ReconsLibrary
 //@{

--- a/src/xmipp/libraries/data/transform_geometry.cpp
+++ b/src/xmipp/libraries/data/transform_geometry.cpp
@@ -24,6 +24,7 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 #include "transform_geometry.h"
+#include "core/geometry.h"
 
 ProgTransformGeometry::ProgTransformGeometry()
 {}

--- a/src/xmipp/libraries/data/xmipp_image_convert.h
+++ b/src/xmipp/libraries/data/xmipp_image_convert.h
@@ -27,6 +27,7 @@
 #define IMAGE_CONVERT_H_
 
 #include <core/xmipp_program.h>
+#include "core/xmipp_image_generic.h"
 
 typedef enum
 {

--- a/src/xmipp/libraries/data/xmipp_polynomials.cpp
+++ b/src/xmipp/libraries/data/xmipp_polynomials.cpp
@@ -28,6 +28,7 @@
 #include "xmipp_polynomials.h"
 #include "numerical_tools.h"
 #include "mask.h"
+#include "core/linear_system_helper.h"
 
 
 #define PR(x) std::cout << #x " = " << x << std::endl;

--- a/src/xmipp/libraries/dimred/dimred_tools.cpp
+++ b/src/xmipp/libraries/dimred/dimred_tools.cpp
@@ -23,7 +23,10 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
+#include <random>
+#include <algorithm>
 #include "dimred_tools.h"
+#include "core/xmipp_funcs.h"
 
 void GenerateData::generateNewDataset(const DatasetType &type, int N, double noise)
 {

--- a/src/xmipp/libraries/dimred/dimred_tools.h
+++ b/src/xmipp/libraries/dimred/dimred_tools.h
@@ -27,6 +27,7 @@
 
 #include <core/matrix2d.h>
 #include <core/matrix1d.h>
+#include "core/xmipp_filename.h"
 
 
 /**@defgroup DimRedTools Tools for dimensionality reduction

--- a/src/xmipp/libraries/dimred/npe.cpp
+++ b/src/xmipp/libraries/dimred/npe.cpp
@@ -27,6 +27,7 @@
 #include "npe.h"
 #include <core/matrix2d.h>
 #include <core/matrix1d.h>
+#include "core/linear_system_helper.h"
 
 void NPE::setSpecificParameters(int k){
 	this->k=k;

--- a/src/xmipp/libraries/interface/docfile.cpp
+++ b/src/xmipp/libraries/interface/docfile.cpp
@@ -26,7 +26,7 @@
 #include <fstream>
 #include <sstream>
 #include <cstdio>
-
+#include "core/transformations.h"
 #include "docfile.h"
 #include <core/args.h>
 

--- a/src/xmipp/libraries/parallel/mpi_angular_class_average.cpp
+++ b/src/xmipp/libraries/parallel/mpi_angular_class_average.cpp
@@ -25,7 +25,7 @@
  ***************************************************************************/
 
 #include "mpi_angular_class_average.h"
-
+#include "core/xmipp_image_generic.h"
 
 MpiProgAngularClassAverage::MpiProgAngularClassAverage()
 {}

--- a/src/xmipp/libraries/parallel/mpi_angular_project_library.cpp
+++ b/src/xmipp/libraries/parallel/mpi_angular_project_library.cpp
@@ -33,6 +33,7 @@
 #include <fstream>
 #include <iomanip>
 #include <random>
+#include "core/xmipp_image_generic.h"
 
 #include <reconstruction/angular_project_library.h>
 

--- a/src/xmipp/libraries/parallel/mpi_classify_CL2D.cpp
+++ b/src/xmipp/libraries/parallel/mpi_classify_CL2D.cpp
@@ -28,6 +28,8 @@
 #include <data/mask.h>
 #include <data/polar.h>
 #include <core/xmipp_image_generic.h>
+#include <core/xmipp_color.h>
+
 
 // Pointer to parameters
 ProgClassifyCL2D *prm = NULL;

--- a/src/xmipp/libraries/parallel/mpi_classify_CL2D_core_analysis.cpp
+++ b/src/xmipp/libraries/parallel/mpi_classify_CL2D_core_analysis.cpp
@@ -25,6 +25,7 @@
 
 #include "mpi_classify_CL2D_core_analysis.h"
 #include <classification/analyze_cluster.h>
+#include "core/matrix2d.h"
 
 // Show block ==============================================================
 std::ostream & operator << (std::ostream &out, const CL2DBlock &block)

--- a/src/xmipp/libraries/parallel/mpi_classify_CLTomo.h
+++ b/src/xmipp/libraries/parallel/mpi_classify_CLTomo.h
@@ -38,6 +38,7 @@
 #include <core/xmipp_program.h>
 #include <core/symmetries.h>
 #include <vector>
+#include "data/mask.h"
 
 /**@defgroup VQforVolumes Vector Quantization for Volumes
    @ingroup ClassificationLibrary */

--- a/src/xmipp/libraries/parallel/mpi_classify_FTTRI.cpp
+++ b/src/xmipp/libraries/parallel/mpi_classify_FTTRI.cpp
@@ -32,6 +32,7 @@
 #include <data/polar.h>
 #include <core/histogram.h>
 #include <data/filters.h>
+#include <core/xmipp_image_generic.h>
 
 //#define FTTRI_ALREADY_COMPUTED
 

--- a/src/xmipp/libraries/reconstruction/align2d.cpp
+++ b/src/xmipp/libraries/reconstruction/align2d.cpp
@@ -28,6 +28,7 @@
 #include <core/xmipp_funcs.h>
 #include <data/mask.h>
 #include <data/filters.h>
+#include "core/xmipp_image_generic.h"
 
 // Read arguments ==========================================================
 void ProgAlign2d::readParams()

--- a/src/xmipp/libraries/reconstruction/angular_continuous_assign2.cpp
+++ b/src/xmipp/libraries/reconstruction/angular_continuous_assign2.cpp
@@ -27,6 +27,7 @@
 #include "program_image_residuals.h"
 #include <data/mask.h>
 #include <data/numerical_tools.h>
+#include "core/xmipp_image_generic.h"
 
 // Empty constructor =======================================================
 ProgAngularContinuousAssign2::ProgAngularContinuousAssign2()

--- a/src/xmipp/libraries/reconstruction/angular_distance.cpp
+++ b/src/xmipp/libraries/reconstruction/angular_distance.cpp
@@ -27,6 +27,7 @@
 
 #include <core/args.h>
 #include <core/histogram.h>
+#include "core/geometry.h"
 
 // Read arguments ==========================================================
 void ProgAngularDistance::readParams()

--- a/src/xmipp/libraries/reconstruction/angular_project_library.cpp
+++ b/src/xmipp/libraries/reconstruction/angular_project_library.cpp
@@ -25,6 +25,7 @@
  ***************************************************************************/
 
 #include "angular_project_library.h"
+#include "core/xmipp_image_generic.h"
 
 /* Empty constructor ------------------------------------------------------- */
 ProgAngularProjectLibrary::ProgAngularProjectLibrary()

--- a/src/xmipp/libraries/reconstruction/angular_rotate.cpp
+++ b/src/xmipp/libraries/reconstruction/angular_rotate.cpp
@@ -26,7 +26,7 @@
 #include <core/xmipp_program.h>
 #include <core/transformations.h>
 #include <core/matrix2d.h>
-
+#include "core/geometry.h"
 
 class ProgAngularRotate: public XmippProgram
 {

--- a/src/xmipp/libraries/reconstruction/base_art_recons.cpp
+++ b/src/xmipp/libraries/reconstruction/base_art_recons.cpp
@@ -27,7 +27,7 @@
 #include "base_art_recons.h"
 #include "recons_misc.h"
 #include <data/fourier_filter.h>
-
+#include "data/wavelet.h"
 
 void ARTReconsBase::readParams(XmippProgram * program)
 {

--- a/src/xmipp/libraries/reconstruction/basic_art.cpp
+++ b/src/xmipp/libraries/reconstruction/basic_art.cpp
@@ -32,6 +32,7 @@
 #include "basic_art.h"
 #include <data/fourier_filter.h>
 #include "recons_misc.h"
+#include "core/metadata_extension.h"
 
 /* Desctructor */
 BasicARTParameters::~BasicARTParameters()

--- a/src/xmipp/libraries/reconstruction/classify_compare_classes.cpp
+++ b/src/xmipp/libraries/reconstruction/classify_compare_classes.cpp
@@ -25,6 +25,7 @@
 
 #include "classify_compare_classes.h"
 #include <core/metadata_extension.h>
+#include "core/matrix2d.h"
 
 // Evaluate classes program -------------------------------------------
 void ProgCompareClass::readParams()

--- a/src/xmipp/libraries/reconstruction/common_lines.cpp
+++ b/src/xmipp/libraries/reconstruction/common_lines.cpp
@@ -33,6 +33,7 @@
 #include <reconstruction/radon.h>
 #include <fstream>
 #include <iomanip>
+#include "core/linear_system_helper.h"
 
 /* Common line ------------------------------------------------------------- */
 CommonLine::CommonLine()

--- a/src/xmipp/libraries/reconstruction/ctf_estimate_from_micrograph.cpp
+++ b/src/xmipp/libraries/reconstruction/ctf_estimate_from_micrograph.cpp
@@ -35,6 +35,7 @@
 #include <core/xmipp_threads.h>
 #include <data/basic_pca.h>
 #include <data/normalize.h>
+#include "core/xmipp_image_generic.h"
 
 /* Read parameters ========================================================= */
 ProgCTFEstimateFromMicrograph::ProgCTFEstimateFromMicrograph()

--- a/src/xmipp/libraries/reconstruction/ctf_sort_psds.cpp
+++ b/src/xmipp/libraries/reconstruction/ctf_sort_psds.cpp
@@ -30,7 +30,7 @@
 #include <data/filters.h>
 #include <core/transformations.h>
 #include <core/histogram.h>
-
+#include "core/xmipp_image_generic.h"
 
 /* Constructor ------------------------------------------------------------- */
 ProgPSDSort::ProgPSDSort()

--- a/src/xmipp/libraries/reconstruction/directions.cpp
+++ b/src/xmipp/libraries/reconstruction/directions.cpp
@@ -24,6 +24,7 @@
  ***************************************************************************/
 
 #include "directions.h"
+#include "core/geometry.h"
 
 // Check whether projection directions are unique =================================
 bool directions_are_unique(double rot,  double tilt,

--- a/src/xmipp/libraries/reconstruction/eq_system_solver.cpp
+++ b/src/xmipp/libraries/reconstruction/eq_system_solver.cpp
@@ -24,7 +24,7 @@
  ***************************************************************************/
 
 #include "eq_system_solver.h"
-
+#include "core/linear_system_helper.h"
 
 template void EquationSystemSolver::solve(Matrix1D<float>& bXt,
         Matrix1D<float>& bYt, Matrix2D<float>& At, Matrix1D<float>& shiftXt,

--- a/src/xmipp/libraries/reconstruction/eq_system_solver.h
+++ b/src/xmipp/libraries/reconstruction/eq_system_solver.h
@@ -26,7 +26,10 @@
 #ifndef LIBRARIES_RECONSTRUCTION_EQ_SYSTEM_SOLVER_H_
 #define LIBRARIES_RECONSTRUCTION_EQ_SYSTEM_SOLVER_H_
 
-#include "core/matrix2d.h"
+template<typename T>
+class Matrix1D;
+template<typename T>
+class Matrix2D;
 
 class EquationSystemSolver {
 public:

--- a/src/xmipp/libraries/reconstruction/flexible_alignment.cpp
+++ b/src/xmipp/libraries/reconstruction/flexible_alignment.cpp
@@ -30,10 +30,11 @@
 #include <core/bilib/messagedisplay.h>
 #include <core/bilib/error.h>
 #include <core/bilib/configs.h>
+#include "core/bilib/linearalgebra.h"
 #include "flexible_alignment.h"
 #include "pdb_nma_deform.h"
 #include "program_extension.h"
-
+#include "core/transformations.h"
 
 // Empty constructor =======================================================
 ProgFlexibleAlignment::ProgFlexibleAlignment()

--- a/src/xmipp/libraries/reconstruction/image_assignment_tilt_pair.cpp
+++ b/src/xmipp/libraries/reconstruction/image_assignment_tilt_pair.cpp
@@ -35,7 +35,9 @@
 #include <core/geometry.h>
 //#include <relion-1.3/include/relion-1.3/src/matrix1d.h>
 #include <core/matrix1d.h>
-//#include <core/multidim_array.h>
+#include "core/linear_system_helper.h"
+#include "core/xmipp_image_extension.h"
+
 
 void ProgassignmentTiltPair::readParams()
 {

--- a/src/xmipp/libraries/reconstruction/image_header.cpp
+++ b/src/xmipp/libraries/reconstruction/image_header.cpp
@@ -28,7 +28,7 @@
 #include <core/metadata.h>
 #include <core/xmipp_program.h>
 #include <core/xmipp_hdf5.h>
-
+#include "core/xmipp_image_generic.h"
 
 typedef enum { HEADER_PRINT, HEADER_EXTRACT, HEADER_ASSIGN, HEADER_RESET, HEADER_SAMPLINGRATE, HEADER_TREE } HeaderOperation;
 

--- a/src/xmipp/libraries/reconstruction/image_odd_even.cpp
+++ b/src/xmipp/libraries/reconstruction/image_odd_even.cpp
@@ -25,6 +25,7 @@
  ***************************************************************************/
 
 #include "image_odd_even.h"
+#include "core/xmipp_image_generic.h"
 //#define DEBUG
 //#define DEBUG_MASK
 

--- a/src/xmipp/libraries/reconstruction/image_rotational_pca.cpp
+++ b/src/xmipp/libraries/reconstruction/image_rotational_pca.cpp
@@ -27,6 +27,7 @@
 #include "image_rotational_pca.h"
 #include <data/mask.h>
 #include <core/metadata_extension.h>
+#include "core/transformations.h"
 
 // Empty constructor =======================================================
 ProgImageRotationalPCA::ProgImageRotationalPCA()

--- a/src/xmipp/libraries/reconstruction/image_sort_by_statistics.cpp
+++ b/src/xmipp/libraries/reconstruction/image_sort_by_statistics.cpp
@@ -24,6 +24,7 @@
  ***************************************************************************/
 
 #include "image_sort_by_statistics.h"
+#include "core/metadata_extension.h"
 
 void ProgSortByStatistics::clear()
 {

--- a/src/xmipp/libraries/reconstruction/ml2d.cpp
+++ b/src/xmipp/libraries/reconstruction/ml2d.cpp
@@ -24,6 +24,7 @@
  ***************************************************************************/
 
 #include <algorithm>
+#include <iomanip>
 #include "ml2d.h"
 
 ML2DBaseProgram::ML2DBaseProgram()

--- a/src/xmipp/libraries/reconstruction/ml_refine3d.cpp
+++ b/src/xmipp/libraries/reconstruction/ml_refine3d.cpp
@@ -41,7 +41,7 @@
 #include <data/fourier_filter.h>
 #include "symmetrize.h"
 #include "volume_segment.h"
-
+#include "core/xmipp_image_generic.h"
 
 //#define DEBUG
 //Macro to obtain the iteration base name

--- a/src/xmipp/libraries/reconstruction/movie_alignment_correlation_base.cpp
+++ b/src/xmipp/libraries/reconstruction/movie_alignment_correlation_base.cpp
@@ -25,6 +25,7 @@
  ***************************************************************************/
 
 #include "reconstruction/movie_alignment_correlation_base.h"
+#include "core/xmipp_image_generic.h"
 
 template<typename T>
 void AProgMovieAlignmentCorrelation<T>::readParams() {

--- a/src/xmipp/libraries/reconstruction/movie_filter_dose.cpp
+++ b/src/xmipp/libraries/reconstruction/movie_filter_dose.cpp
@@ -28,6 +28,7 @@
 #include <core/xmipp_fftw.h>
 #include <data/filters.h>
 #include <typeinfo>
+#include "core/xmipp_image_generic.h"
 
 #define OUTSIDE_WRAP 0
 #define OUTSIDE_AVG 1

--- a/src/xmipp/libraries/reconstruction/nma_alignment.cpp
+++ b/src/xmipp/libraries/reconstruction/nma_alignment.cpp
@@ -27,7 +27,7 @@
 #include <sys/stat.h>
 #include <condor/Solver.h>
 #include <condor/tools.h>
-
+#include "core/transformations.h"
 #include <core/metadata_extension.h>
 #include "program_extension.h"
 #include "nma_alignment.h"

--- a/src/xmipp/libraries/reconstruction/pdb_construct_dictionary.cpp
+++ b/src/xmipp/libraries/reconstruction/pdb_construct_dictionary.cpp
@@ -26,6 +26,8 @@
 #include "pdb_construct_dictionary.h"
 #include <core/xmipp_image_extension.h>
 #include <data/numerical_tools.h>
+#include "core/xmipp_image_generic.h"
+#include "core/transformations.h"
 
 void ProgPDBDictionary::defineParams()
 {

--- a/src/xmipp/libraries/reconstruction/pdb_construct_dictionary.h
+++ b/src/xmipp/libraries/reconstruction/pdb_construct_dictionary.h
@@ -26,6 +26,8 @@
 #define _PROG_CONSTRUCT_DICTIONARY_HH
 
 #include <core/xmipp_program.h>
+#include "core/matrix2d.h"
+#include "core/matrix1d.h"
 
 /**@defgroup PDBConstructDictionary Construct a low and high resolution dictionary
    @ingroup ReconsLibrary */

--- a/src/xmipp/libraries/reconstruction/pdb_label_from_volume.cpp
+++ b/src/xmipp/libraries/reconstruction/pdb_label_from_volume.cpp
@@ -27,7 +27,7 @@
  ***************************************************************************/
 
 #include "pdb_label_from_volume.h"
-
+#include <iomanip>
 #include <core/args.h>
 
 #include <fstream>

--- a/src/xmipp/libraries/reconstruction/phantom_transform.cpp
+++ b/src/xmipp/libraries/reconstruction/phantom_transform.cpp
@@ -27,6 +27,7 @@
 #include <core/geometry.h>
 #include <data/phantom.h>
 #include <data/pdb.h>
+#include "core/transformations.h"
 
 class Phantom_transform_parameters: public XmippProgram
 {

--- a/src/xmipp/libraries/reconstruction/program_image_residuals.h
+++ b/src/xmipp/libraries/reconstruction/program_image_residuals.h
@@ -24,6 +24,8 @@
  ***************************************************************************/
 
 #include <core/xmipp_program.h>
+#include "core/matrix2d.h"
+#include "core/xmipp_image.h"
 
 /** Apply some filter operation on images, or selfiles */
 class ProgImageResiduals: public XmippMetadataProgram

--- a/src/xmipp/libraries/reconstruction/project.cpp
+++ b/src/xmipp/libraries/reconstruction/project.cpp
@@ -27,6 +27,7 @@
 #include "directions.h"
 #include "project_real_shears.h"
 #include <data/fourier_projection.h>
+#include "core/xmipp_image_generic.h"
 
 #include <core/args.h>
 

--- a/src/xmipp/libraries/reconstruction/project_real_shears.cpp
+++ b/src/xmipp/libraries/reconstruction/project_real_shears.cpp
@@ -31,7 +31,7 @@
 #include <core/bilib/getputd.h>
 #include <core/bilib/changebasis.h>
 #include <core/bilib/configs.h>
-
+#include "core/transformations.h"
 #include "project_real_shears.h"
 
 #ifndef DBL_EPSILON

--- a/src/xmipp/libraries/reconstruction/project_xray.cpp
+++ b/src/xmipp/libraries/reconstruction/project_xray.cpp
@@ -23,6 +23,7 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 #include "project_xray.h"
+#include "core/transformations.h"
 
 void ProgXrayProject::defineParams()
 {

--- a/src/xmipp/libraries/reconstruction/radon.cpp
+++ b/src/xmipp/libraries/reconstruction/radon.cpp
@@ -24,7 +24,7 @@
  ***************************************************************************/
 
 #include "radon.h"
-
+#include "core/transformations.h"
 #include <core/geometry.h>
 
 void Radon_Transform(const MultidimArray<double> &vol, double rot, double tilt,

--- a/src/xmipp/libraries/reconstruction/reconstruct_art_pseudo.cpp
+++ b/src/xmipp/libraries/reconstruction/reconstruct_art_pseudo.cpp
@@ -28,6 +28,7 @@
 
 #include <core/histogram.h>
 #include "reconstruct_art_pseudo.h"
+#include "core/geometry.h"
 
 #define FORWARD   1
 #define BACKWARD -1

--- a/src/xmipp/libraries/reconstruction/reconstruct_art_pseudo.h
+++ b/src/xmipp/libraries/reconstruction/reconstruct_art_pseudo.h
@@ -30,6 +30,8 @@
 
 #include <core/xmipp_program.h>
 #include <core/xmipp_filename.h>
+#include "core/matrix1d.h"
+#include "core/matrix2d.h"
 
 /** Parameters for reconstructing with pseudoatoms. */
 class ProgARTPseudo: public XmippProgram

--- a/src/xmipp/libraries/reconstruction/reconstruct_art_xray.cpp
+++ b/src/xmipp/libraries/reconstruction/reconstruct_art_xray.cpp
@@ -25,6 +25,7 @@
 
 #include "reconstruct_art_xray.h"
 #include <core/metadata_extension.h>
+#include "core/transformations.h"
 
 //ProgReconsXrayART::ProgReconsXrayART()
 //{

--- a/src/xmipp/libraries/reconstruction/resolution_ibw.cpp
+++ b/src/xmipp/libraries/reconstruction/resolution_ibw.cpp
@@ -26,6 +26,7 @@
 #include "resolution_ibw.h"
 #include <data/filters.h>
 #include <data/morphology.h>
+#include "data/mask.h"
 
 /* Read parameters --------------------------------------------------------- */
 void ProgResolutionIBW::readParams()

--- a/src/xmipp/libraries/reconstruction/resolution_monotomo.cpp
+++ b/src/xmipp/libraries/reconstruction/resolution_monotomo.cpp
@@ -26,6 +26,7 @@
 
 #include "resolution_monotomo.h"
 #include <core/bilib/kernel.h>
+#include "core/linear_system_helper.h"
 //#define DEBUG
 //#define DEBUG_MASK
 //#define TEST_FRINGES

--- a/src/xmipp/libraries/reconstruction/score_micrograph.cpp
+++ b/src/xmipp/libraries/reconstruction/score_micrograph.cpp
@@ -26,7 +26,7 @@
 #include <core/args.h>
 #include <data/filters.h>
 #include <core/xmipp_fft.h>
-
+#include "data/mask.h"
 #include "score_micrograph.h"
 #include <data/fourier_filter.h>
 #include "fringe_processing.h"

--- a/src/xmipp/libraries/reconstruction/tomo_align_dual_tilt_series.cpp
+++ b/src/xmipp/libraries/reconstruction/tomo_align_dual_tilt_series.cpp
@@ -27,6 +27,7 @@
 #include <core/args.h>
 #include <data/filters.h>
 #include <core/xmipp_fftw.h>
+#include "core/geometry.h"
 
 double wrapperDualAligment(double *p, void *prm)
 {

--- a/src/xmipp/libraries/reconstruction/tomo_align_refinement.h
+++ b/src/xmipp/libraries/reconstruction/tomo_align_refinement.h
@@ -29,6 +29,7 @@
 #include <core/metadata.h>
 #include <core/xmipp_image.h>
 #include <core/xmipp_program.h>
+#include "core/matrix2d.h"
 
 /**@defgroup AngularPredictTomography angular_assign_for_tomogram (Discrete angular assignment for tomography)
    @ingroup ReconsLibrary */

--- a/src/xmipp/libraries/reconstruction/tomo_align_tilt_series.cpp
+++ b/src/xmipp/libraries/reconstruction/tomo_align_tilt_series.cpp
@@ -34,7 +34,7 @@
 #include <fstream>
 #include <queue>
 #include <iostream>
-
+#include "data/mask.h"
 #include <data/fourier_filter.h>
 
 /* Generate mask ----------------------------------------------------------- */

--- a/src/xmipp/libraries/reconstruction/tomo_align_tilt_series.h
+++ b/src/xmipp/libraries/reconstruction/tomo_align_tilt_series.h
@@ -31,6 +31,7 @@
 #include <core/metadata_extension.h>
 #include <core/xmipp_program.h>
 #include <pthread.h>
+#include "core/matrix2d.h"
 
 /**@defgroup AngularAssignTiltSeries angular_assign_for_tilt_series
              (Simultaneous assignment)

--- a/src/xmipp/libraries/reconstruction/tomo_detect_missing_wedge.cpp
+++ b/src/xmipp/libraries/reconstruction/tomo_detect_missing_wedge.cpp
@@ -27,6 +27,7 @@
 #include <core/args.h>
 #include <core/xmipp_fftw.h>
 #include <data/numerical_tools.h>
+#include "core/geometry.h"
 
 // Evaluate plane ----------------------------------------------------------
 double evaluatePlane(double rot, double tilt,

--- a/src/xmipp/libraries/reconstruction/tomo_map_back.cpp
+++ b/src/xmipp/libraries/reconstruction/tomo_map_back.cpp
@@ -25,6 +25,8 @@
 
 #include <core/args.h>
 #include "tomo_map_back.h"
+#include "core/matrix2d.h"
+#include "core/transformations.h"
 
 // Read arguments ==========================================================
 void ProgTomoMapBack::readParams()

--- a/src/xmipp/libraries/reconstruction/volume_deform_sph.cpp
+++ b/src/xmipp/libraries/reconstruction/volume_deform_sph.cpp
@@ -26,6 +26,7 @@
 #include <data/basis.h>
 #include <data/fourier_filter.h>
 #include <data/normalize.h>
+#include <iterator>
 
 // Params definition =======================================================
 void ProgVolDeformSph::defineParams() {

--- a/src/xmipp/libraries/reconstruction/volume_from_pdb.cpp
+++ b/src/xmipp/libraries/reconstruction/volume_from_pdb.cpp
@@ -25,7 +25,7 @@
  ***************************************************************************/
 
 #include "volume_from_pdb.h"
-
+#include "core/transformations.h"
 #include <core/args.h>
 
 #include <fstream>

--- a/src/xmipp/libraries/reconstruction/volume_pca.cpp
+++ b/src/xmipp/libraries/reconstruction/volume_pca.cpp
@@ -26,6 +26,7 @@
 #include <core/args.h>
 #include <data/filters.h>
 #include "volume_pca.h"
+#include "core/xmipp_image_generic.h"
 
 // Read arguments ==========================================================
 void ProgVolumePCA::readParams()

--- a/src/xmipp/libraries/reconstruction/volume_reslice.cpp
+++ b/src/xmipp/libraries/reconstruction/volume_reslice.cpp
@@ -25,6 +25,7 @@
 
 #include <core/xmipp_program.h>
 #include <core/transformations.h>
+#include "core/xmipp_image_generic.h"
 
 class ProgResliceVol : public XmippProgram
 {

--- a/src/xmipp/libraries/reconstruction/xray_import.cpp
+++ b/src/xmipp/libraries/reconstruction/xray_import.cpp
@@ -28,6 +28,8 @@
 #include <data/filters.h>
 #include <core/xmipp_image_extension.h>
 #include "xray_import.h"
+#include "core/xmipp_image_generic.h"
+#include "core/metadata_extension.h"
 
 // usage ===================================================================
 void ProgXrayImport::defineParams()


### PR DESCRIPTION
I have analyzed includes and moved some code here and there.
The aim was to eliminate chain dependencies and unnecessary includes, i.e. to build faster and to reduce impact of changes.
On my machine, this lead to total compile time of 7:19 compared to original 11:20.

Preferably check the changes by commits, as it might be a bit overwhelming all at once.

There is another matching [PR](https://github.com/I2PC/xmippCore/pull/63) for xmippCore repo.