### PR TITLE
xmipp_test_pocs_main & volume_subtraction: fixes

### DIFF
--- a/src/xmipp/applications/tests/function_tests/test_pocs_main.cpp
+++ b/src/xmipp/applications/tests/function_tests/test_pocs_main.cpp
@@ -13,7 +13,7 @@ class POCSTest : public ::testing::Test
 protected:
     virtual void SetUp()
     {
-        img().resize(3,3);
+        img().resize(16,16,16);
         img().initConstant(0.0);
         img(1,1,1) = 1;
         imgAux = img;

--- a/src/xmipp/libraries/reconstruction/volume_subtraction.cpp
+++ b/src/xmipp/libraries/reconstruction/volume_subtraction.cpp
@@ -170,11 +170,7 @@ void POCSFourierAmplitudeRadAvg(MultidimArray<std::complex<double>> &V,
 			{
 				FFT_IDX2DIGFREQ_FAST(j,V1size_x,V1size2_x,V1sizei_x,wx)
 				double w = sqrt(wx*wx + wy2_wz2);
-				auto iw = (int)floor(w*V1size_x);
-				if (iw >= XSIZE(rQ))
-				{
-					iw = iw - 1;
-				}
+				auto iw = std::min((int)floor(w*V1size_x), (int)XSIZE(rQ) -1);
 				DIRECT_A3D_ELEM(V,k,i,j)*=(1-l)+l*DIRECT_MULTIDIM_ELEM(rQ,iw);
 			}
 		}

--- a/src/xmipp/libraries/reconstruction/volume_subtraction.cpp
+++ b/src/xmipp/libraries/reconstruction/volume_subtraction.cpp
@@ -170,13 +170,16 @@ void POCSFourierAmplitudeRadAvg(MultidimArray<std::complex<double>> &V,
 			{
 				FFT_IDX2DIGFREQ_FAST(j,V1size_x,V1size2_x,V1sizei_x,wx)
 				double w = sqrt(wx*wx + wy2_wz2);
-				auto iw = (int)round(w*V1size_x);
+				auto iw = (int)floor(w*V1size_x);
+				if (iw >= XSIZE(rQ))
+				{
+					iw = iw - 1;
+				}
 				DIRECT_A3D_ELEM(V,k,i,j)*=(1-l)+l*DIRECT_MULTIDIM_ELEM(rQ,iw);
 			}
 		}
 	}
 }
-
 
 void POCSMinMax(MultidimArray<double> &V, double v1m, double v1M) {
 	FOR_ALL_DIRECT_ELEMENTS_IN_MULTIDIMARRAY(V) {


### PR DESCRIPTION
Fix in test to have a 3D matrix with more realistic size + sanity check and fix added to volume_subtraction when `index (iw) > last index of radial quotient (rQ)` 