### PR TITLE
SonarCloud bug fixes: division by zero

### DIFF
--- a/src/xmipp/libraries/reconstruction/classify_kmeans_2d.cpp
+++ b/src/xmipp/libraries/reconstruction/classify_kmeans_2d.cpp
@@ -246,6 +246,13 @@ public:
         // create clusters and choose K points as their centers centers
         std::vector<int> prohibited_indexes;
 
+        if (total_points == 0)
+        {
+            std::ostringstream msg;
+            msg << "Division by zero: total_points == 0";
+            throw std::runtime_error(msg.str()); 
+        }
+
         for (int i = 0; i < K; i++)
         {
             while (true)

--- a/src/xmipp/libraries/reconstruction/ml_align2d.cpp
+++ b/src/xmipp/libraries/reconstruction/ml_align2d.cpp
@@ -1316,6 +1316,14 @@ void ProgML2D::doThreadExpectationSingleImageRefno()
     // and this will make the if-statement that checks SIGNIFICANT_WEIGHT_LOW
     // effective right from the start
     //std::cerr << "DEBUG_JM: doThreadExpectationSingleImageRefno: " << std::endl;
+
+    if (nr_nomirror_flips == 0)
+    {
+        std::ostringstream msg;
+        msg << "Division by zero: nr_nomirror_flips == 0";
+        throw std::runtime_error(msg.str()); 
+    }
+
     FOR_ALL_THREAD_REFNO()
     {
 

--- a/src/xmipp/libraries/reconstruction/mlf_align2d.cpp
+++ b/src/xmipp/libraries/reconstruction/mlf_align2d.cpp
@@ -2139,7 +2139,7 @@ void ProgMLF2D::processOneImage(const MultidimArray<double> &Mimg,
         std::ostringstream msg;
         msg << "Division by zero: nr_nomirror_flips == 0";
         throw std::runtime_error(msg.str()); 
-    } 
+    }
 
     // Acummulate all weighted sums
     // and normalize them by sum_refw, such that sum over all weights is one!

--- a/src/xmipp/libraries/reconstruction/mlf_align2d.cpp
+++ b/src/xmipp/libraries/reconstruction/mlf_align2d.cpp
@@ -2134,6 +2134,13 @@ void ProgMLF2D::processOneImage(const MultidimArray<double> &Mimg,
         opt_scale = wsum_sc / wsum_sc2;
     }
 
+    if (nr_nomirror_flips == 0)
+    {
+        std::ostringstream msg;
+        msg << "Division by zero: nr_nomirror_flips == 0";
+        throw std::runtime_error(msg.str()); 
+    } 
+
     // Acummulate all weighted sums
     // and normalize them by sum_refw, such that sum over all weights is one!
     FOR_ALL_MODELS()


### PR DESCRIPTION
This PR fixes the rule "Divison by zero" in the following files:
- src/xmipp/libraries/reconstruction/mlf_align2d.cpp
- src/xmipp/libraries/reconstruction/classify_kmeans_2d.cpp
- src/xmipp/libraries/reconstruction/ml_align2d.cpp