### PR TITLE
rename forward zernike help

### DIFF
--- a/src/xmipp/libraries/reconstruction/forward_art_zernike3d.cpp
+++ b/src/xmipp/libraries/reconstruction/forward_art_zernike3d.cpp
@@ -123,7 +123,7 @@ void ProgForwardArtZernike3D::defineParams()
 	addParamsLine("                               : previous projections");
 	addParamsLine("  [--resume]                   : Resume processing");
 	addExampleLine("A typical use is:", false);
-	addExampleLine("xmipp_art_zernike3d -i anglesFromContinuousAssignment.xmd --ref reference.vol -o assigned_anglesAndDeformations.xmd --l1 3 --l2 2");
+	addExampleLine("xmipp_forward_art_zernike3d -i anglesFromContinuousAssignment.xmd --ref reference.vol -o assigned_anglesAndDeformations.xmd --l1 3 --l2 2");
 }
 
 // // Produce side information ================================================

--- a/src/xmipp/libraries/reconstruction/forward_zernike_images.cpp
+++ b/src/xmipp/libraries/reconstruction/forward_zernike_images.cpp
@@ -132,7 +132,7 @@ void ProgForwardZernikeImages::defineParams()
 	addParamsLine("  [--image_mode <im=-1>]       : Image mode (single, pairs, triplets). By default, it will be automatically identified.");
 	addParamsLine("  [--resume]                   : Resume processing");
     addExampleLine("A typical use is:",false);
-    addExampleLine("xmipp_angular_sph_alignment -i anglesFromContinuousAssignment.xmd --ref reference.vol -o assigned_anglesAndDeformations.xmd --optimizeAlignment --optimizeDeformation --depth 1");
+    addExampleLine("xmipp_forward_zernike_images_priors -i anglesFromContinuousAssignment.xmd --ref reference.vol -o assigned_anglesAndDeformations.xmd --optimizeAlignment --optimizeDeformation --depth 1");
 }
 
 void ProgForwardZernikeImages::preProcess()

--- a/src/xmipp/libraries/reconstruction/forward_zernike_subtomos.cpp
+++ b/src/xmipp/libraries/reconstruction/forward_zernike_subtomos.cpp
@@ -129,7 +129,7 @@ void ProgForwardZernikeSubtomos::defineParams()
 	addParamsLine("  [--blobr <b=4>]              : Blob radius for forward mapping splatting");
 	addParamsLine("  [--resume]                   : Resume processing");
     addExampleLine("A typical use is:",false);
-    addExampleLine("xmipp_angular_sph_alignment -i anglesFromContinuousAssignment.xmd --ref reference.vol -o assigned_anglesAndDeformations.xmd --optimizeAlignment --optimizeDeformation --depth 1");
+    addExampleLine("xmipp_forward_zernike_subtomos -i anglesFromContinuousAssignment.xmd --ref reference.vol -o assigned_anglesAndDeformations.xmd --optimizeAlignment --optimizeDeformation --depth 1");
 }
 
 void ProgForwardZernikeSubtomos::preProcess()

--- a/src/xmipp/libraries/reconstruction/forward_zernike_volume.cpp
+++ b/src/xmipp/libraries/reconstruction/forward_zernike_volume.cpp
@@ -133,7 +133,7 @@ void ProgForwardZernikeVol::defineParams() {
 	addParamsLine("  [--blobr <b=4>]                      : Blob radius for forward mapping splatting");
 	addParamsLine("  [--step <step=1>]                    : Voxel index step");
 	addParamsLine("  [--clnm <metadata_file=\"\">]        : List of deformation coefficients");
-	addExampleLine("xmipp_volume_deform_sph -i vol1.vol -r vol2.vol -o vol1DeformedTo2.vol");
+	addExampleLine("xmipp_forward_zernike_volume -i vol1.vol -r vol2.vol -o vol1DeformedTo2.vol");
 }
 
 // Read arguments ==========================================================


### PR DESCRIPTION
The help texts in the new zernike programs with the forward mapping still said the names of the old programs so now they don't.