### PR TITLE
xmipp install: Linking libsvm to scipion

### DIFF
--- a/xmipp
+++ b/xmipp
@@ -694,8 +694,10 @@ def install(dirname):
     if os.path.isdir(scipionLibs) and os.path.isdir(scipionBindings):
         coreLib = os.path.join(dirname, "lib", "libXmippCore.so")
         xmippLib = os.path.join(dirname, "lib", "libXmipp.so")
+        SVMLib = os.path.join(dirname, "lib", "libsvm.so")
         bindings = os.path.join(dirname, "bindings", "python", "*")
         runJob("ln -srf %s %s" % (coreLib, scipionLibs))
+        runJob("ln -srf %s %s" % (SVMLib, scipionLibs))
         runJob("ln -srf %s %s" % (xmippLib, scipionLibs))
         runJob("ln -srf %s %s" % (bindings, scipionBindings))
     else:


### PR DESCRIPTION
To fix the issue on closed [ PR ](https://github.com/I2PC/xmipp/pull/471). Added link to libsvm.so on 
build/lib/libsvm.so -> /home/agarcia/scipion3/software/lib