### PR TITLE
pdb data lib fix

### DIFF
--- a/scripts/config.py
+++ b/scripts/config.py
@@ -112,7 +112,7 @@ class Config:
             self.configDict['VERIFIED'] = "True"
             self.write()  # store result
         else:
-            print(blue("'%s' is already checked. Set VERIFIED=False to re-checked"
+            print(blue("'%s' is already checked. Set VERIFIED=False to have it re-checked"
                        % Config.FILE_NAME))
         return True
 

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -112,7 +112,7 @@ class Config:
             self.configDict['VERIFIED'] = "True"
             self.write()  # store result
         else:
-            print(blue("'%s' is already checked. Set VERIFIED=False to have it re-checked"
+            print(blue("'%s' is already checked. Set VERIFIED=False to re-checked"
                        % Config.FILE_NAME))
         return True
 

--- a/src/xmipp/libraries/data/pdb.cpp
+++ b/src/xmipp/libraries/data/pdb.cpp
@@ -551,11 +551,11 @@ void PDBRichPhantom::write(const FileName &fnPDB)
     for (size_t i=0; i<imax; ++i)
     {
     	const RichAtom &atom=atomList[i];
-        char* serial;
+        char serial[5+1];
         if (const char* errmsg3 = hy36encode(5, atom.serial, serial); errmsg3) {
             throw std::invalid_argument(errmsg3);
         }
-        char* resseq;
+        char resseq[4+1];
         if (const char* errmsg4 = hy36encode(4, atom.resseq, resseq); errmsg4) {
             throw std::invalid_argument(errmsg4);
         }

--- a/src/xmipp/libraries/data/pdb.cpp
+++ b/src/xmipp/libraries/data/pdb.cpp
@@ -504,17 +504,17 @@ void PDBRichPhantom::read(const FileName &fnPDB, double pseudoatoms, double thre
 			// ATOM      2  CA AALA A   1      73.796  56.531  56.644  0.50 84.78           C
 			atom.record = line.substr(0,6);
 			
-            if (const char* errmsg1 = hy36decode(5, line.substr(6,5).c_str(), 5, &atom.serial);errmsg1) {
-                throw std::invalid_argument(errmsg1);
-            }
+			if (const char* errmsg1 = hy36decode(5, line.substr(6,5).c_str(), 5, &atom.serial);errmsg1) {
+				throw std::invalid_argument(errmsg1);
+			}
 			atom.name = line.substr(12,4);
 			atom.altloc=line[16];
 			atom.resname=line.substr(17,3);
 			atom.chainid=line[21];
 			
-            if (const char* errmsg2 = hy36decode(4, line.substr(22,4).c_str(), 4, &atom.resseq);errmsg2) {
-                throw std::invalid_argument(errmsg2);
-            }
+			if (const char* errmsg2 = hy36decode(4, line.substr(22,4).c_str(), 4, &atom.resseq);errmsg2) {
+				throw std::invalid_argument(errmsg2);
+			}
 			atom.icode = line[26];
 			atom.x = textToFloat(line.substr(30,8));
 			atom.y = textToFloat(line.substr(38,8));

--- a/src/xmipp/libraries/data/pdb.cpp
+++ b/src/xmipp/libraries/data/pdb.cpp
@@ -547,16 +547,16 @@ void PDBRichPhantom::write(const FileName &fnPDB)
     for (size_t i=0; i<imax; ++i)
     {
     	const RichAtom &atom=atomList[i];
-        char serial[5+1];
+        std::string serial;
         const char* errmsg3 = hy36encode(5, atom.serial, serial);
         if (errmsg3) throw std::runtime_error(errmsg3);
-        char resseq[4+1];
+        std::string resseq;
         const char* errmsg4 = hy36encode(4, atom.resseq, resseq);
         if (errmsg4) throw std::runtime_error(errmsg4);
         fprintf (fh_out,"%-6s%5s %-4s%c%-4s%c%4s%c   %8.3f%8.3f%8.3f%6.2f%6.2f      %4s%2s%2s\n",
-				atom.record.c_str(),serial,atom.name.c_str(),
+				atom.record.c_str(),serial.c_str(),atom.name.c_str(),
 				atom.altloc,atom.resname.c_str(),atom.chainid,
-				resseq,atom.icode,
+				resseq.c_str(),atom.icode,
 				atom.x,atom.y,atom.z,atom.occupancy,atom.bfactor,
 				atom.segment.c_str(),atom.atomType.c_str(),atom.charge.c_str());
     }

--- a/src/xmipp/libraries/data/pdb.cpp
+++ b/src/xmipp/libraries/data/pdb.cpp
@@ -504,16 +504,16 @@ void PDBRichPhantom::read(const FileName &fnPDB, double pseudoatoms, double thre
 			// ATOM      2  CA AALA A   1      73.796  56.531  56.644  0.50 84.78           C
 			atom.record = line.substr(0,6);
 			
-			if (const char* errmsg1 = hy36decode(5, line.substr(6,5).c_str(), 5, &atom.serial);errmsg1) {
-				throw std::invalid_argument(errmsg1);
+			if (auto* errmsg1 = hy36decode(5, line.substr(6,5).c_str(), 5, &atom.serial); errmsg1) {
+				REPORT_ERROR(ERR_VALUE_INCORRECT, errmsg1);
 			}
 			atom.name = line.substr(12,4);
 			atom.altloc=line[16];
 			atom.resname=line.substr(17,3);
 			atom.chainid=line[21];
 			
-			if (const char* errmsg2 = hy36decode(4, line.substr(22,4).c_str(), 4, &atom.resseq);errmsg2) {
-				throw std::invalid_argument(errmsg2);
+			if (auto* errmsg2 = hy36decode(4, line.substr(22,4).c_str(), 4, &atom.resseq); errmsg2) {
+				REPORT_ERROR(ERR_VALUE_INCORRECT, errmsg2);
 			}
 			atom.icode = line[26];
 			atom.x = textToFloat(line.substr(30,8));
@@ -552,12 +552,12 @@ void PDBRichPhantom::write(const FileName &fnPDB)
     {
     	const RichAtom &atom=atomList[i];
         char serial[5+1];
-        if (const char* errmsg3 = hy36encode(5, atom.serial, serial); errmsg3) {
-            throw std::invalid_argument(errmsg3);
+        if (auto* errmsg3 = hy36encode(5, atom.serial, serial); errmsg3) {
+            REPORT_ERROR(ERR_VALUE_INCORRECT, errmsg3);
         }
         char resseq[4+1];
-        if (const char* errmsg4 = hy36encode(4, atom.resseq, resseq); errmsg4) {
-            throw std::invalid_argument(errmsg4);
+        if (auto* errmsg4 = hy36encode(4, atom.resseq, resseq); errmsg4) {
+            REPORT_ERROR(ERR_VALUE_INCORRECT, errmsg4);
         }
         fprintf (fh_out,"%-6s%5s %-4s%c%-4s%c%4s%c   %8.3f%8.3f%8.3f%6.2f%6.2f      %4s%2s%2s\n",
 				atom.record.c_str(),serial,atom.name.c_str(),

--- a/src/xmipp/libraries/data/pdb.cpp
+++ b/src/xmipp/libraries/data/pdb.cpp
@@ -533,10 +533,10 @@ void PDBRichPhantom::read(const FileName &fnPDB, bool pseudoatoms, double thresh
 			atom.atomType = line.substr(76,2);
 			atom.charge = line.substr(78,2);
 
-			if(pseudoatoms == true)
+			if(pseudoatoms)
 				intensities.push_back(atom.bfactor);
             
-			if(atom.bfactor >= threshold && pseudoatoms == false)
+			if(!pseudoatoms && atom.bfactor >= threshold)
 				atomList.push_back(atom);
 
         } else if (kind == "REMA")

--- a/src/xmipp/libraries/data/pdb.cpp
+++ b/src/xmipp/libraries/data/pdb.cpp
@@ -573,6 +573,7 @@ void PDBRichPhantom::write(const FileName &fnPDB)
         char serial[5+1];
         if (auto* errmsg3 = hy36encode(5, atom.serial, serial); errmsg3) {
             // try using i+1 instead
+            reportWarning("Failed to use atom.serial. Trying i+1 instead.");
             if (const char* errmsg = hy36encode(5, (int)i + 1, serial); errmsg) {
                 REPORT_ERROR(ERR_VALUE_INCORRECT, errmsg3);
             }  

--- a/src/xmipp/libraries/data/pdb.cpp
+++ b/src/xmipp/libraries/data/pdb.cpp
@@ -504,11 +504,13 @@ void PDBRichPhantom::read(const FileName &fnPDB, double pseudoatoms, double thre
 			// ATOM      2  CA AALA A   1      73.796  56.531  56.644  0.50 84.78           C
 			atom.record = line.substr(0,6);
 			const char* errmsg1 = hy36decode(5, line.substr(6,5).c_str(), 5, &atom.serial);
+            if (errmsg1) throw std::runtime_error(errmsg1);
 			atom.name = line.substr(12,4);
 			atom.altloc=line[16];
 			atom.resname=line.substr(17,3);
 			atom.chainid=line[21];
 			const char* errmsg2 = hy36decode(4, line.substr(22,4).c_str(), 4, &atom.resseq);
+            if (errmsg2) throw std::runtime_error(errmsg2);
 			atom.icode = line[26];
 			atom.x = textToFloat(line.substr(30,8));
 			atom.y = textToFloat(line.substr(38,8));
@@ -547,8 +549,10 @@ void PDBRichPhantom::write(const FileName &fnPDB)
     	const RichAtom &atom=atomList[i];
         char serial[5+1];
         const char* errmsg3 = hy36encode(5, atom.serial, serial);
+        if (errmsg3) throw std::runtime_error(errmsg3);
         char resseq[4+1];
         const char* errmsg4 = hy36encode(4, atom.resseq, resseq);
+        if (errmsg4) throw std::runtime_error(errmsg4);
         fprintf (fh_out,"%-6s%5s %-4s%c%-4s%c%4s%c   %8.3f%8.3f%8.3f%6.2f%6.2f      %4s%2s%2s\n",
 				atom.record.c_str(),serial,atom.name.c_str(),
 				atom.altloc,atom.resname.c_str(),atom.chainid,

--- a/src/xmipp/libraries/data/pdb.cpp
+++ b/src/xmipp/libraries/data/pdb.cpp
@@ -503,7 +503,7 @@ void PDBRichPhantom::read(const FileName &fnPDB, double pseudoatoms, double thre
 			// ATOM    909  CA  ALA A 161      58.775  31.984 111.803  1.00 34.78
 			// ATOM      2  CA AALA A   1      73.796  56.531  56.644  0.50 84.78           C
 			atom.record = line.substr(0,6);
-			atom.serial = textToInteger(line.substr(6,5));
+			const char* errmsg = hy36decode(5, line.substr(6,5), 5, atom.serial);
 			atom.name = line.substr(12,4);
 			atom.altloc=line[16];
 			atom.resname=line.substr(17,3);

--- a/src/xmipp/libraries/data/pdb.cpp
+++ b/src/xmipp/libraries/data/pdb.cpp
@@ -494,7 +494,6 @@ void PDBRichPhantom::read(const FileName &fnPDB, bool pseudoatoms, double thresh
         REPORT_ERROR(ERR_IO_NOTEXIST, fnPDB);
 
     // Process all lines of the file
-    static const std::string empty(80, ' ');
     auto line = std::string(80, ' ');
     std::string kind;
 
@@ -504,14 +503,14 @@ void PDBRichPhantom::read(const FileName &fnPDB, bool pseudoatoms, double thresh
     {
         // Read an ATOM line
         getline(fh_in, line);
-        line.resize (80,' ');
-        if (line == empty)
+        if (line == "")
         {
             continue;
         }
         kind = line.substr(0,4);
         if (kind == "ATOM" || kind == "HETA")
         {
+			line.resize (80,' ');
 			i++;
 
 			// Extract atom type and position

--- a/src/xmipp/libraries/data/pdb.cpp
+++ b/src/xmipp/libraries/data/pdb.cpp
@@ -560,9 +560,9 @@ void PDBRichPhantom::write(const FileName &fnPDB)
             throw std::invalid_argument(errmsg4);
         }
         fprintf (fh_out,"%-6s%5s %-4s%c%-4s%c%4s%c   %8.3f%8.3f%8.3f%6.2f%6.2f      %4s%2s%2s\n",
-				atom.record.c_str(),serial.c_str(),atom.name.c_str(),
+				atom.record.c_str(),serial,atom.name.c_str(),
 				atom.altloc,atom.resname.c_str(),atom.chainid,
-				resseq.c_str(),atom.icode,
+				resseq,atom.icode,
 				atom.x,atom.y,atom.z,atom.occupancy,atom.bfactor,
 				atom.segment.c_str(),atom.atomType.c_str(),atom.charge.c_str());
     }

--- a/src/xmipp/libraries/data/pdb.cpp
+++ b/src/xmipp/libraries/data/pdb.cpp
@@ -532,9 +532,6 @@ void PDBRichPhantom::read(const FileName &fnPDB, double pseudoatoms, double thre
 					atom.segment += " ";
 				}
 			}
-			else {
-				atom.segment = "    ";
-			}
 
 			if (line.length() > 77) {
 				atom.atomType = line.substr(76,2);
@@ -542,18 +539,12 @@ void PDBRichPhantom::read(const FileName &fnPDB, double pseudoatoms, double thre
 			else if (line.length() > 76) {
 				atom.atomType = line.substr(76,1) + " ";
 			}
-			else {
-				atom.atomType = "  ";
-			}
 
 			if (line.length() > 79) {
 				atom.charge = line.substr(78,2);
 			}
 			else if (line.length() > 78) {
 				atom.charge = line.substr(78,1) + " ";
-			}
-			else {
-				atom.charge = "  ";
 			}
 
 			if(pseudoatoms != -1)

--- a/src/xmipp/libraries/data/pdb.cpp
+++ b/src/xmipp/libraries/data/pdb.cpp
@@ -550,16 +550,19 @@ void PDBRichPhantom::read(const FileName &fnPDB, bool pseudoatoms, double thresh
 }
 
 /* Write phantom to PDB --------------------------------------------------- */
-void PDBRichPhantom::write(const FileName &fnPDB)
+void PDBRichPhantom::write(const FileName &fnPDB, bool renumber)
 {
     FILE* fh_out=fopen(fnPDB.c_str(),"w");
     if (!fh_out)
         REPORT_ERROR(ERR_IO_NOWRITE, fnPDB);
     size_t imax=remarks.size();
     for (size_t i=0; i<imax; ++i)
-    	fprintf(fh_out,"%s\n",remarks[i].c_str());
+        fprintf(fh_out,"%s\n",remarks[i].c_str());
     
     bool useSerial=true;
+    if (renumber)
+        useSerial=false;
+
     imax=atomList.size();
     for (size_t i=0; i<imax; ++i)
     {

--- a/src/xmipp/libraries/data/pdb.cpp
+++ b/src/xmipp/libraries/data/pdb.cpp
@@ -551,12 +551,12 @@ void PDBRichPhantom::write(const FileName &fnPDB)
     for (size_t i=0; i<imax; ++i)
     {
     	const RichAtom &atom=atomList[i];
-        std::string serial;
-        if (const char* errmsg3 = hy36encode(5, atom.serial, const_cast<char*> (serial.c_str())); errmsg3) {
+        char* serial;
+        if (const char* errmsg3 = hy36encode(5, atom.serial, serial); errmsg3) {
             throw std::invalid_argument(errmsg3);
         }
-        std::string resseq;
-        if (const char* errmsg4 = hy36encode(4, atom.resseq, const_cast<char*> (resseq.c_str())); errmsg4) {
+        char* resseq;
+        if (const char* errmsg4 = hy36encode(4, atom.resseq, resseq); errmsg4) {
             throw std::invalid_argument(errmsg4);
         }
         fprintf (fh_out,"%-6s%5s %-4s%c%-4s%c%4s%c   %8.3f%8.3f%8.3f%6.2f%6.2f      %4s%2s%2s\n",

--- a/src/xmipp/libraries/data/pdb.cpp
+++ b/src/xmipp/libraries/data/pdb.cpp
@@ -524,9 +524,9 @@ void PDBRichPhantom::read(const FileName &fnPDB, double pseudoatoms, double thre
 			atom.z = textToFloat(line.substr(46,8));
 			atom.occupancy = textToFloat(line.substr(54,6));
 			atom.bfactor = textToFloat(line.substr(60,6));
-            atom.segment = line.substr(72,4);
-            atom.atomType = line.substr(76,2);
-            atom.charge = line.substr(78,2);
+			atom.segment = line.substr(72,4);
+			atom.atomType = line.substr(76,2);
+			atom.charge = line.substr(78,2);
 
 			if(pseudoatoms != -1)
 				intensities.push_back(atom.bfactor);

--- a/src/xmipp/libraries/data/pdb.cpp
+++ b/src/xmipp/libraries/data/pdb.cpp
@@ -538,8 +538,9 @@ void PDBRichPhantom::read(const FileName &fnPDB, double pseudoatoms, double thre
                 if (i < pseudoatoms)
 				    atomList.push_back(atom);
 				
-			else if(atom.bfactor >= threshold)
-				atomList.push_back(atom);
+			else 
+                if(atom.bfactor >= threshold)
+				    atomList.push_back(atom);
 
         } else if (kind == "REMA")
         	remarks.push_back(line);

--- a/src/xmipp/libraries/data/pdb.cpp
+++ b/src/xmipp/libraries/data/pdb.cpp
@@ -489,7 +489,6 @@ void PDBRichPhantom::read(const FileName &fnPDB, double pseudoatoms, double thre
         REPORT_ERROR(ERR_IO_NOTEXIST, fnPDB);
 
     // Process all lines of the file
-    // std::string line;
     static const std::string empty(80, ' ');
     auto line = std::string(80, ' ');
     std::string kind;
@@ -551,12 +550,13 @@ void PDBRichPhantom::write(const FileName &fnPDB)
     size_t imax=remarks.size();
     for (size_t i=0; i<imax; ++i)
     	fprintf(fh_out,"%s\n",remarks[i].c_str());
+    
+    bool useSerial=true;
     imax=atomList.size();
     for (size_t i=0; i<imax; ++i)
     {
     	const RichAtom &atom=atomList[i];
         char serial[5+1];
-        bool useSerial=true;
         if (useSerial) {
             auto* errmsg3 = hy36encode(5, atom.serial, serial);
             if (errmsg3) {

--- a/src/xmipp/libraries/data/pdb.cpp
+++ b/src/xmipp/libraries/data/pdb.cpp
@@ -578,7 +578,7 @@ void PDBRichPhantom::write(const FileName &fnPDB)
         if (auto* errmsg4 = hy36encode(4, atom.resseq, resseq); errmsg4) {
             REPORT_ERROR(ERR_VALUE_INCORRECT, errmsg4);
         }
-        fprintf (fh_out,"%-6s%5s %-4s%c%-4s%c%4s%c   %8.3f%8.3f%8.3f%6.2f%6.2f      %4s%2s%2s\n",
+        fprintf (fh_out,"%-6s%5s %-4s%c%-4s%c%4s%c   %8.3f%8.3f%8.3f%6.2f%6.2f      %4s%2s%-2s\n",
 				atom.record.c_str(),serial,atom.name.c_str(),
 				atom.altloc,atom.resname.c_str(),atom.chainid,
 				resseq,atom.icode,

--- a/src/xmipp/libraries/data/pdb.cpp
+++ b/src/xmipp/libraries/data/pdb.cpp
@@ -508,7 +508,7 @@ void PDBRichPhantom::read(const FileName &fnPDB, double pseudoatoms, double thre
 			atom.altloc=line[16];
 			atom.resname=line.substr(17,3);
 			atom.chainid=line[21];
-			atom.resseq = textToInteger(line.substr(22,4));
+			const char* errmsg = hy36decode(4, line.substr(22,4), 4, atom.resseq);
 			atom.icode = line[26];
 			atom.x = textToFloat(line.substr(30,8));
 			atom.y = textToFloat(line.substr(38,8));
@@ -545,12 +545,14 @@ void PDBRichPhantom::write(const FileName &fnPDB)
     for (size_t i=0; i<imax; ++i)
     {
     	const RichAtom &atom=atomList[i];
-        char result[5+1];
-        const char* errmsg = hy36encode(5, atom.serial, result);
-        fprintf (fh_out,"%-6s%5s %-4s%c%-4s%c%4d%c   %8.3f%8.3f%8.3f%6.2f%6.2f      %4s%2s%2s\n",
-				atom.record.c_str(),result,atom.name.c_str(),
+        char serial[5+1];
+        const char* errmsg = hy36encode(5, atom.serial, serial);
+        char resseq[4+1];
+        const char* errmsg = hy36encode(4, atom.resseq, resseq);
+        fprintf (fh_out,"%-6s%5s %-4s%c%-4s%c%4s%c   %8.3f%8.3f%8.3f%6.2f%6.2f      %4s%2s%2s\n",
+				atom.record.c_str(),serial.c_str(),atom.name.c_str(),
 				atom.altloc,atom.resname.c_str(),atom.chainid,
-				atom.resseq,atom.icode,
+				resseq.c_str(),atom.icode,
 				atom.x,atom.y,atom.z,atom.occupancy,atom.bfactor,
 				atom.segment.c_str(),atom.atomType.c_str(),atom.charge.c_str());
     }

--- a/src/xmipp/libraries/data/pdb.cpp
+++ b/src/xmipp/libraries/data/pdb.cpp
@@ -533,12 +533,11 @@ void PDBRichPhantom::read(const FileName &fnPDB, double pseudoatoms, double thre
 			atom.atomType = line.substr(76,2);
 			atom.charge = line.substr(78,2);
 
-			if(pseudoatoms != -1){
+			if(pseudoatoms != -1 && i < pseudoatoms){
                 intensities.push_back(atom.bfactor);
-                if (i < pseudoatoms)
-                    atomList.push_back(atom);
+                atomList.push_back(atom);
             }
-			else if(atom.bfactor >= threshold) {
+			if(pseudoatoms == -1 && atom.bfactor >= threshold) {
                 atomList.push_back(atom);    
             }
 

--- a/src/xmipp/libraries/data/pdb.cpp
+++ b/src/xmipp/libraries/data/pdb.cpp
@@ -571,9 +571,13 @@ void PDBRichPhantom::write(const FileName &fnPDB)
     {
     	const RichAtom &atom=atomList[i];
         char serial[5+1];
+        int warned=0;
         if (auto* errmsg3 = hy36encode(5, atom.serial, serial); errmsg3) {
             // try using i+1 instead
-            reportWarning("Failed to use atom.serial. Trying i+1 instead.");
+            if (warned == 0) {
+                reportWarning("Failed to use atom.serial. Trying i+1 instead.");
+                warned = 1;
+            }
             if (const char* errmsg = hy36encode(5, (int)i + 1, serial); errmsg) {
                 REPORT_ERROR(ERR_VALUE_INCORRECT, errmsg3);
             }  

--- a/src/xmipp/libraries/data/pdb.cpp
+++ b/src/xmipp/libraries/data/pdb.cpp
@@ -546,7 +546,7 @@ void PDBRichPhantom::write(const FileName &fnPDB)
     {
     	const RichAtom &atom=atomList[i];
         char result[5+1];
-        const char* errmsg = hy36encode(5, (int)i, result);
+        const char* errmsg = hy36encode(5, atom.serial, result);
         fprintf (fh_out,"%-6s%5s %-4s%c%-4s%c%4d%c   %8.3f%8.3f%8.3f%6.2f%6.2f      %4s%2s%2s\n",
 				atom.record.c_str(),result,atom.name.c_str(),
 				atom.altloc,atom.resname.c_str(),atom.chainid,

--- a/src/xmipp/libraries/data/pdb.cpp
+++ b/src/xmipp/libraries/data/pdb.cpp
@@ -505,7 +505,7 @@ void PDBRichPhantom::read(const FileName &fnPDB, double pseudoatoms, double thre
 			atom.record = line.substr(0,6);
 			
             if (const char* errmsg1 = hy36decode(5, line.substr(6,5).c_str(), 5, &atom.serial);errmsg1) {
-                throw std::runtime_error(errmsg1);
+                throw std::invalid_argument(errmsg1);
             }
 			atom.name = line.substr(12,4);
 			atom.altloc=line[16];
@@ -513,7 +513,7 @@ void PDBRichPhantom::read(const FileName &fnPDB, double pseudoatoms, double thre
 			atom.chainid=line[21];
 			
             if (const char* errmsg2 = hy36decode(4, line.substr(22,4).c_str(), 4, &atom.resseq);errmsg2) {
-                throw std::runtime_error(errmsg2);
+                throw std::invalid_argument(errmsg2);
             }
 			atom.icode = line[26];
 			atom.x = textToFloat(line.substr(30,8));
@@ -553,11 +553,11 @@ void PDBRichPhantom::write(const FileName &fnPDB)
     	const RichAtom &atom=atomList[i];
         std::string serial;
         if (const char* errmsg3 = hy36encode(5, atom.serial, const_cast<char*> (serial.c_str())); errmsg3) {
-            throw std::runtime_error(errmsg3);
+            throw std::invalid_argument(errmsg3);
         }
         std::string resseq;
         if (const char* errmsg4 = hy36encode(4, atom.resseq, const_cast<char*> (resseq.c_str())); errmsg4) {
-            throw std::runtime_error(errmsg4);
+            throw std::invalid_argument(errmsg4);
         }
         fprintf (fh_out,"%-6s%5s %-4s%c%-4s%c%4s%c   %8.3f%8.3f%8.3f%6.2f%6.2f      %4s%2s%2s\n",
 				atom.record.c_str(),serial.c_str(),atom.name.c_str(),

--- a/src/xmipp/libraries/data/pdb.cpp
+++ b/src/xmipp/libraries/data/pdb.cpp
@@ -558,21 +558,17 @@ void PDBRichPhantom::write(const FileName &fnPDB, bool renumber)
     size_t imax=remarks.size();
     for (size_t i=0; i<imax; ++i)
         fprintf(fh_out,"%s\n",remarks[i].c_str());
-    
-    bool useSerial=true;
-    if (renumber)
-        useSerial=false;
 
     imax=atomList.size();
     for (size_t i=0; i<imax; ++i)
     {
     	const RichAtom &atom=atomList[i];
         char serial[5+1];
-        if (useSerial) {
+        if (!renumber) {
             auto* errmsg3 = hy36encode(5, atom.serial, serial);
             if (errmsg3) {
                 reportWarning("Failed to use atom.serial. Using i+1 instead.");
-                useSerial=false;
+                renumber=true;
                 hy36encodeSafe(5, (int)i + 1, serial);
             }
         }

--- a/src/xmipp/libraries/data/pdb.cpp
+++ b/src/xmipp/libraries/data/pdb.cpp
@@ -481,6 +481,11 @@ void PDBPhantom::shift(double x, double y, double z)
 
 /* Read phantom from PDB --------------------------------------------------- */
 void PDBRichPhantom::read(const FileName &fnPDB, double pseudoatoms, double threshold)
+/* - fnPDB is the filename of the PDB file
+   - pseudoatoms is a number of pseudoatoms to keep for pdb_reduce_pseudoatoms
+     or -1 if we want to keep everything or don't have pseudoatoms (default)
+   - threshold is a B factor threshold for filtering out for pdb_reduce_pseudoatoms
+*/
 {
     // Open file
     std::ifstream fh_in;
@@ -494,6 +499,7 @@ void PDBRichPhantom::read(const FileName &fnPDB, double pseudoatoms, double thre
     std::string kind;
 
     RichAtom atom;
+    int i=0;
     while (!fh_in.eof())
     {
         // Read an ATOM line
@@ -527,7 +533,8 @@ void PDBRichPhantom::read(const FileName &fnPDB, double pseudoatoms, double thre
 			atom.atomType = line.substr(76,2);
 			atom.charge = line.substr(78,2);
 
-			if(pseudoatoms != -1)
+			if(pseudoatoms != -1 && i < pseudoatoms)
+				atomList.push_back(atom);
 				intensities.push_back(atom.bfactor);
 
 			if(atom.bfactor >= threshold && pseudoatoms == -1)
@@ -535,6 +542,8 @@ void PDBRichPhantom::read(const FileName &fnPDB, double pseudoatoms, double thre
 
         } else if (kind == "REMA")
         	remarks.push_back(line);
+
+        i++;
     }
 
     // Close files

--- a/src/xmipp/libraries/data/pdb.cpp
+++ b/src/xmipp/libraries/data/pdb.cpp
@@ -480,10 +480,10 @@ void PDBPhantom::shift(double x, double y, double z)
 }
 
 /* Read phantom from PDB --------------------------------------------------- */
-void PDBRichPhantom::read(const FileName &fnPDB, double pseudoatoms, double threshold)
+void PDBRichPhantom::read(const FileName &fnPDB, bool pseudoatoms, double threshold)
 /* - fnPDB is the filename of the PDB file
-   - pseudoatoms is a number of pseudoatoms to keep for pdb_reduce_pseudoatoms
-     or -1 if we want to keep everything or don't have pseudoatoms (default)
+   - pseudoatoms is a flag for returning intensities (stored in B-factors) instead of atoms.
+     **false** (default) is used when there are no pseudoatoms or when using a threshold 
    - threshold is a B factor threshold for filtering out for pdb_reduce_pseudoatoms
 */
 {
@@ -533,13 +533,11 @@ void PDBRichPhantom::read(const FileName &fnPDB, double pseudoatoms, double thre
 			atom.atomType = line.substr(76,2);
 			atom.charge = line.substr(78,2);
 
-			if(pseudoatoms != -1 && i < pseudoatoms){
-                intensities.push_back(atom.bfactor);
-                atomList.push_back(atom);
-            }
-			if(pseudoatoms == -1 && atom.bfactor >= threshold) {
-                atomList.push_back(atom);    
-            }
+			if(pseudoatoms == true)
+				intensities.push_back(atom.bfactor);
+            
+			if(atom.bfactor >= threshold && pseudoatoms == false)
+				atomList.push_back(atom);
 
         } else if (kind == "REMA")
         	remarks.push_back(line);

--- a/src/xmipp/libraries/data/pdb.cpp
+++ b/src/xmipp/libraries/data/pdb.cpp
@@ -57,10 +57,10 @@ hy36encode(unsigned width, int value, char* result);
 const char*
 hy36decode(unsigned width, const char* s, unsigned s_size, int* result);
 
-const int*
+void
 hy36encodeSafe(unsigned width, int value, char* result);
 
-const int*
+void
 hy36decodeSafe(unsigned width, const char* s, unsigned s_size, int* result);
 
 #ifdef __cplusplus
@@ -517,12 +517,12 @@ void PDBRichPhantom::read(const FileName &fnPDB, double pseudoatoms, double thre
 			// ATOM    909  CA  ALA A 161      58.775  31.984 111.803  1.00 34.78
 			// ATOM      2  CA AALA A   1      73.796  56.531  56.644  0.50 84.78           C
 			atom.record = line.substr(0,6);
-			const int* zero1 = hy36decodeSafe(5, line.substr(6,5).c_str(), 5, &atom.serial);
+			hy36decodeSafe(5, line.substr(6,5).c_str(), 5, &atom.serial);
 			atom.name = line.substr(12,4);
-			atom.altloc=line[16];
-			atom.resname=line.substr(17,3);
-			atom.chainid=line[21];
-			const int* zero2 = hy36decodeSafe(4, line.substr(22,4).c_str(), 4, &atom.resseq);
+			atom.altloc = line[16];
+			atom.resname = line.substr(17,3);
+			atom.chainid = line[21];
+			hy36decodeSafe(4, line.substr(22,4).c_str(), 4, &atom.resseq);
 			atom.icode = line[26];
 			atom.x = textToFloat(line.substr(30,8));
 			atom.y = textToFloat(line.substr(38,8));
@@ -571,15 +571,15 @@ void PDBRichPhantom::write(const FileName &fnPDB)
             if (errmsg3) {
                 reportWarning("Failed to use atom.serial. Using i+1 instead.");
                 useSerial=false;
-                const int* zero3 = hy36encodeSafe(5, (int)i + 1, serial);
+                hy36encodeSafe(5, (int)i + 1, serial);
             }
         }
         else {
             // use i+1 instead
-            const int* zero4 = hy36encodeSafe(5, (int)i + 1, serial);
+            hy36encodeSafe(5, (int)i + 1, serial);
         }
         char resseq[4+1];
-        const int* zero5 = hy36encodeSafe(4, atom.resseq, resseq);
+        hy36encodeSafe(4, atom.resseq, resseq);
         fprintf (fh_out,"%-6s%5s %-4s%c%-4s%c%4s%c   %8.3f%8.3f%8.3f%6.2f%6.2f      %4s%2s%-2s\n",
 				atom.record.c_str(),serial,atom.name.c_str(),
 				atom.altloc,atom.resname.c_str(),atom.chainid,
@@ -1676,21 +1676,19 @@ hy36decode(unsigned width, const char* s, unsigned s_size, int* result)
 }
 
 // safe function for hy36decode
-const int*
-hy36decodeSafe(unsigned width, const char* s, unsigned s_size, int* result)
+void hy36decodeSafe(unsigned width, const char* s, unsigned s_size, int* result)
 {
-    if (auto* errmsg = hy36decode(width, s, s_size, result); errmsg) {
+    auto* errmsg = hy36decode(width, s, s_size, result); 
+    if (errmsg) {
         REPORT_ERROR(ERR_VALUE_INCORRECT, errmsg);
     }
-    return 0;
 }
 
 // safe function for hy36encode
-const int*
-hy36encodeSafe(unsigned width, int value, char* result)
+void hy36encodeSafe(unsigned width, int value, char* result)
 {
-    if (const char* errmsg = hy36encode(width, value, result); errmsg) {
+    const char* errmsg = hy36encode(width, value, result); 
+    if (errmsg) {
         REPORT_ERROR(ERR_VALUE_INCORRECT, errmsg);
     }
-    return 0;
 }

--- a/src/xmipp/libraries/data/pdb.cpp
+++ b/src/xmipp/libraries/data/pdb.cpp
@@ -521,9 +521,40 @@ void PDBRichPhantom::read(const FileName &fnPDB, double pseudoatoms, double thre
 			atom.z = textToFloat(line.substr(46,8));
 			atom.occupancy = textToFloat(line.substr(54,6));
 			atom.bfactor = textToFloat(line.substr(60,6));
-			atom.segment = line.substr(72,4);
-			atom.atomType = line.substr(76,2);
-			atom.charge = line.substr(78,2);
+
+			if (line.length() > 75) {
+				atom.segment = line.substr(72,4);
+			}
+			else if (line.length() > 72) {
+				atom.segment = line.substr(72,line.length()-72+1);
+				for(int i=atom.segment.length();i<4;i++) {
+					atom.segment += " ";
+				}
+			}
+			else {
+				atom.segment = "    ";
+			}
+
+			if (line.length() > 77) {
+				atom.atomType = line.substr(76,2);
+			}
+			else if (line.length() > 76) {
+				atom.atomType = line.substr(76,1) + " ";
+			}
+			else {
+				atom.atomType = "  ";
+			}
+
+			if (line.length() > 79) {
+				atom.charge = line.substr(78,2);
+			}
+			else if (line.length() > 78) {
+				atom.charge = line.substr(78,1) + " ";
+			}
+			else {
+				atom.charge = "  ";
+			}
+
 			if(pseudoatoms != -1)
 				intensities.push_back(atom.bfactor);
 

--- a/src/xmipp/libraries/data/pdb.cpp
+++ b/src/xmipp/libraries/data/pdb.cpp
@@ -498,7 +498,6 @@ void PDBRichPhantom::read(const FileName &fnPDB, bool pseudoatoms, double thresh
     std::string kind;
 
     RichAtom atom;
-    int i = -1;
     while (!fh_in.eof())
     {
         // Read an ATOM line
@@ -511,7 +510,6 @@ void PDBRichPhantom::read(const FileName &fnPDB, bool pseudoatoms, double thresh
         if (kind == "ATOM" || kind == "HETA")
         {
 			line.resize (80,' ');
-			i++;
 
 			// Extract atom type and position
 			// Typical line:

--- a/src/xmipp/libraries/data/pdb.cpp
+++ b/src/xmipp/libraries/data/pdb.cpp
@@ -501,8 +501,10 @@ void PDBRichPhantom::read(const FileName &fnPDB, double pseudoatoms, double thre
 			// Extract atom type and position
 			// Typical line:
 			// ATOM    909  CA  ALA A 161      58.775  31.984 111.803  1.00 34.78
-			atom.name=line.substr(12,4);
-			atom.atomType = line[13];
+			// ATOM      2  CA AALA A   1      73.796  56.531  56.644  0.50 84.78           C
+			atom.record = line.substr(0,6);
+			atom.serial = textToInteger(line.substr(6,5));
+			atom.name = line.substr(12,4);
 			atom.altloc=line[16];
 			atom.resname=line.substr(17,3);
 			atom.chainid=line[21];
@@ -513,6 +515,8 @@ void PDBRichPhantom::read(const FileName &fnPDB, double pseudoatoms, double thre
 			atom.z = textToFloat(line.substr(46,8));
 			atom.occupancy = textToFloat(line.substr(54,6));
 			atom.bfactor = textToFloat(line.substr(60,6));
+			atom.atomType = line.substr(76,2);
+			atom.charge = line.substr(78,2);
 			if(pseudoatoms != -1)
 				intensities.push_back(atom.bfactor);
 
@@ -542,11 +546,12 @@ void PDBRichPhantom::write(const FileName &fnPDB)
     	const RichAtom &atom=atomList[i];
         char result[5+1];
         const char* errmsg = hy36encode(5, (int)i, result);
-    	fprintf (fh_out,"ATOM  %5s %4s%c%-4s%c%4d%c   %8.3f%8.3f%8.3f%6.2f%6.2f      %4s\n",
-    			result,atom.name.c_str(),
-    			atom.altloc,atom.resname.c_str(),atom.chainid,
-    			atom.resseq,atom.icode,atom.x,atom.y,atom.z,atom.occupancy,atom.bfactor,
-    			atom.name.c_str());
+    	fprintf (fh_out,"%6s%5d %4s%c%-4s%c%4d%c   %8.3f%8.3f%8.3f%6.2f%6.2f      %2s%2s\n",
+				result,atom.record.c_str(),atom.serial,atom.name.c_str(),
+				atom.altloc,atom.resname.c_str(),atom.chainid,
+				atom.resseq,atom.icode,
+				atom.x,atom.y,atom.z,atom.occupancy,atom.bfactor,
+				atom.atomType.c_str(),atom.charge.c_str());
     }
     fclose(fh_out);
 }

--- a/src/xmipp/libraries/data/pdb.cpp
+++ b/src/xmipp/libraries/data/pdb.cpp
@@ -499,7 +499,7 @@ void PDBRichPhantom::read(const FileName &fnPDB, bool pseudoatoms, double thresh
     std::string kind;
 
     RichAtom atom;
-    int i=0;
+    int i = -1;
     while (!fh_in.eof())
     {
         // Read an ATOM line
@@ -512,6 +512,8 @@ void PDBRichPhantom::read(const FileName &fnPDB, bool pseudoatoms, double thresh
         kind = line.substr(0,4);
         if (kind == "ATOM" || kind == "HETA")
         {
+			i++;
+
 			// Extract atom type and position
 			// Typical line:
 			// ATOM    909  CA  ALA A 161      58.775  31.984 111.803  1.00 34.78
@@ -539,10 +541,8 @@ void PDBRichPhantom::read(const FileName &fnPDB, bool pseudoatoms, double thresh
 			if(!pseudoatoms && atom.bfactor >= threshold)
 				atomList.push_back(atom);
 
-        } else if (kind == "REMA")
-        	remarks.push_back(line);
-
-        i++;
+		} else if (kind == "REMA")
+			remarks.push_back(line);
     }
 
     // Close files

--- a/src/xmipp/libraries/data/pdb.cpp
+++ b/src/xmipp/libraries/data/pdb.cpp
@@ -533,11 +533,12 @@ void PDBRichPhantom::read(const FileName &fnPDB, double pseudoatoms, double thre
 			atom.atomType = line.substr(76,2);
 			atom.charge = line.substr(78,2);
 
-			if(pseudoatoms != -1 && i < pseudoatoms)
-				atomList.push_back(atom);
-				intensities.push_back(atom.bfactor);
-
-			if(atom.bfactor >= threshold && pseudoatoms == -1)
+			if(pseudoatoms != -1)
+                intensities.push_back(atom.bfactor);
+                if (i < pseudoatoms)
+				    atomList.push_back(atom);
+				
+			else if(atom.bfactor >= threshold)
 				atomList.push_back(atom);
 
         } else if (kind == "REMA")

--- a/src/xmipp/libraries/data/pdb.cpp
+++ b/src/xmipp/libraries/data/pdb.cpp
@@ -535,14 +535,11 @@ void PDBRichPhantom::read(const FileName &fnPDB, double pseudoatoms, double thre
 
 			if(pseudoatoms != -1){
                 intensities.push_back(atom.bfactor);
-                if (i < pseudoatoms){
+                if (i < pseudoatoms)
                     atomList.push_back(atom);
-                }
             }
-			else {
-                if(atom.bfactor >= threshold) {
-                    atomList.push_back(atom);
-                }    
+			else if(atom.bfactor >= threshold) {
+                atomList.push_back(atom);    
             }
 
         } else if (kind == "REMA")

--- a/src/xmipp/libraries/data/pdb.cpp
+++ b/src/xmipp/libraries/data/pdb.cpp
@@ -503,14 +503,18 @@ void PDBRichPhantom::read(const FileName &fnPDB, double pseudoatoms, double thre
 			// ATOM    909  CA  ALA A 161      58.775  31.984 111.803  1.00 34.78
 			// ATOM      2  CA AALA A   1      73.796  56.531  56.644  0.50 84.78           C
 			atom.record = line.substr(0,6);
-			const char* errmsg1 = hy36decode(5, line.substr(6,5).c_str(), 5, &atom.serial);
-            if (errmsg1) throw std::runtime_error(errmsg1);
+			
+            if (const char* errmsg1 = hy36decode(5, line.substr(6,5).c_str(), 5, &atom.serial);errmsg1) {
+                throw std::runtime_error(errmsg1);
+            }
 			atom.name = line.substr(12,4);
 			atom.altloc=line[16];
 			atom.resname=line.substr(17,3);
 			atom.chainid=line[21];
-			const char* errmsg2 = hy36decode(4, line.substr(22,4).c_str(), 4, &atom.resseq);
-            if (errmsg2) throw std::runtime_error(errmsg2);
+			
+            if (const char* errmsg2 = hy36decode(4, line.substr(22,4).c_str(), 4, &atom.resseq);errmsg2) {
+                throw std::runtime_error(errmsg2);
+            }
 			atom.icode = line[26];
 			atom.x = textToFloat(line.substr(30,8));
 			atom.y = textToFloat(line.substr(38,8));
@@ -548,11 +552,13 @@ void PDBRichPhantom::write(const FileName &fnPDB)
     {
     	const RichAtom &atom=atomList[i];
         std::string serial;
-        const char* errmsg3 = hy36encode(5, atom.serial, serial);
-        if (errmsg3) throw std::runtime_error(errmsg3);
+        if (const char* errmsg3 = hy36encode(5, atom.serial, const_cast<char*> (serial.c_str())); errmsg3) {
+            throw std::runtime_error(errmsg3);
+        }
         std::string resseq;
-        const char* errmsg4 = hy36encode(4, atom.resseq, resseq);
-        if (errmsg4) throw std::runtime_error(errmsg4);
+        if (const char* errmsg4 = hy36encode(4, atom.resseq, const_cast<char*> (resseq.c_str())); errmsg4) {
+            throw std::runtime_error(errmsg4);
+        }
         fprintf (fh_out,"%-6s%5s %-4s%c%-4s%c%4s%c   %8.3f%8.3f%8.3f%6.2f%6.2f      %4s%2s%2s\n",
 				atom.record.c_str(),serial.c_str(),atom.name.c_str(),
 				atom.altloc,atom.resname.c_str(),atom.chainid,

--- a/src/xmipp/libraries/data/pdb.cpp
+++ b/src/xmipp/libraries/data/pdb.cpp
@@ -503,12 +503,12 @@ void PDBRichPhantom::read(const FileName &fnPDB, double pseudoatoms, double thre
 			// ATOM    909  CA  ALA A 161      58.775  31.984 111.803  1.00 34.78
 			// ATOM      2  CA AALA A   1      73.796  56.531  56.644  0.50 84.78           C
 			atom.record = line.substr(0,6);
-			const char* errmsg = hy36decode(5, line.substr(6,5), 5, atom.serial);
+			const char* errmsg1 = hy36decode(5, line.substr(6,5).c_str(), 5, &atom.serial);
 			atom.name = line.substr(12,4);
 			atom.altloc=line[16];
 			atom.resname=line.substr(17,3);
 			atom.chainid=line[21];
-			const char* errmsg = hy36decode(4, line.substr(22,4), 4, atom.resseq);
+			const char* errmsg2 = hy36decode(4, line.substr(22,4).c_str(), 4, &atom.resseq);
 			atom.icode = line[26];
 			atom.x = textToFloat(line.substr(30,8));
 			atom.y = textToFloat(line.substr(38,8));
@@ -546,13 +546,13 @@ void PDBRichPhantom::write(const FileName &fnPDB)
     {
     	const RichAtom &atom=atomList[i];
         char serial[5+1];
-        const char* errmsg = hy36encode(5, atom.serial, serial);
+        const char* errmsg3 = hy36encode(5, atom.serial, serial);
         char resseq[4+1];
-        const char* errmsg = hy36encode(4, atom.resseq, resseq);
+        const char* errmsg4 = hy36encode(4, atom.resseq, resseq);
         fprintf (fh_out,"%-6s%5s %-4s%c%-4s%c%4s%c   %8.3f%8.3f%8.3f%6.2f%6.2f      %4s%2s%2s\n",
-				atom.record.c_str(),serial.c_str(),atom.name.c_str(),
+				atom.record.c_str(),serial,atom.name.c_str(),
 				atom.altloc,atom.resname.c_str(),atom.chainid,
-				resseq.c_str(),atom.icode,
+				resseq,atom.icode,
 				atom.x,atom.y,atom.z,atom.occupancy,atom.bfactor,
 				atom.segment.c_str(),atom.atomType.c_str(),atom.charge.c_str());
     }

--- a/src/xmipp/libraries/data/pdb.cpp
+++ b/src/xmipp/libraries/data/pdb.cpp
@@ -533,14 +533,17 @@ void PDBRichPhantom::read(const FileName &fnPDB, double pseudoatoms, double thre
 			atom.atomType = line.substr(76,2);
 			atom.charge = line.substr(78,2);
 
-			if(pseudoatoms != -1)
+			if(pseudoatoms != -1){
                 intensities.push_back(atom.bfactor);
-                if (i < pseudoatoms)
-				    atomList.push_back(atom);
-				
-			else 
-                if(atom.bfactor >= threshold)
-				    atomList.push_back(atom);
+                if (i < pseudoatoms){
+                    atomList.push_back(atom);
+                }
+            }
+			else {
+                if(atom.bfactor >= threshold) {
+                    atomList.push_back(atom);
+                }    
+            }
 
         } else if (kind == "REMA")
         	remarks.push_back(line);

--- a/src/xmipp/libraries/data/pdb.cpp
+++ b/src/xmipp/libraries/data/pdb.cpp
@@ -573,7 +573,7 @@ void PDBRichPhantom::write(const FileName &fnPDB)
         char serial[5+1];
         if (auto* errmsg3 = hy36encode(5, atom.serial, serial); errmsg3) {
             // try using i+1 instead
-            if (const char* errmsg = hy36encode(5, (int)i + 1, result); errmsg) {
+            if (const char* errmsg = hy36encode(5, (int)i + 1, serial); errmsg) {
                 REPORT_ERROR(ERR_VALUE_INCORRECT, errmsg3);
             }  
         }

--- a/src/xmipp/libraries/data/pdb.cpp
+++ b/src/xmipp/libraries/data/pdb.cpp
@@ -527,7 +527,8 @@ void PDBRichPhantom::read(const FileName &fnPDB, double pseudoatoms, double thre
 			}
 			else if (line.length() > 72) {
 				atom.segment = line.substr(72,line.length()-72+1);
-				for(int i=atom.segment.length();i<4;i++) {
+				int lenSegment = atom.segment.length();
+				for(int i=lenSegment; i<4; i++) {
 					atom.segment += " ";
 				}
 			}

--- a/src/xmipp/libraries/data/pdb.cpp
+++ b/src/xmipp/libraries/data/pdb.cpp
@@ -515,6 +515,7 @@ void PDBRichPhantom::read(const FileName &fnPDB, double pseudoatoms, double thre
 			atom.z = textToFloat(line.substr(46,8));
 			atom.occupancy = textToFloat(line.substr(54,6));
 			atom.bfactor = textToFloat(line.substr(60,6));
+			atom.segment = line.substr(72,4);
 			atom.atomType = line.substr(76,2);
 			atom.charge = line.substr(78,2);
 			if(pseudoatoms != -1)
@@ -546,13 +547,12 @@ void PDBRichPhantom::write(const FileName &fnPDB)
     	const RichAtom &atom=atomList[i];
         char result[5+1];
         const char* errmsg = hy36encode(5, (int)i, result);
-    	fprintf (fh_out,"%6s%5d %4s%c%-4s%c%4d%c   %8.3f%8.3f%8.3f%6.2f%6.2f      %2s%2s\n",
-				//result,
-                atom.record.c_str(),atom.serial,atom.name.c_str(),
+        fprintf (fh_out,"%-6s%5s %-4s%c%-4s%c%4d%c   %8.3f%8.3f%8.3f%6.2f%6.2f      %4s%2s%2s\n",
+				atom.record.c_str(),result,atom.name.c_str(),
 				atom.altloc,atom.resname.c_str(),atom.chainid,
 				atom.resseq,atom.icode,
 				atom.x,atom.y,atom.z,atom.occupancy,atom.bfactor,
-				atom.atomType.c_str(),atom.charge.c_str());
+				atom.segment.c_str(),atom.atomType.c_str(),atom.charge.c_str());
     }
     fclose(fh_out);
 }

--- a/src/xmipp/libraries/data/pdb.cpp
+++ b/src/xmipp/libraries/data/pdb.cpp
@@ -547,7 +547,8 @@ void PDBRichPhantom::write(const FileName &fnPDB)
         char result[5+1];
         const char* errmsg = hy36encode(5, (int)i, result);
     	fprintf (fh_out,"%6s%5d %4s%c%-4s%c%4d%c   %8.3f%8.3f%8.3f%6.2f%6.2f      %2s%2s\n",
-				result,atom.record.c_str(),atom.serial,atom.name.c_str(),
+				//result,
+                atom.record.c_str(),atom.serial,atom.name.c_str(),
 				atom.altloc,atom.resname.c_str(),atom.chainid,
 				atom.resseq,atom.icode,
 				atom.x,atom.y,atom.z,atom.occupancy,atom.bfactor,

--- a/src/xmipp/libraries/data/pdb.cpp
+++ b/src/xmipp/libraries/data/pdb.cpp
@@ -527,24 +527,20 @@ void PDBRichPhantom::read(const FileName &fnPDB, double pseudoatoms, double thre
 			}
 			else if (line.length() > 72) {
 				atom.segment = line.substr(72,line.length()-72+1);
-				int lenSegment = atom.segment.length();
-				for(int i=lenSegment; i<4; i++) {
-					atom.segment += " ";
-				}
 			}
 
 			if (line.length() > 77) {
 				atom.atomType = line.substr(76,2);
 			}
 			else if (line.length() > 76) {
-				atom.atomType = line.substr(76,1) + " ";
+				atom.atomType = line.substr(76,1);
 			}
 
 			if (line.length() > 79) {
 				atom.charge = line.substr(78,2);
 			}
 			else if (line.length() > 78) {
-				atom.charge = line.substr(78,1) + " ";
+				atom.charge = line.substr(78,1);
 			}
 
 			if(pseudoatoms != -1)

--- a/src/xmipp/libraries/data/pdb.h
+++ b/src/xmipp/libraries/data/pdb.h
@@ -209,7 +209,7 @@ public:
     /// atom element type
     std::string atomType;
 
-    /// charge
+    /// 2-char charge with sign 2nd (e.g. 1- or 2+)
     std::string charge;
 };
 

--- a/src/xmipp/libraries/data/pdb.h
+++ b/src/xmipp/libraries/data/pdb.h
@@ -237,7 +237,7 @@ public:
     }
 
     /// Read from PDB file
-    void read(const FileName &fnPDB, double pseudoatoms = -1.0, double threshold = 0.0);
+    void read(const FileName &fnPDB, bool pseudoatoms = false, double threshold = 0.0);
 
     /// Write to PDB file
     void write(const FileName &fnPDB);

--- a/src/xmipp/libraries/data/pdb.h
+++ b/src/xmipp/libraries/data/pdb.h
@@ -240,7 +240,7 @@ public:
     void read(const FileName &fnPDB, bool pseudoatoms = false, double threshold = 0.0);
 
     /// Write to PDB file
-    void write(const FileName &fnPDB);
+    void write(const FileName &fnPDB, bool renumber = false);
 
 };
 

--- a/src/xmipp/libraries/data/pdb.h
+++ b/src/xmipp/libraries/data/pdb.h
@@ -167,9 +167,6 @@ public:
     /// Record Type ("ATOM  " or "HETATM")
     std::string record;
 
-    /// element Type
-    std::string atomType;
-
     /// atom serial number
     int serial;
 
@@ -205,6 +202,12 @@ public:
 
     /// Bfactor
     double bfactor;
+
+    /// segment name
+    std::string segment;
+
+    /// atom element type
+    std::string atomType;
 
     /// charge
     std::string charge;

--- a/src/xmipp/libraries/data/pdb.h
+++ b/src/xmipp/libraries/data/pdb.h
@@ -164,8 +164,14 @@ public:
 class RichAtom
 {
 public:
-    /// Type
-    char atomType;
+    /// Record Type ("ATOM  " or "HETATM")
+    std::string record;
+
+    /// element Type
+    std::string atomType;
+
+    /// atom serial number
+    int serial;
 
     /// Position X
     double x;
@@ -199,6 +205,9 @@ public:
 
     /// Bfactor
     double bfactor;
+
+    /// charge
+    std::string charge;
 };
 
 /** Phantom description using atoms. */

--- a/src/xmipp/libraries/reconstruction/pdb_reduce_pseudoatoms.cpp
+++ b/src/xmipp/libraries/reconstruction/pdb_reduce_pseudoatoms.cpp
@@ -76,7 +76,7 @@ void ProgPdbReduce::reduceNumberPseudoatoms()
 		pdb.remarks.clear();
 		pdb.read(fn_volume, false, thresh);
 	}
-	pdb.write(fn_out);
+	pdb.write(fn_out, true); // keep renumbering
 }
 
 void ProgPdbReduce::run()

--- a/src/xmipp/libraries/reconstruction/pdb_reduce_pseudoatoms.cpp
+++ b/src/xmipp/libraries/reconstruction/pdb_reduce_pseudoatoms.cpp
@@ -66,15 +66,15 @@ void ProgPdbReduce::reduceNumberPseudoatoms()
 {
 	PDBRichPhantom pdb;
 	if(thresh != 0.0)
-		pdb.read(fn_volume, -1.0, thresh);
+		pdb.read(fn_volume, false, thresh);
 	else
 	{
-		pdb.read(fn_volume, num);
+		pdb.read(fn_volume, true);
 		std::sort(pdb.intensities.rbegin(), pdb.intensities.rend());
 		thresh = pdb.intensities.at(num);
 		pdb.atomList.clear();
 		pdb.remarks.clear();
-		pdb.read(fn_volume, -1.0, thresh);
+		pdb.read(fn_volume, false, thresh);
 	}
 	pdb.write(fn_out);
 }


### PR DESCRIPTION
The pdb data library now has all the right fields and should write the record type ("`ATOM  `" or "`HETATM`") correctly at the beginning of the line and the atomType (element) and charge (if applicable) correctly at the end of the line.

I also added in a grammar fix in the config messages about "re-checked"