### PR TITLE
Fixed memory leak of CudaBSplineGeoTransformer

### DIFF
--- a/src/xmipp/libraries/reconstruction_cuda/cuda_bspline_geo_transformer.h
+++ b/src/xmipp/libraries/reconstruction_cuda/cuda_bspline_geo_transformer.h
@@ -39,6 +39,10 @@ public:
         setDefault();
     }
 
+    virtual ~CudaBSplineGeoTransformer() {
+        release();
+    }
+
     void setSrc(const T *data) override;
 
     const T *getSrc() const override {


### PR DESCRIPTION
When CudaBSplineGeoTransformer object was destroyed, it didn't properly release allocated memory.
I added a destructor that releases the resources.