### PR TITLE
bug fix and allowed controlling high sampling rate

### DIFF
--- a/src/xmipp/libraries/reconstruction/project.cpp
+++ b/src/xmipp/libraries/reconstruction/project.cpp
@@ -37,6 +37,7 @@ void ProgProject::readParams()
     fnPhantom = getParam("-i");
     fnOut = getParam("-o");
     samplingRate  = getDoubleParam("--sampling_rate");
+    highTs = getDoubleParam("--high_sampling_rate");
     singleProjection = false;
     if (STR_EQUAL(getParam("--method"), "real_space"))
         projType = REALSPACE;
@@ -96,6 +97,7 @@ void ProgProject::defineParams()
     addParamsLine("   -i <volume_file>                           : Voxel volume, PDB or description file");
     addParamsLine("   -o <image_file>                            : Output stack or image");
     addParamsLine("  [--sampling_rate <Ts=1>]                    : It is only used for PDB phantoms");
+    addParamsLine("  [--high_sampling_rate <highTs=0.08333333>]  : Sampling rate before downsampling. It is only used for PDB phantoms");
     addParamsLine("  [--method <method=real_space>]              : Projection method");
     addParamsLine("        where <method>");
     addParamsLine("                real_space                    : Makes projections by ray tracing in real space");
@@ -896,8 +898,13 @@ void PROJECT_Side_Info::produce_Side_Info(ParametersProjection &prm,
     else if (prog_prm.fnPhantom.getExtension()=="pdb")
     {
         phantomPDB.read(prog_prm.fnPhantom);
-        const double highTs=1.0/12.0;
-        int M=ROUND(prog_prm.samplingRate/highTs);
+        for (int i=0; i<phantomPDB.atomList.size(); i++)
+        {
+		phantomPDB.atomList[i].x /=prog_prm.samplingRate;
+		phantomPDB.atomList[i].y /=prog_prm.samplingRate;
+		phantomPDB.atomList[i].z /=prog_prm.samplingRate;
+        }
+        int M=ROUND(prog_prm.samplingRate/prog_prm.highTs);
         interpolator.setup(M,prog_prm.samplingRate/M,true);
         phantomMode = PDB;
         if (prog_prm.singleProjection)

--- a/src/xmipp/libraries/reconstruction/project.h
+++ b/src/xmipp/libraries/reconstruction/project.h
@@ -61,6 +61,8 @@ public:
     int projSize;
     /// Sampling rate: Only used for PDB projections
     double samplingRate;
+    /// High sampling rate: Only used for PDB projections
+    double highTs;
     /// Only create angles, do not project
     bool only_create_angles;
     /// Single projection


### PR DESCRIPTION
The original script had a missing step of dividing the atomic coordinates by the sampling rate. Also, I added a flag to control the high sampling rate (lower values give better images), since this parameter exists to the user in xmipp_volume_from_pdb