### PR TITLE
Support newer versions of CUDA and gcc

### DIFF
--- a/scripts/config.py
+++ b/scripts/config.py
@@ -500,9 +500,9 @@ class Config:
             # nvcc 11.4.1 --> gcc 11
             return v[v.index('9.3'):]
         elif 11.1 <= nvcc_version < 11.5:
-            return v[v.index('10'):]
+            return v[v.index('9.3'):]
         elif 11.5 <= nvcc_version <= 11.6:
-            return v[v.index('11.2'):]
+            return v[v.index('9.4'):]
         return []  # not supported
 
     def _join_with_prefix(self, collection, prefix):

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -494,7 +494,7 @@ class Config:
         elif 9.2 <= nvcc_version < 10.1:
             return v[v.index('7.3'):]
         elif 10.1 <= nvcc_version <= 10.2:
-            return v[v.index('8.4'):]
+            return v[v.index('8.5'):]
         elif 11.0 <= nvcc_version <= 11.4:
             # nvcc 11.4.0 --> gcc 9.3
             # nvcc 11.4.1 --> gcc 11

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -496,14 +496,14 @@ class Config:
         elif 10.1 <= nvcc_version <= 10.2:
             return v[v.index('8.5'):]
         elif 11.0 <= nvcc_version < 11.1:
-            # nvcc 11.4.0 --> gcc 10
-            # nvcc 11.4.1 --> gcc 11
             return v[v.index('9.3'):]
         elif 11.1 <= nvcc_version < 11.5:
-            return v[v.index('9.3'):]
+            # nvcc 11.4.0 --> gcc 10
+            # nvcc 11.4.1 --> gcc 11
+            return v[v.index('10.0'):]
         elif 11.5 <= nvcc_version <= 11.6:
-            return v[v.index('9.4'):]
-        return []  # not supported
+            return v[v.index('11'):]
+        return []
 
     def _join_with_prefix(self, collection, prefix):
         return ' '.join([prefix + i for i in collection if i])

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -495,12 +495,14 @@ class Config:
             return v[v.index('7.3'):]
         elif 10.1 <= nvcc_version <= 10.2:
             return v[v.index('8.5'):]
-        elif 11.0 <= nvcc_version <= 11.4:
-            # nvcc 11.4.0 --> gcc 9.3
+        elif 11.0 <= nvcc_version < 11.1:
+            # nvcc 11.4.0 --> gcc 10
             # nvcc 11.4.1 --> gcc 11
             return v[v.index('9.3'):]
+        elif 11.1 <= nvcc_version < 11.5:
+            return v[v.index('10'):]
         elif 11.5 <= nvcc_version <= 11.6:
-            return v[v.index('9.3'):]#gcc 11 is suported by nvcc not by XMIPP
+            return v[v.index('11.2'):]
         return []  # not supported
 
     def _join_with_prefix(self, collection, prefix):

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -479,9 +479,10 @@ class Config:
 
     def _get_compatible_GCC(self, nvcc_version):
         # https://gist.github.com/ax3l/9489132
-        v = ['10.2', '10.1', '10',
-             '9.3', '9.2', '9.1', '9',
-             '8.4', '8.3', '8.2', '8.1', '8',
+        v = ['11.2', '11.1', '11',
+             '10.3', '10.2', '10.1', '10',
+             '9.4', '9.3', '9.2', '9.1', '9',
+             '8.5', '8.4', '8.3', '8.2', '8.1', '8',
              '7.5', '7.4', '7.3', '7.2', '7.1', '7',
              '6.5', '6.4', '6.3', '6.2', '6.1', '6',
              '5.5', '5.4', '5.3', '5.2', '5.1', '5',
@@ -494,8 +495,12 @@ class Config:
             return v[v.index('7.3'):]
         elif 10.1 <= nvcc_version <= 10.2:
             return v[v.index('8.4'):]
-        elif 11.0 <= nvcc_version <= 11.2:
+        elif 11.0 <= nvcc_version <= 11.4:
+            # nvcc 11.4.0 --> gcc 9.3
+            # nvcc 11.4.1 --> gcc 11
             return v[v.index('9.3'):]
+        elif 11.5 <= nvcc_version <= 11.6:
+            return v[v.index('9.3'):]#gcc 11 is suported by nvcc not by XMIPP
         return []  # not supported
 
     def _join_with_prefix(self, collection, prefix):


### PR DESCRIPTION
Supporting new CUDA's and gcc based on [it](https://gist.github.com/ax3l/9489132) 
[Related: Issue507](https://github.com/I2PC/xmipp/issues/507)
Limitations: Does not support gcc over version 9.3  (gcc 11 does not work for me)