### PR TITLE
Fixed unitialized unique pointers

### DIFF
--- a/src/xmipp/bindings/python/python_image.cpp
+++ b/src/xmipp/bindings/python/python_image.cpp
@@ -34,11 +34,6 @@
 /*                            Image                         */
 /**************************************************************/
 
-/* Destructor */
-void Image_dealloc(ImageObject* self)
-{
-    Py_TYPE(self)->tp_free((PyObject*)self);
-}//function Image_dealloc
 
 
 /* Image methods that behave like numbers */
@@ -204,11 +199,20 @@ PyTypeObject ImageType = {
                              Image_new, /* tp_new */
                          };//ImageType
 
+/* Destructor */
+void Image_dealloc(ImageObject* self)
+{
+    self->~ImageObject(); // Call the destructor
+    Py_TYPE(self)->tp_free((PyObject*)self);
+}//function Image_dealloc
+
 /* Constructor */
 PyObject *
 Image_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 {
     ImageObject *self = (ImageObject*)type->tp_alloc(type, 0);
+    new (self) ImageObject(); //Call the constructor in place
+
     if (self != nullptr)
     {
         PyObject *input = nullptr;

--- a/src/xmipp/bindings/python/python_image.cpp
+++ b/src/xmipp/bindings/python/python_image.cpp
@@ -211,7 +211,6 @@ PyObject *
 Image_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 {
     ImageObject *self = (ImageObject*)type->tp_alloc(type, 0);
-    new (self) ImageObject(); //Call the constructor in place
 
     if (self != nullptr)
     {

--- a/src/xmipp/bindings/python/python_image.cpp
+++ b/src/xmipp/bindings/python/python_image.cpp
@@ -1241,7 +1241,7 @@ Image_computePSD(PyObject *obj, PyObject *args, PyObject *kwargs)
         int dimX = 384;
         int dimY = 384;
         unsigned threads = 1;
-        ImageObject *result = PyObject_New(ImageObject, &ImageType);
+        ImageObject *result = (ImageObject*)PyObject_CallFunction((PyObject*)&ImageType, "");
         if (PyArg_ParseTuple(args, "|fIIb", &overlap, &dimX, &dimY, &threads)
                 && (nullptr != result)) {
             // prepare dims
@@ -1273,7 +1273,7 @@ Image_adjustAndSubtract(PyObject *obj, PyObject *args, PyObject *kwargs)
 {
     const auto *self = reinterpret_cast<ImageObject*>(obj);
     PyObject *pimg2 = nullptr;
-    ImageObject * result = PyObject_New(ImageObject, &ImageType);
+    ImageObject * result = (ImageObject*)PyObject_CallFunction((PyObject*)&ImageType, "");
     if (self != nullptr)
     {
         try
@@ -1374,7 +1374,7 @@ Image_correlationAfterAlignment(PyObject *obj, PyObject *args, PyObject *kwargs)
 PyObject *
 Image_add(PyObject *obj1, PyObject *obj2)
 {
-    ImageObject * result = PyObject_New(ImageObject, &ImageType);
+    ImageObject * result = (ImageObject*)PyObject_CallFunction((PyObject*)&ImageType, "");
     if (result != nullptr)
     {
         try
@@ -1399,7 +1399,7 @@ Image_iadd(PyObject *obj1, PyObject *obj2)
     try
     {
         Image_Value(obj1).add(Image_Value(obj2));
-        if ((result = PyObject_New(ImageObject, &ImageType)))
+        if ((result = (ImageObject*)PyObject_CallFunction((PyObject*)&ImageType, "")))
             result->image = std::make_unique<ImageGeneric>(Image_Value(obj1));
         //return obj1;
     }
@@ -1449,7 +1449,7 @@ Image_inplaceAdd(PyObject *self, PyObject *args, PyObject *kwargs)
 PyObject *
 Image_subtract(PyObject *obj1, PyObject *obj2)
 {
-    ImageObject * result = PyObject_New(ImageObject, &ImageType);
+    ImageObject * result = (ImageObject*)PyObject_CallFunction((PyObject*)&ImageType, "");
     if (result != nullptr)
     {
         try
@@ -1474,7 +1474,7 @@ Image_isubtract(PyObject *obj1, PyObject *obj2)
     try
     {
         Image_Value(obj1).subtract(Image_Value(obj2));
-        if ((result = PyObject_New(ImageObject, &ImageType)))
+        if ((result = (ImageObject*)PyObject_CallFunction((PyObject*)&ImageType, "")))
             result->image = std::make_unique<ImageGeneric>(Image_Value(obj1));
     }
     catch (XmippError &xe)
@@ -1515,7 +1515,7 @@ Image_inplaceSubtract(PyObject *self, PyObject *args, PyObject *kwargs)
 PyObject *
 Image_multiply(PyObject *obj1, PyObject *obj2)
 {
-    ImageObject * result = PyObject_New(ImageObject, &ImageType);
+    ImageObject * result = (ImageObject*)PyObject_CallFunction((PyObject*)&ImageType, "");
     if (result != nullptr)
     {
         try
@@ -1540,7 +1540,7 @@ Image_imultiply(PyObject *obj1, PyObject *obj2)
     try
     {
         ImageObject * result = nullptr;
-        if ((result = PyObject_New(ImageObject, &ImageType)))
+        if ((result = (ImageObject*)PyObject_CallFunction((PyObject*)&ImageType, "")))
             result->image = std::make_unique<ImageGeneric>(Image_Value(obj1));
         double value = PyFloat_AsDouble(obj2);
         Image_Value(result).multiply(value);
@@ -1590,7 +1590,7 @@ PyObject *
 Image_true_divide(PyObject *obj1, PyObject *obj2)
 {
     std::cerr << "TODO: not working Image_divide_____________________________" << std::endl;
-    ImageObject * result = PyObject_New(ImageObject, &ImageType);
+    ImageObject * result = (ImageObject*)PyObject_CallFunction((PyObject*)&ImageType, "");
     if (result != nullptr)
     {
         try
@@ -1620,7 +1620,7 @@ Image_idivide(PyObject *obj1, PyObject *obj2)
     try
     {
       ImageObject * result = nullptr;
-      if ((result = PyObject_New(ImageObject, &ImageType)))
+      if ((result = (ImageObject*)PyObject_CallFunction((PyObject*)&ImageType, "")))
           result->image = std::make_unique<ImageGeneric>(Image_Value(obj1));
       double value = PyFloat_AsDouble(obj2);
       Image_Value(result).divide(value);
@@ -1830,7 +1830,7 @@ Image_warpAffine(PyObject *obj, PyObject *args, PyObject *kwargs)
             MULTIDIM_ARRAY_GENERIC(*image).getMultidimArrayPointer(in);
             in->setXmippOrigin();
 
-            ImageObject *result = PyObject_New(ImageObject, &ImageType);
+            ImageObject *result = (ImageObject*)PyObject_CallFunction((PyObject*)&ImageType, "");
             result->image = std::make_unique<ImageGeneric>(DT_Double);
             MultidimArray<double> *out;
             MULTIDIM_ARRAY_GENERIC(*result->image).getMultidimArrayPointer(out);
@@ -1905,7 +1905,7 @@ Image_radialAvgAxis(PyObject *obj, PyObject *args, PyObject *kwargs)
 	    if (nullptr == self) return nullptr;
 	    try {
 	    	char axis = 'z';
-	        ImageObject *result = PyObject_New(ImageObject, &ImageType);
+	        ImageObject *result = (ImageObject*)PyObject_CallFunction((PyObject*)&ImageType, "");
 	        if (PyArg_ParseTuple(args, "|c", &axis)
 	                && (nullptr != result)) {
 	            // prepare input image

--- a/src/xmipp/bindings/python/python_image.h
+++ b/src/xmipp/bindings/python/python_image.h
@@ -51,8 +51,6 @@ typedef struct
 }
 ImageObject;
 
-#define ImageObject_New() (ImageObject*)malloc(sizeof(ImageObject))
-
 /* Destructor */
 void Image_dealloc(ImageObject* self);
 

--- a/src/xmipp/bindings/python/python_metadata.cpp
+++ b/src/xmipp/bindings/python/python_metadata.cpp
@@ -80,7 +80,7 @@ PyMethodDef MDQuery_methods[] = { { nullptr } /* Sentinel */
 /* Destructor */
 void MDQuery_dealloc(MDQueryObject* self)
 {
-    self->~MDQueryObject();
+    self->~MDQueryObject(); // Call the destructor
     Py_TYPE(self)->tp_free((PyObject*)self);
 }
 
@@ -89,7 +89,6 @@ PyObject *
 MDQuery_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 {
     auto *self = (MDQueryObject*)type->tp_alloc(type, 0);
-    new (self) MDQueryObject(); // Construct the object in place
     return (PyObject *)self;
 }
 
@@ -127,7 +126,7 @@ createMDValueRelational(PyObject *args, int op)
         auto object = createMDObject(label, pyValue);
         if (!object)
             return nullptr;
-        auto * pyQuery = PyObject_New(MDQueryObject, &MDQueryType);
+        auto *pyQuery = (MDQueryObject*)PyObject_CallFunction((PyObject*)&MDQueryType, "");
         pyQuery->query = std::make_unique<MDValueRelational>(*object, (RelationalOp) op,
                                                limit, offset, (MDLabel) orderLabel);
         return (PyObject *) pyQuery;
@@ -194,7 +193,7 @@ xmipp_MDValueRange(PyObject *obj, PyObject *args, PyObject *kwargs)
         auto object2 = createMDObject(label, pyValue2);
         if (!object1 || !object2)
             return nullptr;
-        auto * pyQuery = PyObject_New(MDQueryObject, &MDQueryType);
+        auto *pyQuery = (MDQueryObject*)PyObject_CallFunction((PyObject*)&MDQueryType, "");
         pyQuery->query = std::make_unique<MDValueRange>(*object1, *object2, limit, offset,
                                           (MDLabel) orderLabel);
         return (PyObject *) pyQuery;
@@ -495,7 +494,6 @@ PyObject *
 MetaData_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 {
     auto *self = (MetaDataObject*)type->tp_alloc(type, 0);
-    new (self) MetaDataObject(); // Construct the object in place
 
     if (self != nullptr)
     {

--- a/src/xmipp/bindings/python/python_metadata.h
+++ b/src/xmipp/bindings/python/python_metadata.h
@@ -58,6 +58,9 @@ MDQueryObject;
 
 /* Destructor */
 void MDQuery_dealloc(MDQueryObject* self);
+/* Constructor */
+PyObject *
+MDQuery_new(PyTypeObject *type, PyObject *args, PyObject *kwargs);
 
 /* String representation */
 PyObject *
@@ -129,6 +132,9 @@ MetaDataObject;
 /* Destructor */
 void MetaData_dealloc(MetaDataObject* self);
 /* Constructor */
+PyObject *
+MetaData_new(PyTypeObject *type, PyObject *args, PyObject *kwargs);
+
  PyObject *
 MetaData_aggregate(PyObject *obj, PyObject *args, PyObject *kwargs);
 
@@ -156,8 +162,6 @@ MetaData_intersection(PyObject *obj, PyObject *args, PyObject *kwargs);
  PyObject *
 MetaData_merge(PyObject *obj, PyObject *args, PyObject *kwargs);
 
-PyObject *
-MetaData_new(PyTypeObject *type, PyObject *args, PyObject *kwargs);
 
  PyObject *
 MetaData_operate(PyObject *obj, PyObject *args, PyObject *kwargs);

--- a/src/xmipp/bindings/python/xmippmodule.cpp
+++ b/src/xmipp/bindings/python/xmippmodule.cpp
@@ -1142,7 +1142,7 @@ Image_align(PyObject *obj, PyObject *args, PyObject *kwargs)
 {
     PyObject *pimg1 = nullptr;
     PyObject *pimg2 = nullptr;
-    auto * result = PyObject_New(ImageObject, &ImageType);
+    auto * result = (ImageObject*)PyObject_CallFunction((PyObject*)&ImageType, "");
 	try
 	{
 		if (PyArg_ParseTuple(args, "OO", &pimg1, &pimg2))
@@ -1257,7 +1257,7 @@ Image_projectVolumeDouble(PyObject *obj, PyObject *args, PyObject *kwargs)
             mVolume->getDimensions(aDim);
             mVolume->setXmippOrigin();
             projectVolume(*mVolume, P, aDim.xdim, aDim.ydim,rot, tilt, psi);
-            result = PyObject_New(ImageObject, &ImageType);
+            result = (ImageObject*)PyObject_CallFunction((PyObject*)&ImageType, "");
             Image <double> I;
             result->image = std::make_unique<ImageGeneric>();
             result->image->setDatatype(DT_Double);


### PR DESCRIPTION
A new bug was added when switching from raw pointers to std::unique_ptr-s in the python binding. This bug originates from the allocation of structs that hold these unique pointers but their constructor is not called because they are allocated by Python. Therefore, they hold a random memory address which will be freed as soon as a value is assigned to the pointer. Moreover, a memory leak related with this same bug has been identified.
The solution proposed on this PR calls the release method of the unique pointer when this gets allocated, so that it points to null when assigned for the first time.