### PR TITLE
Compilation: MatLab compilation raises exceptions on fail

### DIFF
--- a/src/xmipp/SConscript
+++ b/src/xmipp/SConscript
@@ -373,7 +373,9 @@ def compileMatlabBinding(target, source, env):
     mex = join(env['MATLAB_DIR'], 'bin', 'mex')
     command = '%s -O CFLAGS="\$CFLAGS -std=c++11 -fpermissive" -outdir %s %s %s %s %s ' % (mex, matlabDir, incStr, libStr, libs, source[0])
     print(command)
-    os.system(command)
+    matlab_ok = os.system(command)
+    if matlab_ok != 0:
+        raise Exception('MatLab Binding compilation failed...')
 
 # Matlab programs
 def addMatlabBinding(name):


### PR DESCRIPTION
`Sconscript` has been modified so it raises an exception whenever the compilation of a  program included in the MatLab binding fails. Previously, these errors were not handled and the compilation of Xmipp finished without reporting them.

This PR shouldn't be merged until devel and release branches have the same changes to avoid MatLab compilation issues.