### PR TITLE
Transform Geometry: save new shifted coordinates in option "shift to" + CenterOfMass to python binding

### DIFF
--- a/src/xmipp/bindings/python/python_image.cpp
+++ b/src/xmipp/bindings/python/python_image.cpp
@@ -154,7 +154,8 @@ PyMethodDef Image_methods[] =
           "apply a warp affine transformation equivalent to cv2.warpaffine and used by Scipion" },
 		{ "radialAverageAxis", (PyCFunction) Image_radialAvgAxis, METH_VARARGS,
 		  "compute radial average around an axis" },
-
+        { "centerOfMass", (PyCFunction) Image_centerOfMass, METH_VARARGS,
+          "Return image center of mass as a tuple" },
 
         { nullptr } /* Sentinel */
     };//Image_methods
@@ -1856,4 +1857,28 @@ Image_radialAvgAxis(PyObject *obj, PyObject *args, PyObject *kwargs)
 	        PyErr_SetString(PyXmippError, xe.msg.c_str());
 	    }
     return Py_BuildValue("");
+}
+
+/* Return center of mass as a tuple */
+PyObject *
+Image_centerOfMass(PyObject *obj, PyObject *args, PyObject *kwargs)
+{
+    ImageObject *self = (ImageObject*) obj;
+    if (self != NULL)
+    {
+        try
+        {
+            Matrix1D< double > center;
+            self->image->convert2Datatype(DT_Double);
+            MultidimArray<double> *in;
+            MULTIDIM_ARRAY_GENERIC(*self->image).getMultidimArrayPointer(in);
+            in->centerOfMass(center);
+            return Py_BuildValue("fff", XX(center), YY(center), ZZ(center));
+        }
+        catch (XmippError &xe)
+        {
+            PyErr_SetString(PyXmippError, xe.msg.c_str());
+        }
+    }
+    return NULL;
 }

--- a/src/xmipp/bindings/python/python_image.cpp
+++ b/src/xmipp/bindings/python/python_image.cpp
@@ -1861,10 +1861,10 @@ Image_radialAvgAxis(PyObject *obj, PyObject *args, PyObject *kwargs)
 
 /* Return center of mass as a tuple */
 PyObject *
-Image_centerOfMass(PyObject *obj, PyObject *args, PyObject *kwargs)
+Image_centerOfMass(PyObject *obj)
 {
-    ImageObject *self = (ImageObject*) obj;
-    if (self != NULL)
+    auto *self = (ImageObject*) obj;
+    if (self != nullptr)
     {
         try
         {
@@ -1875,10 +1875,10 @@ Image_centerOfMass(PyObject *obj, PyObject *args, PyObject *kwargs)
             in->centerOfMass(center);
             return Py_BuildValue("fff", XX(center), YY(center), ZZ(center));
         }
-        catch (XmippError &xe)
+        catch (const XmippError &xe)
         {
             PyErr_SetString(PyXmippError, xe.msg.c_str());
         }
     }
-    return NULL;
+    return nullptr;
 }

--- a/src/xmipp/bindings/python/python_image.h
+++ b/src/xmipp/bindings/python/python_image.h
@@ -263,6 +263,9 @@ Image_inplaceDivide(PyObject *self, PyObject *args, PyObject *kwargs);
 PyObject *
 Image_radialAvgAxis(PyObject *obj, PyObject *args, PyObject *kwargs);
 
+PyObject *
+Image_centerOfMass(PyObject *obj, PyObject *args, PyObject *kwargs);
+
 
 extern PyNumberMethods Image_NumberMethods;
 extern PyMethodDef Image_methods[];

--- a/src/xmipp/bindings/python/python_image.h
+++ b/src/xmipp/bindings/python/python_image.h
@@ -264,7 +264,7 @@ PyObject *
 Image_radialAvgAxis(PyObject *obj, PyObject *args, PyObject *kwargs);
 
 PyObject *
-Image_centerOfMass(PyObject *obj, PyObject *args, PyObject *kwargs);
+Image_centerOfMass(PyObject *obj);
 
 
 extern PyNumberMethods Image_NumberMethods;

--- a/src/xmipp/libraries/data/transform_geometry.cpp
+++ b/src/xmipp/libraries/data/transform_geometry.cpp
@@ -259,6 +259,14 @@ void ProgTransformGeometry::processImage(const FileName &fnImg,
 		rowOut.setValue(MDL_SHIFT_X, -posp(0));
 		rowOut.setValue(MDL_SHIFT_Y, -posp(1));
 		T.initIdentity(3);
+		int nx;
+		rowIn.getValue(MDL_XCOOR, nx);
+		nx += - posp(0);
+		rowOut.setValue(MDL_XCOOR, nx);
+		int ny;
+		rowIn.getValue(MDL_YCOOR, ny);
+		ny += - posp(1);
+		rowOut.setValue(MDL_YCOOR, ny);
 		geo2TransformationMatrix(rowOut, T, true);
     }
 

--- a/src/xmipp/libraries/data/transform_geometry.cpp
+++ b/src/xmipp/libraries/data/transform_geometry.cpp
@@ -261,11 +261,11 @@ void ProgTransformGeometry::processImage(const FileName &fnImg,
 		T.initIdentity(3);
 		int nx;
 		rowIn.getValue(MDL_XCOOR, nx);
-		nx += - posp(0);
+		nx += int(-posp(0));
 		rowOut.setValue(MDL_XCOOR, nx);
 		int ny;
 		rowIn.getValue(MDL_YCOOR, ny);
-		ny += - posp(1);
+		ny += int(-posp(1));
 		rowOut.setValue(MDL_YCOOR, ny);
 		geo2TransformationMatrix(rowOut, T, true);
     }


### PR DESCRIPTION
Transform_geometry: save new shifted coordinates in option shift to
Add centerOfMass to python binding as it is used now in protocol shift_particles (https://github.com/I2PC/scipion-em-xmipp/pull/456)