### PR TITLE
Sonar cloud issues define constants

### DIFF
--- a/src/xmipp/libraries/classification/gaussian_kerdensom.cpp
+++ b/src/xmipp/libraries/classification/gaussian_kerdensom.cpp
@@ -35,7 +35,7 @@
 #include "gaussian_kerdensom.h"
 #include <core/metadata_vec.h>
 
-#define  MAXZ -11282
+constexpr signed int MAXZ =  -11282;
 
 //-----------------------------------------------------------------------------
 /**

--- a/src/xmipp/libraries/classification/kSVD.h
+++ b/src/xmipp/libraries/classification/kSVD.h
@@ -68,8 +68,9 @@ double lasso(const Matrix1D<double> &x,
     double lambda, Matrix1D<double> &alpha,
     const int maxIter=20, const double tol=0.005);
 
-#define OMP_PROJECTION 1
-#define LASSO_PROJECTION 2
+constexpr int OMP_PROJECTION = 1;
+constexpr int  LASSO_PROJECTION = 2;
+
 
 #ifdef UNUSED // detected as unused 29.6.2018
 /** kSVD

--- a/src/xmipp/libraries/data/blobs.h
+++ b/src/xmipp/libraries/data/blobs.h
@@ -350,7 +350,7 @@ void blobs2voxels(const GridVolume &vol_blobs,
 void blobs2space_coefficients(const GridVolume &vol_blobs, const struct blobtype &blob,
                               MultidimArray<double> *vol_coefs);
 
-#define SHOW_CONVERSION 1
+constexpr int SHOW_CONVERSION = 1;
 /** Voxels ---> Blobs.
     The voxels to blobs procedure is an iterative process resolved by
     ART as an iterative technique to solve an equation system. The blobs to
@@ -375,8 +375,8 @@ void voxels2blobs(const MultidimArray<double> *vol_voxels,
                   const Matrix2D<double> *D = nullptr,
                   double final_error_change = 0.01, int tell = 0, double R = -1, int threads = 1);
 
-#define VARTK 1
-#define VMAXARTK 2
+constexpr int VARTK = 1;
+constexpr int VMAXARTK = 2;
 
 /** Voxels ---> Blobs, single step.
     This is the basic step of the voxels to blobs conversion. It applies

--- a/src/xmipp/libraries/data/euler.h
+++ b/src/xmipp/libraries/data/euler.h
@@ -238,7 +238,7 @@ bool  _parityEven  :
 Axis  _initialAxis  :
     2; // First axis of rotation
 };
-#define eulerOrderNumber 24
+constexpr int eulerOrderNumber = 24;
 Euler::eulerOrder eulerOrderList[eulerOrderNumber] =
     {
         Euler::XYZ , Euler::XZY , Euler::YZX , Euler::YXZ , Euler::ZXY , Euler::ZYX ,

--- a/src/xmipp/libraries/data/filters.cpp
+++ b/src/xmipp/libraries/data/filters.cpp
@@ -2039,9 +2039,9 @@ void computeAlignmentTransforms(const MultidimArray<double>& I, AlignmentTransfo
     polarFourierTransform<true>(I, ITransforms.polarFourierI, false, XSIZE(I) / 5, XSIZE(I) / 2, aux.plans, 1);
 }
 
-constexpr float SHIFT_THRESHOLD = 0.95;             // Shift threshold in pixels.
+constexpr double SHIFT_THRESHOLD = 0.95;             // Shift threshold in pixels.
 constexpr float  ROTATE_THRESHOLD  =	1.0	;		// Rotate threshold in degrees.
-constexpr float  INITIAL_SHIFT_THRESHOLD =	SHIFT_THRESHOLD + 1.0;		// Shift threshold in pixels.
+constexpr double  INITIAL_SHIFT_THRESHOLD =	SHIFT_THRESHOLD + 1.0;		// Shift threshold in pixels.
 constexpr float  INITIAL_ROTATE_THRESHOLD = ROTATE_THRESHOLD + 1.0	;	// Rotate threshold in degrees.
 
 double alignImages(const MultidimArray<double>& Iref, const AlignmentTransforms& IrefTransforms, MultidimArray<double>& I,

--- a/src/xmipp/libraries/data/filters.cpp
+++ b/src/xmipp/libraries/data/filters.cpp
@@ -2039,11 +2039,10 @@ void computeAlignmentTransforms(const MultidimArray<double>& I, AlignmentTransfo
     polarFourierTransform<true>(I, ITransforms.polarFourierI, false, XSIZE(I) / 5, XSIZE(I) / 2, aux.plans, 1);
 }
 
-#define SHIFT_THRESHOLD 	0.95		// Shift threshold in pixels.
-#define ROTATE_THRESHOLD 	1.0			// Rotate threshold in degrees.
-
-#define INITIAL_SHIFT_THRESHOLD 	SHIFT_THRESHOLD + 1.0		// Shift threshold in pixels.
-#define INITIAL_ROTATE_THRESHOLD 	ROTATE_THRESHOLD + 1.0		// Rotate threshold in degrees.
+constexpr float SHIFT_THRESHOLD = 0.95;             // Shift threshold in pixels.
+constexpr float  ROTATE_THRESHOLD  =	1.0	;		// Rotate threshold in degrees.
+constexpr float  INITIAL_SHIFT_THRESHOLD =	SHIFT_THRESHOLD + 1.0;		// Shift threshold in pixels.
+constexpr float  INITIAL_ROTATE_THRESHOLD = ROTATE_THRESHOLD + 1.0	;	// Rotate threshold in degrees.
 
 double alignImages(const MultidimArray<double>& Iref, const AlignmentTransforms& IrefTransforms, MultidimArray<double>& I,
                    Matrix2D<double>&M, bool wrap, AlignmentAux &aux, CorrelationAux &aux2,
@@ -2717,7 +2716,7 @@ double Update_edge_Shah(MultidimArray<double> &img,
 }
 
 /* Smoothing Shah ---------------------------------------------------------- */
-#define SHAH_CONVERGENCE_THRESHOLD  0.0001
+constexpr double SHAH_CONVERGENCE_THRESHOLD = 0.0001;
 void smoothingShah(MultidimArray<double> &img,
                    MultidimArray<double> &surface_strength,
                    MultidimArray<double> &edge_strength, const Matrix1D<double> &W,

--- a/src/xmipp/libraries/data/filters.h
+++ b/src/xmipp/libraries/data/filters.h
@@ -23,15 +23,14 @@
 *  e-mail address 'xmipp@cnb.csic.es'
 ***************************************************************************/
 
-#ifndef CORE_FILTERS_H
-#define CORE_FILTERS_H
-
-constexpr double LOG2 = 0.693147181;
-
 #include "core/xmipp_image.h"
 #include "core/matrix2d.h"
 #include "data/numerical_tools.h"
 #include "data/polar.h"
+
+#ifndef CORE_FILTERS_H
+#define CORE_FILTERS_H
+constexpr double LOG2 = 0.693147181;
 
 class XmippProgram;
 class MetaData;

--- a/src/xmipp/libraries/data/filters.h
+++ b/src/xmipp/libraries/data/filters.h
@@ -26,7 +26,7 @@
 #ifndef CORE_FILTERS_H
 #define CORE_FILTERS_H
 
-#define LOG2 0.693147181
+constexpr double LOG2 = 0.693147181;
 
 #include "core/xmipp_image.h"
 #include "core/matrix2d.h"

--- a/src/xmipp/libraries/data/image_resize.h
+++ b/src/xmipp/libraries/data/image_resize.h
@@ -33,7 +33,7 @@
 
 
 typedef enum { RESIZE_NONE, RESIZE_FACTOR, RESIZE_FOURIER, RESIZE_PYRAMID_EXPAND, RESIZE_PYRAMID_REDUCE } ScaleType;
-#define INTERP_FOURIER -1
+constexpr signed int INTERP_FOURIER = -1;
 /**@defgroup ProgImageResize Image Resize class
    @ingroup DataLibrary */
 //@{

--- a/src/xmipp/libraries/data/integration.cpp
+++ b/src/xmipp/libraries/data/integration.cpp
@@ -119,8 +119,8 @@ double Trapeze::Trap(int n)
 //**********************************************************
 // Implementation of the integral using the Romberg method
 //**********************************************************mask.cpp to adapt
-#define JMAXP 30
-#define K 5
+constexpr int JMAXP = 30;
+constexpr int K = 5;
 
 double Romberg::operator()()
 {  //adapted from qromb

--- a/src/xmipp/libraries/data/mask.h
+++ b/src/xmipp/libraries/data/mask.h
@@ -44,10 +44,10 @@ void apply_geo_cont_2D_mask(MultidimArray< double >& mask,
 /// @ingroup DataLibrary
 //@{
 
-#define INNER_MASK 1
-#define OUTSIDE_MASK 2
-#define NO_ACTIVATE 0
-#define ACTIVATE 1
+constexpr int INNER_MASK = 1;
+constexpr int OUTSIDE_MASK = 2;
+constexpr int NO_ACTIVATE = 0;
+constexpr int ACTIVATE = 1;
 
 ///@name Actual masks
 //@{
@@ -939,9 +939,9 @@ void compute_hist_within_binary_mask(const MultidimArray< int >& mask,
     }
 }
 
-#define COUNT_ABOVE 1
-#define COUNT_BELOW 2
-#define COUNT_BETWEEN 3
+constexpr int  COUNT_ABOVE = 1;
+constexpr int  COUNT_BELOW = 2;
+constexpr int  COUNT_BETWEEN = 3;
 
 /** Count pixels/voxels with mask and above a threshold
  *

--- a/src/xmipp/libraries/data/micrograph.cpp
+++ b/src/xmipp/libraries/data/micrograph.cpp
@@ -716,9 +716,9 @@ void TiltPairAligner::passToUntilted(int _mtX, int _mtY, int &_muX, int &_muY)
 /* Compute tilting angle --------------------------------------------------- */
 void TiltPairAligner::computeGamma()
 {
-#define TRIANGLE_NO 15000
-#define MIN_AREA       15
-#define MAX_AREA   250000
+constexpr int  TRIANGLE_NO =  15000;
+constexpr int  MIN_AREA =        15;
+constexpr int  MAX_AREA =    250000;
     gamma = 0;
     Matrix1D<int> iju(2); // From i to j in untilted
     Matrix1D<int> iku(2); // From i to j in untilted

--- a/src/xmipp/libraries/data/numerical_tools.h
+++ b/src/xmipp/libraries/data/numerical_tools.h
@@ -259,16 +259,16 @@ void solve(const Matrix2D<T>& A, const Matrix2D<T>& b, Matrix2D<T>& result);
 // Last Modified: 6/8/98
 // Revision: 1.0
 
-#define stBest1Exp   0
-#define stRand1Exp   1
-#define stRandToBest1Exp 2
-#define stBest2Exp   3
-#define stRand2Exp   4
-#define stBest1Bin   5
-#define stRand1Bin   6
-#define stRandToBest1Bin 7
-#define stBest2Bin   8
-#define stRand2Bin   9
+constexpr int stBest1Exp =   0;
+constexpr int stRand1Exp =   1;
+constexpr int stRandToBest1Exp = 2;
+constexpr int stBest2Exp =   3;
+constexpr int stRand2Exp =   4;
+constexpr int stBest1Bin =   5;
+constexpr int stRand1Bin =   6;
+constexpr int stRandToBest1Bin = 7;
+constexpr int stBest2Bin =   8;
+constexpr int stRand2Bin =   9;
 
 class DESolver;
 

--- a/src/xmipp/libraries/data/pdb.cpp
+++ b/src/xmipp/libraries/data/pdb.cpp
@@ -1090,7 +1090,7 @@ void projectAtom(const Atom &atom, Projection &P,
                  const Matrix2D<double> &VP, const Matrix2D<double> &PV,
                  const AtomInterpolator &interpolator)
 {
-constexpr int SUBSAMPLING = 2;                  // for every measure 2x2 line
+constexpr float SUBSAMPLING = 2;                  // for every measure 2x2 line
     // integrals will be taken to
     // avoid numerical errors
 constexpr float SUBSTEP = 1/(SUBSAMPLING*2.0);

--- a/src/xmipp/libraries/data/pdb.cpp
+++ b/src/xmipp/libraries/data/pdb.cpp
@@ -1090,10 +1090,10 @@ void projectAtom(const Atom &atom, Projection &P,
                  const Matrix2D<double> &VP, const Matrix2D<double> &PV,
                  const AtomInterpolator &interpolator)
 {
-#define SUBSAMPLING 2                  // for every measure 2x2 line
+constexpr int SUBSAMPLING = 2;                  // for every measure 2x2 line
     // integrals will be taken to
     // avoid numerical errors
-#define SUBSTEP 1/(SUBSAMPLING*2.0)
+constexpr float SUBSTEP = 1/(SUBSAMPLING*2.0);
 
     Matrix1D<double> origin(3);
     Matrix1D<double> direction;

--- a/src/xmipp/libraries/data/phantom.cpp
+++ b/src/xmipp/libraries/data/phantom.cpp
@@ -1293,10 +1293,10 @@ double Cone::intersection(
 void Feature::project_to(Projection &P, const Matrix2D<double> &VP,
                          const Matrix2D<double> &PV) const
 {
-#define SUBSAMPLING 2                  // for every measure 2x2 line
+constexpr int SUBSAMPLING = 2;                  // for every measure 2x2 line
     // integrals will be taken to
     // avoid numerical errors
-#define SUBSTEP 1/(SUBSAMPLING*2.0)
+constexpr float SUBSTEP = 1/(SUBSAMPLING*2.0);
 
     Matrix1D<double> origin(3);
     Matrix1D<double> direction;

--- a/src/xmipp/libraries/data/phantom.cpp
+++ b/src/xmipp/libraries/data/phantom.cpp
@@ -1293,7 +1293,7 @@ double Cone::intersection(
 void Feature::project_to(Projection &P, const Matrix2D<double> &VP,
                          const Matrix2D<double> &PV) const
 {
-constexpr int SUBSAMPLING = 2;                  // for every measure 2x2 line
+constexpr float SUBSAMPLING = 2;                  // for every measure 2x2 line
     // integrals will be taken to
     // avoid numerical errors
 constexpr float SUBSTEP = 1/(SUBSAMPLING*2.0);

--- a/src/xmipp/libraries/data/polar.h
+++ b/src/xmipp/libraries/data/polar.h
@@ -37,12 +37,12 @@
 #include "core/xmipp_fftw.h"
 #include "core/xmipp_filename.h"
 
-#define FULL_CIRCLES 0
-#define HALF_CIRCLES 1
-#define DONT_CONJUGATE false
-#define CONJUGATE true
-#define DONT_KEEP_TRANSFORM false
-#define KEEP_TRANSFORM true
+constexpr int FULL_CIRCLES = 0;
+constexpr int HALF_CIRCLES = 1;
+constexpr bool DONT_CONJUGATE = false;
+constexpr bool CONJUGATE = true;
+constexpr bool DONT_KEEP_TRANSFORM = false;
+constexpr bool KEEP_TRANSFORM = true;
 
 /// @defgroup Polar Polar coordinates
 /// @ingroup DataLibrary

--- a/src/xmipp/libraries/data/projection.h
+++ b/src/xmipp/libraries/data/projection.h
@@ -171,14 +171,14 @@ void project_SimpleGrid(Image<T> *vol, const SimpleGrid *grid,
 /* PROJECTION GENERATION                                                     */
 /*---------------------------------------------------------------------------*/
 // Projecting functions ====================================================
-#define FORWARD  1
-#define BACKWARD 0
+constexpr int FORWARD =  1;
+constexpr int BACKWARD = 0;
 
-#define ARTK     1
-#define CAVK     2
-#define COUNT_EQ 3
-#define CAV      4
-#define CAVARTK  5
+constexpr int ARTK =     1;
+constexpr int CAVK =     2;
+constexpr int COUNT_EQ = 3;
+constexpr int CAV =      4;
+constexpr int CAVARTK =  5;
 
 /** From voxel volumes.
     The voxel volume is projected onto a projection plane defined by

--- a/src/xmipp/libraries/parallel/mpi_angular_class_average.h
+++ b/src/xmipp/libraries/parallel/mpi_angular_class_average.h
@@ -36,34 +36,34 @@
 //Tags already defined in xmipp
 //#define TAG_WORK                     0
 //#define TAG_STOP                     1
-#define TAG_I_FINISH_WRITTING        12
-#define TAG_MAY_I_WRITE              13
-#define TAG_YES_YOU_MAY_WRITE        14
-#define TAG_DO_NOT_DARE_TO_WRITE     15
-#define TAG_I_AM_FREE                16
+constexpr int TAG_I_FINISH_WRITTING =         12;
+constexpr int TAG_MAY_I_WRITE =               13;
+constexpr int TAG_YES_YOU_MAY_WRITE =         14;
+constexpr int TAG_DO_NOT_DARE_TO_WRITE =      15;
+constexpr int TAG_I_AM_FREE =                 16;
 
-#define lockWeightIndexesSize 5
-#define index_lockIndex 0
-#define index_weight 1
-#define index_weights1 2
-#define index_weights2 3
-#define index_ref3d 4
+constexpr int lockWeightIndexesSize =  5;
+constexpr int index_lockIndex =  0;
+constexpr int index_weight =  1;
+constexpr int index_weights1 =  2;
+constexpr int index_weights2 =  3;
+constexpr int index_ref3d =  4;
 
-#define ArraySize 8
-#define index_DefGroup 0
-#define index_2DRef 1
-#define index_3DRef 2
-#define index_Order 3
-#define index_Count 4
-#define index_jobId 5
-#define index_Rot 6
-#define index_Tilt 7
+constexpr int ArraySize =  8;
+constexpr int index_DefGroup =  0;
+constexpr int index_2DRef =  1;
+constexpr int index_3DRef =  2;
+constexpr int index_Order =  3;
+constexpr int index_Count =  4;
+constexpr int index_jobId =  5;
+constexpr int index_Rot =  6;
+constexpr int index_Tilt =  7;
 
-#define AVG_OUPUT_SIZE 10
+constexpr int AVG_OUPUT_SIZE =  10;
 
-#define split0 0
-#define split1 1
-#define split2 2
+constexpr int split0 =  0;
+constexpr int split1 =  1;
+constexpr int split2 =  2;
 
 /// @defgroup MpiProgAngularClassAverage MPI Angular Class Average
 /// @ingroup ParallelLibrary

--- a/src/xmipp/libraries/parallel/mpi_angular_project_library.cpp
+++ b/src/xmipp/libraries/parallel/mpi_angular_project_library.cpp
@@ -37,10 +37,10 @@
 
 #include <reconstruction/angular_project_library.h>
 
-#define TAG_WORKFORWORKER   0
-#define TAG_STOP   1
-#define TAG_WAIT   2
-#define TAG_FREEWORKER   3
+constexpr int  TAG_WORKFORWORKER =   0;
+constexpr int  TAG_STOP =   1;
+constexpr int  TAG_WAIT =   2;
+constexpr int  TAG_FREEWORKER =   3;
 
 #define DEBUG
 class ProgMpiAngularProjectLibrary: public ProgAngularProjectLibrary

--- a/src/xmipp/libraries/parallel/mpi_angular_projection_matching.cpp
+++ b/src/xmipp/libraries/parallel/mpi_angular_projection_matching.cpp
@@ -27,8 +27,8 @@
 #include "core/xmipp_image_macros.h"
 
 /*Some constast to message passing tags */
-#define TAG_JOB_REQUEST 1
-#define TAG_JOB_REPLY 2
+constexpr int  TAG_JOB_REQUEST =  1;
+constexpr int  TAG_JOB_REPLY =  2;
 
 /*Constructor */
 MpiProgAngularProjectionMatching::MpiProgAngularProjectionMatching()

--- a/src/xmipp/libraries/parallel/mpi_classify_CL2D.cpp
+++ b/src/xmipp/libraries/parallel/mpi_classify_CL2D.cpp
@@ -212,7 +212,7 @@ void CL2DClass::transferUpdate(bool centerReference)
 constexpr double SHIFT_THRESHOLD = 	0.95;		// Shift threshold in pixels.
 constexpr float ROTATE_THRESHOLD = 	1.0	;		// Rotate threshold in degrees.
 
-constexpr float INITIAL_SHIFT_THRESHOLD = 	SHIFT_THRESHOLD + 1.0;		// Shift threshold in pixels.
+constexpr double INITIAL_SHIFT_THRESHOLD = 	SHIFT_THRESHOLD + 1.0;		// Shift threshold in pixels.
 constexpr float INITIAL_ROTATE_THRESHOLD = 	ROTATE_THRESHOLD + 1.0	;	// Rotate threshold in degrees.
 
 //#define DEBUG

--- a/src/xmipp/libraries/parallel/mpi_classify_CL2D.cpp
+++ b/src/xmipp/libraries/parallel/mpi_classify_CL2D.cpp
@@ -209,7 +209,7 @@ void CL2DClass::transferUpdate(bool centerReference)
 }
 #undef DEBUG
 
-constexpr float SHIFT_THRESHOLD = 	0.95;		// Shift threshold in pixels.
+constexpr double SHIFT_THRESHOLD = 	0.95;		// Shift threshold in pixels.
 constexpr float ROTATE_THRESHOLD = 	1.0	;		// Rotate threshold in degrees.
 
 constexpr float INITIAL_SHIFT_THRESHOLD = 	SHIFT_THRESHOLD + 1.0;		// Shift threshold in pixels.

--- a/src/xmipp/libraries/parallel/mpi_classify_CL2D.cpp
+++ b/src/xmipp/libraries/parallel/mpi_classify_CL2D.cpp
@@ -209,11 +209,11 @@ void CL2DClass::transferUpdate(bool centerReference)
 }
 #undef DEBUG
 
-#define SHIFT_THRESHOLD 	0.95		// Shift threshold in pixels.
-#define ROTATE_THRESHOLD 	1.0			// Rotate threshold in degrees.
+constexpr float SHIFT_THRESHOLD = 	0.95;		// Shift threshold in pixels.
+constexpr float ROTATE_THRESHOLD = 	1.0	;		// Rotate threshold in degrees.
 
-#define INITIAL_SHIFT_THRESHOLD 	SHIFT_THRESHOLD + 1.0		// Shift threshold in pixels.
-#define INITIAL_ROTATE_THRESHOLD 	ROTATE_THRESHOLD + 1.0		// Rotate threshold in degrees.
+constexpr float INITIAL_SHIFT_THRESHOLD = 	SHIFT_THRESHOLD + 1.0;		// Shift threshold in pixels.
+constexpr float INITIAL_ROTATE_THRESHOLD = 	ROTATE_THRESHOLD + 1.0	;	// Rotate threshold in degrees.
 
 //#define DEBUG
 //#define DEBUG_MORE

--- a/src/xmipp/libraries/parallel/mpi_ml_align2d.cpp
+++ b/src/xmipp/libraries/parallel/mpi_ml_align2d.cpp
@@ -26,9 +26,9 @@
 #include "mpi_ml_align2d.h"
 
 /* Some constast to message passing tags */
-#define TAG_SEED 1
-#define TAG_DOCFILESIZE 2
-#define TAG_DOCFILE 3
+constexpr int TAG_SEED = 1;
+constexpr int TAG_DOCFILESIZE = 2;
+constexpr int TAG_DOCFILE = 3;
 
 MpiML2DBase::MpiML2DBase(XmippProgram * prm)
 {

--- a/src/xmipp/libraries/parallel/mpi_reconstruct_fourier.h
+++ b/src/xmipp/libraries/parallel/mpi_reconstruct_fourier.h
@@ -41,14 +41,14 @@
 #include <fstream>
 #include <iomanip>
 
-#define TAG_WORKFORWORKER    0
+constexpr int TAG_WORKFORWORKER =    0;
 #define TAG_STOP     1
-#define TAG_TRANSFER   2
-#define TAG_FREEWORKER    3
-#define TAG_COLLECT_FOR_FSC  4
-#define TAG_SETVERBOSE  5
+constexpr int TAG_TRANSFER =   2;
+constexpr int TAG_FREEWORKER =    3;
+constexpr int TAG_COLLECT_FOR_FSC =  4;
+constexpr int TAG_SETVERBOSE =  5;
 
-#define BUFFSIZE 10000000
+constexpr int BUFFSIZE = 10000000;
 
 //TODO (MARIANA) Please give more documentation and in a good structure e.g. @name
 

--- a/src/xmipp/libraries/reconstruction/angular_continuous_assign2.h
+++ b/src/xmipp/libraries/reconstruction/angular_continuous_assign2.h
@@ -38,8 +38,8 @@ class FourierProjector;
    @ingroup ReconsLibrary */
 //@{
 
-#define CONTCOST_CORR 0
-#define CONTCOST_L1 1
+constexpr int  CONTCOST_CORR = 0;
+constexpr int  CONTCOST_L1 = 1;
 
 /** Predict Continuous Parameters. */
 class ProgAngularContinuousAssign2: public XmippMetadataProgram

--- a/src/xmipp/libraries/reconstruction/angular_projection_matching.h
+++ b/src/xmipp/libraries/reconstruction/angular_projection_matching.h
@@ -37,7 +37,7 @@
 template<typename T>
 class Image;
 
-#define MY_OUPUT_SIZE 10
+constexpr int MY_OUPUT_SIZE = 10;
 
 class ProgAngularProjectionMatching;
 

--- a/src/xmipp/libraries/reconstruction/common_lines.cpp
+++ b/src/xmipp/libraries/reconstruction/common_lines.cpp
@@ -817,8 +817,8 @@ void anglesRotationMatrix(size_t nRays, int clI, int clJ,
     R = U * Q.transpose();
 }//function
 
-#define  EPS 1.0e-13 // % Should be 1.0e-13 after fixing XXX below.
-#define  MAX_COND 1000 // % Largest allowed condition number for the system of equations
+constexpr long double  EPS = 1.0e-13; // % Should be 1.0e-13 after fixing XXX below.
+constexpr int  MAX_COND = 1000; // % Largest allowed condition number for the system of equations
 #define cl(i, j) dMij(clMatrix, k##i, k##j)
 
 /** Negative output means error

--- a/src/xmipp/libraries/reconstruction/common_lines.h
+++ b/src/xmipp/libraries/reconstruction/common_lines.h
@@ -201,7 +201,7 @@ void commonlineMatrixCheat(const DMatrix &quaternions, size_t nRays,
 
 void anglesRotationMatrix(size_t nRays, int i, int j, DMatrix &U);
 
-#define SMALL_TRIANGLE -101
+constexpr signed int  SMALL_TRIANGLE = -101;
 /** Negative output means error
  * -101 Triangle too small
  */

--- a/src/xmipp/libraries/reconstruction/ctf_correct_wiener3d.cpp
+++ b/src/xmipp/libraries/reconstruction/ctf_correct_wiener3d.cpp
@@ -26,8 +26,7 @@
 #include <fstream>
 #include "ctf_correct_wiener3d.h"
 
-#define OVERSAMPLE 8
-
+constexpr int OVERSAMPLE = 8;
 /* Read parameters from command line. -------------------------------------- */
 void ProgCtfCorrectAmplitude3D::readParams()
 {

--- a/src/xmipp/libraries/reconstruction/ctf_estimate_from_psd.cpp
+++ b/src/xmipp/libraries/reconstruction/ctf_estimate_from_psd.cpp
@@ -38,16 +38,16 @@
 double CTF_fitness(double *, void *);
 
 /* Number of CTF parameters */
-#define ALL_CTF_PARAMETERS           38
-#define CTF_PARAMETERS               30
-#define PARAMETRIC_CTF_PARAMETERS    16
-#define BACKGROUND_CTF_PARAMETERS    14
-#define SQRT_CTF_PARAMETERS           8
-#define ENVELOPE_PARAMETERS          11
-#define DEFOCUS_PARAMETERS            5
-#define FIRST_SQRT_PARAMETER         16
-#define FIRST_ENVELOPE_PARAMETER      4
-#define FIRST_DEFOCUS_PARAMETER       0
+constexpr int  ALL_CTF_PARAMETERS =           38;
+constexpr int  CTF_PARAMETERS =               30;
+constexpr int  PARAMETRIC_CTF_PARAMETERS =    16;
+constexpr int  BACKGROUND_CTF_PARAMETERS =    14;
+constexpr int  SQRT_CTF_PARAMETERS =           8;
+constexpr int  ENVELOPE_PARAMETERS =          11;
+constexpr int  DEFOCUS_PARAMETERS =            5;
+constexpr int  FIRST_SQRT_PARAMETER =         16;
+constexpr int  FIRST_ENVELOPE_PARAMETER =      4;
+constexpr int  FIRST_DEFOCUS_PARAMETER =       0;
 
 //#define DEBUG_WITH_TEXTFILES
 #ifdef DEBUG_WITH_TEXTFILES

--- a/src/xmipp/libraries/reconstruction/ctf_estimate_from_psd_fast.cpp
+++ b/src/xmipp/libraries/reconstruction/ctf_estimate_from_psd_fast.cpp
@@ -38,17 +38,17 @@ double CTF_fitness_fast(double *, void *);
 extern double CTF_fitness(double *p, void *vprm);
 
 /* Number of CTF parameters */
-#define ALL_CTF_PARAMETERS2D         38
-#define ALL_CTF_PARAMETERS           28
-#define CTF_PARAMETERS               20
-#define PARAMETRIC_CTF_PARAMETERS    16
-#define BACKGROUND_CTF_PARAMETERS     9
-#define SQRT_CTF_PARAMETERS           6
-#define ENVELOPE_PARAMETERS          11
-#define DEFOCUS_PARAMETERS            3
-#define FIRST_SQRT_PARAMETER         14
-#define FIRST_ENVELOPE_PARAMETER      2
-#define FIRST_DEFOCUS_PARAMETER       0
+constexpr int ALL_CTF_PARAMETERS2D =         38;
+constexpr int ALL_CTF_PARAMETERS =           28;
+constexpr int CTF_PARAMETERS =               20;
+constexpr int PARAMETRIC_CTF_PARAMETERS =    16;
+constexpr int BACKGROUND_CTF_PARAMETERS =     9;
+constexpr int SQRT_CTF_PARAMETERS =           6;
+constexpr int ENVELOPE_PARAMETERS =          11;
+constexpr int DEFOCUS_PARAMETERS =            3;
+constexpr int FIRST_SQRT_PARAMETER =         14;
+constexpr int FIRST_ENVELOPE_PARAMETER =      2;
+constexpr int FIRST_DEFOCUS_PARAMETER =       0;
 
 //#define DEBUG_WITH_TEXTFILES
 #ifdef DEBUG_WITH_TEXTFILES

--- a/src/xmipp/libraries/reconstruction/ctf_estimate_psd_with_arma.h
+++ b/src/xmipp/libraries/reconstruction/ctf_estimate_psd_with_arma.h
@@ -26,9 +26,9 @@
 
 #ifndef _CORE_PROG_SPARMA_HH
 #define _CORE_PROG_SPARMA_HH
-#define AR          0   // To distinguish between an AR parameter or a MA
-#define MA        1   // parameter, or sigma in the output ARMAParameters matrix
-#define SIGMA       2   // returned by functions.
+constexpr int  AR          =0;   // To distinguish between an AR parameter or a MA
+constexpr int  MA        =1;   // parameter, or sigma in the output ARMAParameters matrix
+constexpr int  SIGMA       =2;   // returned by functions.
 
 #include <core/multidim_array.h>
 #include <core/xmipp_program.h>

--- a/src/xmipp/libraries/reconstruction/ctf_estimate_psd_with_arma.h
+++ b/src/xmipp/libraries/reconstruction/ctf_estimate_psd_with_arma.h
@@ -23,17 +23,14 @@
  *  All comments concerning this program package may be sent to the
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
-
-
-#ifndef _CORE_PROG_SPARMA_HH
-#define _CORE_PROG_SPARMA_HH
-constexpr int  AR          =0;   // To distinguish between an AR parameter or a MA
-constexpr int  MA        =1;   // parameter, or sigma in the output ARMAParameters matrix
-constexpr int  SIGMA       =2;   // returned by functions.
-
 #pragma once
+
 #include <core/multidim_array.h>
 #include <core/xmipp_program.h>
+
+constexpr int  AR       =0;   // To distinguish between an AR parameter or a MA
+constexpr int  MA       =1;   // parameter, or sigma in the output ARMAParameters matrix
+constexpr int  SIGMA    =2;   // returned by functions.
 
 /**@defgroup SpARMA Spectrum modelling by ARMA filters
    @ingroup ReconsLibrary */

--- a/src/xmipp/libraries/reconstruction/ctf_estimate_psd_with_arma.h
+++ b/src/xmipp/libraries/reconstruction/ctf_estimate_psd_with_arma.h
@@ -23,8 +23,7 @@
  *  All comments concerning this program package may be sent to the
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
-#include <core/multidim_array.h>
-#include <core/xmipp_program.h>
+
 
 #ifndef _CORE_PROG_SPARMA_HH
 #define _CORE_PROG_SPARMA_HH
@@ -32,7 +31,9 @@ constexpr int  AR          =0;   // To distinguish between an AR parameter or a 
 constexpr int  MA        =1;   // parameter, or sigma in the output ARMAParameters matrix
 constexpr int  SIGMA       =2;   // returned by functions.
 
-
+#pragma once
+#include <core/multidim_array.h>
+#include <core/xmipp_program.h>
 
 /**@defgroup SpARMA Spectrum modelling by ARMA filters
    @ingroup ReconsLibrary */

--- a/src/xmipp/libraries/reconstruction/ctf_estimate_psd_with_arma.h
+++ b/src/xmipp/libraries/reconstruction/ctf_estimate_psd_with_arma.h
@@ -130,4 +130,3 @@ void ARMAFilter(MultidimArray<double> &Img, MultidimArray< double > &Filter,
                 ARMA_parameters &prm);
 //@}
 
-#endif

--- a/src/xmipp/libraries/reconstruction/ctf_estimate_psd_with_arma.h
+++ b/src/xmipp/libraries/reconstruction/ctf_estimate_psd_with_arma.h
@@ -23,6 +23,8 @@
  *  All comments concerning this program package may be sent to the
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
+#include <core/multidim_array.h>
+#include <core/xmipp_program.h>
 
 #ifndef _CORE_PROG_SPARMA_HH
 #define _CORE_PROG_SPARMA_HH
@@ -30,8 +32,7 @@ constexpr int  AR          =0;   // To distinguish between an AR parameter or a 
 constexpr int  MA        =1;   // parameter, or sigma in the output ARMAParameters matrix
 constexpr int  SIGMA       =2;   // returned by functions.
 
-#include <core/multidim_array.h>
-#include <core/xmipp_program.h>
+
 
 /**@defgroup SpARMA Spectrum modelling by ARMA filters
    @ingroup ReconsLibrary */

--- a/src/xmipp/libraries/reconstruction/image_find_center.cpp
+++ b/src/xmipp/libraries/reconstruction/image_find_center.cpp
@@ -34,16 +34,16 @@
 #include "core/xmipp_image.h"
 
 // Old code -----------------------------------------------------------------
-#define NATURAL       1                /* natural, 1 byte/pixel format */
-#define INTFMT        2                /* integer, 2 byte/pixel format */
-#define LONGFMT       3                /* long, 4 bytes/pixel format   */
-#define FLOATFMT      4                /* float, 4 bytes/pixel format  */
-#define FOURIER       5                /* Fourier transform format     */
-#define SPIDER        6                /* Spider (header) format       */
-#define DEF_IT     5  /*Default iterations number */
-#define DEF_DEL    2
-#define DEF_IN     2
-#define ALLOC_SIZE  65000              /* Allocation unit size         */
+#define  NATURAL        1               /* natural, 1 byte/pixel format */
+constexpr int  INTFMT =        2;                /* integer, 2 byte/pixel format */
+constexpr int  LONGFMT =       3;                /* long, 4 bytes/pixel format   */
+constexpr int  FLOATFMT =      4;                /* float, 4 bytes/pixel format  */
+constexpr int  FOURIER =       5;                /* Fourier transform format     */
+constexpr int  SPIDER =        6;                /* Spider (header) format       */
+constexpr int  DEF_IT =     5;  /*Default iterations number */
+constexpr int  DEF_DEL =    2;
+constexpr int  DEF_IN =     2;
+constexpr int  ALLOC_SIZE =  65000;              /* Allocation unit size         */
 typedef unsigned char  BYTE;       /*** Only this and float are used ***/
 typedef unsigned short UWORD;
 typedef unsigned long  ULONG;

--- a/src/xmipp/libraries/reconstruction/image_find_center.cpp
+++ b/src/xmipp/libraries/reconstruction/image_find_center.cpp
@@ -34,7 +34,7 @@
 #include "core/xmipp_image.h"
 
 // Old code -----------------------------------------------------------------
-//constexpr int  NATURAL =      1;              /* natural, 1 byte/pixel format */
+//constexpr int  NATURAL =      1;               natural, 1 byte/pixel format
 constexpr int  INTFMT =        2;                /* integer, 2 byte/pixel format */
 constexpr int  LONGFMT =       3;                /* long, 4 bytes/pixel format   */
 constexpr int  FLOATFMT =      4;                /* float, 4 bytes/pixel format  */

--- a/src/xmipp/libraries/reconstruction/image_find_center.cpp
+++ b/src/xmipp/libraries/reconstruction/image_find_center.cpp
@@ -34,7 +34,7 @@
 #include "core/xmipp_image.h"
 
 // Old code -----------------------------------------------------------------
-#define  NATURAL        1               /* natural, 1 byte/pixel format */
+//constexpr int  NATURAL =      1;              /* natural, 1 byte/pixel format */
 constexpr int  INTFMT =        2;                /* integer, 2 byte/pixel format */
 constexpr int  LONGFMT =       3;                /* long, 4 bytes/pixel format   */
 constexpr int  FLOATFMT =      4;                /* float, 4 bytes/pixel format  */

--- a/src/xmipp/libraries/reconstruction/mlf_align2d.h
+++ b/src/xmipp/libraries/reconstruction/mlf_align2d.h
@@ -49,10 +49,10 @@
 #define VSIG_ITEM dAi(Vsig[ifocus], irr)
 
 #define SIGNIFICANT_WEIGHT_LOW 1e-8
-#define SMALLVALUE 1e-4
-#define HISTMIN -6.
-#define HISTMAX 6.
-#define HISTSTEPS 120
+constexpr int  SMALLVALUE = 1e-4;
+constexpr float  HISTMIN = -6.;
+constexpr float  HISTMAX = 6.;
+constexpr int  HISTSTEPS = 120;
 
 /** Some filename convetions for output files */
 #define FN_EXTRA(file) formatString("%sextra/%s", fn_root.c_str(), file)

--- a/src/xmipp/libraries/reconstruction/mlf_align2d.h
+++ b/src/xmipp/libraries/reconstruction/mlf_align2d.h
@@ -49,7 +49,7 @@
 #define VSIG_ITEM dAi(Vsig[ifocus], irr)
 
 #define SIGNIFICANT_WEIGHT_LOW 1e-8
-constexpr int  SMALLVALUE = 1e-4;
+constexpr double  SMALLVALUE = 1e-4;
 constexpr float  HISTMIN = -6.;
 constexpr float  HISTMAX = 6.;
 constexpr int  HISTSTEPS = 120;

--- a/src/xmipp/libraries/reconstruction/multireference_aligneability.h
+++ b/src/xmipp/libraries/reconstruction/multireference_aligneability.h
@@ -22,11 +22,6 @@
  *  All comments concerning this program package may be sent to the
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
-
-#ifndef MULTIREFERENCE_ALIGNEABILITY_H_
-#define MULTIREFERENCE_ALIGNEABILITY_H_
-constexpr double PI = 3.14159265;
-
 #include <core/xmipp_program.h>
 #include "validation_nontilt.h"
 #include <math.h>
@@ -34,6 +29,12 @@ constexpr double PI = 3.14159265;
 #include <string.h>
 #include <data/mask.h>
 #include <core/symmetries.h>
+
+#ifndef MULTIREFERENCE_ALIGNEABILITY_H_
+#define MULTIREFERENCE_ALIGNEABILITY_H_
+//#define PI  3.14159265
+
+
 
 /**@defgroup MultireferenceAligneability Multireference Aligneability
    @ingroup ReconsLibrary */

--- a/src/xmipp/libraries/reconstruction/multireference_aligneability.h
+++ b/src/xmipp/libraries/reconstruction/multireference_aligneability.h
@@ -25,7 +25,7 @@
 
 #ifndef MULTIREFERENCE_ALIGNEABILITY_H_
 #define MULTIREFERENCE_ALIGNEABILITY_H_
-#define PI 3.14159265
+constexpr double PI = 3.14159265;
 
 #include <core/xmipp_program.h>
 #include "validation_nontilt.h"

--- a/src/xmipp/libraries/reconstruction/project_crystal.cpp
+++ b/src/xmipp/libraries/reconstruction/project_crystal.cpp
@@ -495,7 +495,7 @@ void project_crystal(Phantom &phantom, Projection &P,
 #undef DEBUG_MORE
 
 /* Find crystal limits ----------------------------------------------------- */
-constexpr float MIN_MODULE = 1e-2;
+constexpr double MIN_MODULE = 1e-2;
 void find_crystal_limits(
     const Matrix1D<double> &proj_corner1, const Matrix1D<double> &proj_corner2,
     const Matrix1D<double> &cell_corner1, const Matrix1D<double> &cell_corner2,

--- a/src/xmipp/libraries/reconstruction/project_crystal.cpp
+++ b/src/xmipp/libraries/reconstruction/project_crystal.cpp
@@ -495,7 +495,7 @@ void project_crystal(Phantom &phantom, Projection &P,
 #undef DEBUG_MORE
 
 /* Find crystal limits ----------------------------------------------------- */
-#define MIN_MODULE 1e-2
+constexpr float MIN_MODULE = 1e-2;
 void find_crystal_limits(
     const Matrix1D<double> &proj_corner1, const Matrix1D<double> &proj_corner2,
     const Matrix1D<double> &cell_corner1, const Matrix1D<double> &cell_corner2,

--- a/src/xmipp/libraries/reconstruction/reconstruct_art_pseudo.cpp
+++ b/src/xmipp/libraries/reconstruction/reconstruct_art_pseudo.cpp
@@ -30,8 +30,8 @@
 #include "core/geometry.h"
 #include "core/xmipp_image.h"
 
-#define FORWARD   1
-#define BACKWARD -1
+constexpr signed int FORWARD =   1;
+constexpr signed int BACKWARD = -1;
 
 /** Projection of a pseudoatom volume */
 void project_Pseudo(const std::vector< Matrix1D<double> > &atomPosition,

--- a/src/xmipp/libraries/reconstruction/reconstruct_art_pseudo.cpp
+++ b/src/xmipp/libraries/reconstruction/reconstruct_art_pseudo.cpp
@@ -30,7 +30,7 @@
 #include "core/geometry.h"
 #include "core/xmipp_image.h"
 
-constexpr signed int FORWARD =   1;
+constexpr int FORWARD =   1;
 constexpr signed int BACKWARD = -1;
 
 /** Projection of a pseudoatom volume */

--- a/src/xmipp/libraries/reconstruction/reconstruct_art_pseudo.cpp
+++ b/src/xmipp/libraries/reconstruction/reconstruct_art_pseudo.cpp
@@ -31,7 +31,7 @@
 #include "core/xmipp_image.h"
 
 constexpr int FORWARD =   1;
-constexpr signed int BACKWARD = -1;
+constexpr int BACKWARD = -1;
 
 /** Projection of a pseudoatom volume */
 void project_Pseudo(const std::vector< Matrix1D<double> > &atomPosition,

--- a/src/xmipp/libraries/reconstruction/reconstruct_fourier.h
+++ b/src/xmipp/libraries/reconstruction/reconstruct_fourier.h
@@ -40,8 +40,8 @@
 constexpr int  BLOB_TABLE_SIZE= 5000;
 constexpr int  BLOB_TABLE_SIZE_SQRT= 10000;
 
-constexpr float  MINIMUMWEIGHT= 0.001;
-constexpr float  ACCURACY= 0.001;
+constexpr double  MINIMUMWEIGHT= 0.001;
+constexpr double ACCURACY= 0.001;
 
 constexpr int EXIT_THREAD= 0;
 constexpr int PROCESS_IMAGE= 1;

--- a/src/xmipp/libraries/reconstruction/reconstruct_fourier.h
+++ b/src/xmipp/libraries/reconstruction/reconstruct_fourier.h
@@ -37,16 +37,16 @@
 #include "data/ctf.h"
 #include "recons.h"
 
-#define BLOB_TABLE_SIZE 5000
-#define BLOB_TABLE_SIZE_SQRT 10000
+constexpr int  BLOB_TABLE_SIZE= 5000;
+constexpr int  BLOB_TABLE_SIZE_SQRT= 10000;
 
-#define MINIMUMWEIGHT 0.001
-#define ACCURACY 0.001
+constexpr float  MINIMUMWEIGHT= 0.001;
+constexpr float  ACCURACY= 0.001;
 
-#define EXIT_THREAD 0
-#define PROCESS_IMAGE 1
-#define PROCESS_WEIGHTS 2
-#define PRELOAD_IMAGE 3
+constexpr int EXIT_THREAD= 0;
+constexpr int PROCESS_IMAGE= 1;
+constexpr int PROCESS_WEIGHTS= 2;
+constexpr int PRELOAD_IMAGE= 3;
 
 /**@defgroup FourierReconstruction Fourier reconstruction
    @ingroup ReconsLibrary */

--- a/src/xmipp/libraries/reconstruction/reconstruct_fourier_accel.h
+++ b/src/xmipp/libraries/reconstruction/reconstruct_fourier_accel.h
@@ -46,8 +46,8 @@ struct Array2D;
 constexpr int  BLOB_TABLE_SIZE= 5000;
 constexpr int  BLOB_TABLE_SIZE_SQRT= 10000;
 
-constexpr float  MINIMUMWEIGHT= 0.001;
-constexpr float  ACCURACY= 0.001;
+constexpr double  MINIMUMWEIGHT= 0.001;
+constexpr double  ACCURACY= 0.001;
 
 constexpr int  EXIT_THREAD= 0;
 constexpr int  PRELOAD_IMAGE= 1;

--- a/src/xmipp/libraries/reconstruction/reconstruct_fourier_accel.h
+++ b/src/xmipp/libraries/reconstruction/reconstruct_fourier_accel.h
@@ -43,14 +43,14 @@ class MultidimArray;
 template<typename T>
 struct Array2D;
 
-#define BLOB_TABLE_SIZE 5000
-#define BLOB_TABLE_SIZE_SQRT 10000
+constexpr int  BLOB_TABLE_SIZE= 5000;
+constexpr int  BLOB_TABLE_SIZE_SQRT= 10000;
 
-#define MINIMUMWEIGHT 0.001
-#define ACCURACY 0.001
+constexpr float  MINIMUMWEIGHT= 0.001;
+constexpr float  ACCURACY= 0.001;
 
-#define EXIT_THREAD 0
-#define PRELOAD_IMAGE 1
+constexpr int  EXIT_THREAD= 0;
+constexpr int  PRELOAD_IMAGE= 1;
 
 /**@defgroup FourierReconstruction Fourier reconstruction
    @ingroup ReconsLibrary */

--- a/src/xmipp/libraries/reconstruction/reconstruct_fourier_defines.h
+++ b/src/xmipp/libraries/reconstruction/reconstruct_fourier_defines.h
@@ -27,39 +27,39 @@
 #define XMIPP_LIBRARIES_DATA_RECONSTRUCT_FOURIER_DEFINES_H_
 
 typedef float MATRIX[3][3];
-#define BLOB_TABLE_SIZE_SQRT 10000
-#define ACCURACY 0.001
+constexpr int BLOB_TABLE_SIZE_SQRT= 10000;
+constexpr float ACCURACY= 0.001;
 
 #define PASCAL
 
 #ifdef KEPLER
 // GPU specific
-#define BLOCK_DIM 16
-#define SHARED_BLOB_TABLE 0
-#define SHARED_IMG 0
-#define PRECOMPUTE_BLOB_VAL 0
-#define TILE 8
-#define GRID_DIM_Z 1
+constexpr int  BLOCK_DIM=  16;
+constexpr int  SHARED_BLOB_TABLE=  0;
+constexpr int  SHARED_IMG=  0;
+constexpr int  PRECOMPUTE_BLOB_VAL=  0;
+constexpr int  TILE=  8;
+constexpr int  GRID_DIM_Z=  1;
 #endif
 
 #ifdef MAXWELL
 // GPU specific
-#define BLOCK_DIM 8
-#define SHARED_BLOB_TABLE 0
-#define SHARED_IMG 0
-#define PRECOMPUTE_BLOB_VAL 1
-#define TILE 4
-#define GRID_DIM_Z 8
+constexpr int  BLOCK_DIM=  8;
+constexpr int  SHARED_BLOB_TABLE=  0;
+constexpr int  SHARED_IMG=  0;
+constexpr int  PRECOMPUTE_BLOB_VAL=  1;
+constexpr int  TILE=  4;
+constexpr int  GRID_DIM_Z=  8;
 #endif
 
 #ifdef PASCAL
 // GPU specific
-#define BLOCK_DIM 16
-#define SHARED_BLOB_TABLE 1
-#define SHARED_IMG 0
-#define PRECOMPUTE_BLOB_VAL 1
-#define TILE 2
-#define GRID_DIM_Z 1
+constexpr int BLOCK_DIM=  16;
+constexpr int SHARED_BLOB_TABLE=  1;
+constexpr int SHARED_IMG=  0;
+constexpr int PRECOMPUTE_BLOB_VAL=  1;
+constexpr int TILE=  2;
+constexpr int GRID_DIM_Z=  1;
 #endif
 
 #endif /* XMIPP_LIBRARIES_DATA_RECONSTRUCT_FOURIER_DEFINES_H_ */

--- a/src/xmipp/libraries/reconstruction/reconstruct_fourier_defines.h
+++ b/src/xmipp/libraries/reconstruction/reconstruct_fourier_defines.h
@@ -28,7 +28,7 @@
 
 typedef float MATRIX[3][3];
 constexpr int BLOB_TABLE_SIZE_SQRT= 10000;
-constexpr float ACCURACY= 0.001;
+constexpr double ACCURACY= 0.001;
 
 #define PASCAL
 


### PR DESCRIPTION
> A macro is a textual replacement, which means that it’s not respecting the type system, it’s not respecting scoping rules…​ There is no reason not to use a constant instead.

I've change `#define` by `constexpr type ...`
