### PR TITLE
Update metadata imports in matlab binding

### DIFF
--- a/src/xmipp/bindings/matlab/xmipp_nma_read_alignment.cpp
+++ b/src/xmipp/bindings/matlab/xmipp_nma_read_alignment.cpp
@@ -1,6 +1,6 @@
 #include <fstream>
 #include <mex.h>
-#include <core/metadata.h>
+#include <core/xmipp_metadata_program.h>
 
 /* the gateway function */
 void mexFunction( int nlhs, mxArray *plhs[],
@@ -17,7 +17,7 @@ void mexFunction( int nlhs, mxArray *plhs[],
   mxGetString(prhs[0],nmaDir,mxGetN(prhs[0])+1);
   
   /* Read images */
-  MetaData mdImages;
+  MetaDataVec mdImages;
   mdImages.read(((String)nmaDir)+"/images.xmd");
   if (!mdImages.containsLabel(MDL_NMA))
   {
@@ -53,7 +53,7 @@ void mexFunction( int nlhs, mxArray *plhs[],
   int nImgs=(int)mdImages.size();
 
   /* Read modes */
-  MetaData mdModes;
+  MetaDataVec mdModes;
   mdModes.read(((String)nmaDir)+"/modes.xmd");
   mdModes.removeDisabled();
   int nModes=(int)mdModes.size();
@@ -73,12 +73,12 @@ void mexFunction( int nlhs, mxArray *plhs[],
   std::vector<double> lambda;
   FOR_ALL_OBJECTS_IN_METADATA(mdImages)
   {
-	  mdImages.getValue(MDL_IMAGE,fnImg,__iter.objId);
+	  mdImages.getValue(MDL_IMAGE,fnImg,objId);
 	  mxSetCell(plhs[0], i, mxCreateString(fnImg.c_str()));
-	  mdImages.getValue(MDL_NMA,lambda,__iter.objId);
+	  mdImages.getValue(MDL_NMA,lambda,objId);
 	  for (int j=0; j<nModes; ++j)
 		  ptrNMADistplacements[j*nImgs+i]=lambda[j]; // x*Ydim+y
-	  mdImages.getValue(MDL_COST,*ptrCost,__iter.objId);
+	  mdImages.getValue(MDL_COST,*ptrCost,objId);
 	  i++;
 	  ptrCost++;
   }

--- a/src/xmipp/bindings/matlab/xmipp_nma_save_cluster.cpp
+++ b/src/xmipp/bindings/matlab/xmipp_nma_save_cluster.cpp
@@ -1,5 +1,5 @@
 #include <mex.h>
-#include <core/metadata.h>
+#include <core/xmipp_metadata_program.h>
 
 /* the gateway function */
 /* xmipp_nma_save_cluster(NMAdirectory,clusterName,inCluster) */
@@ -18,17 +18,17 @@ void mexFunction( int nlhs, mxArray *plhs[],
   double *ptrInCluster = mxGetPr(prhs[2]);
   
   /* Read images */
-  MetaData mdImages, mdImagesOut;
+  MetaDataVec mdImages, mdImagesOut;
   mdImages.read(((String)nmaDir)+"/images.xmd");
   mdImages.removeDisabled();
 
   // Fill output
-  MDRow row;
+  MDRowVec row;
   FOR_ALL_OBJECTS_IN_METADATA(mdImages)
   {
 	  if (*ptrInCluster!=0)
 	  {
-		  mdImages.getRow(row,__iter.objId);
+		  mdImages.getRow(row,objId);
 		  size_t id=mdImagesOut.addObject();
 		  mdImagesOut.setRow(row,id);
 	  }

--- a/src/xmipp/bindings/matlab/xmipp_read_structure_factor.cpp
+++ b/src/xmipp/bindings/matlab/xmipp_read_structure_factor.cpp
@@ -1,5 +1,5 @@
 #include <mex.h>
-#include <core/metadata.h>
+#include <core/xmipp_metadata_program.h>
 
 /* the gateway function */
 void mexFunction( int nlhs, mxArray *plhs[],
@@ -16,7 +16,7 @@ void mexFunction( int nlhs, mxArray *plhs[],
   mxGetString(prhs[0],runDir,mxGetN(prhs[0])+1);
   
   /* Read metadata */
-  MetaData md;
+  MetaDataVec md;
   md.read(((String)runDir)+"/structureFactor.xmd");
   int nSamples=(int)md.size();
 
@@ -30,8 +30,8 @@ void mexFunction( int nlhs, mxArray *plhs[],
   int i=0;
   FOR_ALL_OBJECTS_IN_METADATA(md)
   {
-	  md.getValue(MDL_RESOLUTION_FREQ2,*ptrFreq2++,__iter.objId);
-	  md.getValue(MDL_RESOLUTION_LOG_STRUCTURE_FACTOR,*ptrLogStruct++,__iter.objId);
+	  md.getValue(MDL_RESOLUTION_FREQ2,*ptrFreq2++,objId);
+	  md.getValue(MDL_RESOLUTION_LOG_STRUCTURE_FACTOR,*ptrLogStruct++,objId);
   }
   
 }


### PR DESCRIPTION
Some programs in matlab binding have been updated to fix the compilation errors arising from an outdated metadata import.