### PR TITLE
removing a redundant confusing check

### DIFF
--- a/src/xmipp/libraries/dimred/matrix_dimred.cpp
+++ b/src/xmipp/libraries/dimred/matrix_dimred.cpp
@@ -102,7 +102,7 @@ void ProgDimRed::defineParams()
     addParamsLine("                  CorrDim: Correlation dimension");
     addParamsLine("                  MLE: Maximum Likelihood Estimate");
     addParamsLine("  [--saveMapping <fn=\"\">] : Save mapping if available (PCA, LLTSA, LPP, pPCA, NPE) so that it can be reused later (Y=X*M)");
-    addParamsLine("                            :+X is the input matrix with individuals as rows");
+    addParamsLine("                            :+X is the input matrix with individuals as rows (mean subtracted from the columns)");
     addParamsLine("                            :+Y is the output matrix with individuals as rows");
 }
 

--- a/src/xmipp/libraries/dimred/matrix_dimred.cpp
+++ b/src/xmipp/libraries/dimred/matrix_dimred.cpp
@@ -101,9 +101,13 @@ void ProgDimRed::defineParams()
     addParamsLine("       where <method>");
     addParamsLine("                  CorrDim: Correlation dimension");
     addParamsLine("                  MLE: Maximum Likelihood Estimate");
-    addParamsLine("  [--saveMapping <fn=\"\">] : Save mapping if available (PCA, LLTSA, LPP, pPCA, NPE) so that it can be reused later (Y=X*M)");
-    addParamsLine("                            :+X is the input matrix with individuals as rows (mean subtracted from the columns)");
-    addParamsLine("                            :+Y is the output matrix with individuals as rows");
+    addParamsLine("  [--saveMapping <fn=\"\">] : Save mapping if available (PCA, LLTSA, LPP, pPCA, NPE) so that it can be reused later (Y=X*M) (use the flag --more for details)");
+    addParamsLine("                            :+Y is the output matrix with individuals as rows, M is the mapping matrix");
+    addParamsLine("                            :+X is the input matrix with individuals as rows, with the mean subtracted from the columns");
+    addParamsLine("                            :+Python code to generate X:");
+    addParamsLine("                            :+    from numpy import loadtxt, mean, outer, ones");
+    addParamsLine("                            :+    X_original = loadtxt('data.txt')");
+    addParamsLine("                            :+    X = X_original - outer(ones(X_original.shape[0]),mean(X_original, axis=0))");
 }
 
 // Produce Side info  ====================================================================

--- a/src/xmipp/libraries/reconstruction/volume_from_pdb.cpp
+++ b/src/xmipp/libraries/reconstruction/volume_from_pdb.cpp
@@ -103,8 +103,6 @@ void ProgPdbConverter::produceSideInfo()
                 continue;
             std::vector< std::string > results;
             splitString(line," ",results);
-            if (results[1]=="xmipp_convert_vol2pseudo")
-                useFixedGaussian=true;
             if (useFixedGaussian && results[1]=="fixedGaussian")
                 sigmaGaussian=textToFloat(results[2]);
             if (useFixedGaussian && results[1]=="intensityColumn")


### PR DESCRIPTION
It happened that "xmipp_convert_vol2pseudo" has changed to "xmipp_volume_to_pseudoatoms" long time ago. But this code was never causing a problem because the check that it does is redundant (the if statement guarantees that useFixedGaussian is true). We are removing this line to avoid confusion.