### PR TITLE
Fixing importing pwem.metadata

### DIFF
--- a/src/xmipp/libraries/py_xmipp/deepDenoising/gan.py
+++ b/src/xmipp/libraries/py_xmipp/deepDenoising/gan.py
@@ -26,7 +26,7 @@ from skimage.transform import rotate
 
 import xmippLib
 import matplotlib.pyplot as plt
-import pwem.metadata as md
+import pwem.emlib.metadata as md
 from .DeepLearningGeneric import DeepLearningModel
 from .dataGenerator import normalizeImgs, getDataGenerator, extractNBatches
 


### PR DESCRIPTION
Trying to fix that [#283 issue:](https://github.com/scipion-em/scipion-em/issues/283) 
Fixing importing path, similar to [this](https://github.com/I2PC/scipion-em-xmipp/blob/bfa4101e0ce1d4dea30b8161b7c4935479f93c9a/xmipp3/protocols/protocol_align_volume_and_particles.py#L35) 
I cant reproduce the issue... but `import pwem.metadata` must be an error