### PR TITLE
Opencv not detected. Added include to user/include/opencv4 folder on config file

### DIFF
--- a/scripts/config.py
+++ b/scripts/config.py
@@ -327,6 +327,9 @@ class Config:
                 if hdf5Inc:
                     self.configDict["INCDIRFLAGS"] += " -I%s" % hdf5Inc
 
+            if findFileInDirList("opencv4/opencv2/core/core.hpp", ["/usr/include"]):
+                self.configDict["INCDIRFLAGS"] += " -I%s" % "/usr/include/opencv4"
+
         if self.configDict["PYTHON_LIB"] == "":
             # malloc flavour is not needed from 3.8
             malloc = "m" if sys.version_info.minor < 8 else ""


### PR DESCRIPTION
Added an include in "xmipp.conf" `INCDIRFLAGS` if an `opencv4/opencv2/core/core` is found.
--> [issue#436](https://github.com/I2PC/xmipp/issues/436#issuecomment-947595634)