### PR TITLE
Jmk pseudoatoms

### DIFF
--- a/src/xmipp/libraries/reconstruction/volume_to_pseudoatoms.cpp
+++ b/src/xmipp/libraries/reconstruction/volume_to_pseudoatoms.cpp
@@ -935,25 +935,43 @@ void ProgVolumeToPseudoatoms::writeResults()
         if (allowIntensity)
             intensity=0.01+ROUND(100*a*(atoms[n].intensity-minIntensity))/100.0;
         if (col==1)
-            fprintf(fhOut,
-            //      "%-6s%5s %-4s%c%-4s%c%4s%c   %8.3f%8.3f%8.3f%6.2f%6.2f      %4s%2s%2s\n",
-            //       ATOM      2  CA AALA A   1      73.796  56.531  56.644  0.50 84.78           C
-            //       ATOM      1DENS  DEN     1     -29.425   5.511  53.019     1  0.05      DENS
-            //       ATOM  14491DENS  DEN  14491     12.840  44.940  25.680     1  0.07      DENS
-                    "ATOM  %5dDENS  DEN  %5d   %8.3f%8.3f%8.3f%6.2f     1      DENS\n",
-                    n+1,n+1,
-                    (float)(atoms[n].location(2)*sampling),
-                    (float)(atoms[n].location(1)*sampling),
-                    (float)(atoms[n].location(0)*sampling),
-                    (float)intensity);
+            if (n+1 < 10000)
+                fprintf(fhOut,
+                //       ATOM      1DENS  DEN     1     -29.425   5.511  53.019  0.05     1      DENS
+                        "ATOM  %5dDENS  DEN  %4d    %8.3f%8.3f%8.3f%6.2f     1      DENS\n",
+                        n+1,n+1,
+                        (float)(atoms[n].location(2)*sampling),
+                        (float)(atoms[n].location(1)*sampling),
+                        (float)(atoms[n].location(0)*sampling),
+                        (float)intensity);
+            else
+                fprintf(fhOut,
+                //       ATOM  14491DENS  DEN  14491     12.840  44.940  25.680  0.07     1      DENS
+                        "ATOM  %5dDENS  DEN  %5d   %8.3f%8.3f%8.3f%6.2f     1      DENS\n",
+                        n+1,n+1,
+                        (float)(atoms[n].location(2)*sampling),
+                        (float)(atoms[n].location(1)*sampling),
+                        (float)(atoms[n].location(0)*sampling),
+                        (float)intensity);
         else
-            fprintf(fhOut,
-                    "ATOM  %5dDENS  DEN  %5d   %8.3f%8.3f%8.3f     1%6.2f      DENS\n",
-                    n+1,n+1,
-                    (float)(atoms[n].location(2)*sampling),
-                    (float)(atoms[n].location(1)*sampling),
-                    (float)(atoms[n].location(0)*sampling),
-                    (float)intensity);
+            if (n+1 < 10000)
+                fprintf(fhOut,
+                //       ATOM      1DENS  DEN     1     -29.425   5.511  53.019     1  0.05      DENS
+                        "ATOM  %5dDENS  DEN  %4d    %8.3f%8.3f%8.3f     1%6.2f      DENS\n",
+                        n+1,n+1,
+                        (float)(atoms[n].location(2)*sampling),
+                        (float)(atoms[n].location(1)*sampling),
+                        (float)(atoms[n].location(0)*sampling),
+                        (float)intensity);
+            else
+                fprintf(fhOut,
+                //       ATOM  14491DENS  DEN  14491     12.840  44.940  25.680     1  0.07      DENS
+                        "ATOM  %5dDENS  DEN  %5d   %8.3f%8.3f%8.3f     1%6.2f      DENS\n",
+                        n+1,n+1,
+                        (float)(atoms[n].location(2)*sampling),
+                        (float)(atoms[n].location(1)*sampling),
+                        (float)(atoms[n].location(0)*sampling),
+                        (float)intensity);
     }
     fclose(fhOut);
 

--- a/src/xmipp/libraries/reconstruction/volume_to_pseudoatoms.cpp
+++ b/src/xmipp/libraries/reconstruction/volume_to_pseudoatoms.cpp
@@ -936,7 +936,11 @@ void ProgVolumeToPseudoatoms::writeResults()
             intensity=0.01+ROUND(100*a*(atoms[n].intensity-minIntensity))/100.0;
         if (col==1)
             fprintf(fhOut,
-                    "ATOM  %5d DENS DENS%5d    %8.3f%8.3f%8.3f%6.2f     1      DENS\n",
+            //      "%-6s%5s %-4s%c%-4s%c%4s%c   %8.3f%8.3f%8.3f%6.2f%6.2f      %4s%2s%2s\n",
+            //       ATOM      2  CA AALA A   1      73.796  56.531  56.644  0.50 84.78           C
+            //       ATOM      1DENS  DEN     1     -29.425   5.511  53.019     1  0.05      DENS
+            //       ATOM  14491DENS  DENS14491      12.840  44.940  25.680     1  0.07      DENS
+                    "ATOM  %5dDENS  DEN %5d    %8.3f%8.3f%8.3f%6.2f     1      DENS\n",
                     n+1,n+1,
                     (float)(atoms[n].location(2)*sampling),
                     (float)(atoms[n].location(1)*sampling),
@@ -944,7 +948,7 @@ void ProgVolumeToPseudoatoms::writeResults()
                     (float)intensity);
         else
             fprintf(fhOut,
-                    "ATOM  %5d DENS DENS%5d    %8.3f%8.3f%8.3f     1%6.2f      DENS\n",
+                    "ATOM  %5dDENS  DEN %5d    %8.3f%8.3f%8.3f     1%6.2f      DENS\n",
                     n+1,n+1,
                     (float)(atoms[n].location(2)*sampling),
                     (float)(atoms[n].location(1)*sampling),

--- a/src/xmipp/libraries/reconstruction/volume_to_pseudoatoms.cpp
+++ b/src/xmipp/libraries/reconstruction/volume_to_pseudoatoms.cpp
@@ -939,8 +939,8 @@ void ProgVolumeToPseudoatoms::writeResults()
             //      "%-6s%5s %-4s%c%-4s%c%4s%c   %8.3f%8.3f%8.3f%6.2f%6.2f      %4s%2s%2s\n",
             //       ATOM      2  CA AALA A   1      73.796  56.531  56.644  0.50 84.78           C
             //       ATOM      1DENS  DEN     1     -29.425   5.511  53.019     1  0.05      DENS
-            //       ATOM  14491DENS  DEN  14491      12.840  44.940  25.680     1  0.07      DENS
-                    "ATOM  %5dDENS  DEN  %5d    %8.3f%8.3f%8.3f%6.2f     1      DENS\n",
+            //       ATOM  14491DENS  DEN  14491     12.840  44.940  25.680     1  0.07      DENS
+                    "ATOM  %5dDENS  DEN  %5d   %8.3f%8.3f%8.3f%6.2f     1      DENS\n",
                     n+1,n+1,
                     (float)(atoms[n].location(2)*sampling),
                     (float)(atoms[n].location(1)*sampling),
@@ -948,7 +948,7 @@ void ProgVolumeToPseudoatoms::writeResults()
                     (float)intensity);
         else
             fprintf(fhOut,
-                    "ATOM  %5dDENS  DEN  %5d    %8.3f%8.3f%8.3f     1%6.2f      DENS\n",
+                    "ATOM  %5dDENS  DEN  %5d   %8.3f%8.3f%8.3f     1%6.2f      DENS\n",
                     n+1,n+1,
                     (float)(atoms[n].location(2)*sampling),
                     (float)(atoms[n].location(1)*sampling),

--- a/src/xmipp/libraries/reconstruction/volume_to_pseudoatoms.cpp
+++ b/src/xmipp/libraries/reconstruction/volume_to_pseudoatoms.cpp
@@ -939,8 +939,8 @@ void ProgVolumeToPseudoatoms::writeResults()
             //      "%-6s%5s %-4s%c%-4s%c%4s%c   %8.3f%8.3f%8.3f%6.2f%6.2f      %4s%2s%2s\n",
             //       ATOM      2  CA AALA A   1      73.796  56.531  56.644  0.50 84.78           C
             //       ATOM      1DENS  DEN     1     -29.425   5.511  53.019     1  0.05      DENS
-            //       ATOM  14491DENS  DENS14491      12.840  44.940  25.680     1  0.07      DENS
-                    "ATOM  %5dDENS  DEN %5d    %8.3f%8.3f%8.3f%6.2f     1      DENS\n",
+            //       ATOM  14491DENS  DEN  14491      12.840  44.940  25.680     1  0.07      DENS
+                    "ATOM  %5dDENS  DEN  %5d    %8.3f%8.3f%8.3f%6.2f     1      DENS\n",
                     n+1,n+1,
                     (float)(atoms[n].location(2)*sampling),
                     (float)(atoms[n].location(1)*sampling),
@@ -948,7 +948,7 @@ void ProgVolumeToPseudoatoms::writeResults()
                     (float)intensity);
         else
             fprintf(fhOut,
-                    "ATOM  %5dDENS  DEN %5d    %8.3f%8.3f%8.3f     1%6.2f      DENS\n",
+                    "ATOM  %5dDENS  DEN  %5d    %8.3f%8.3f%8.3f     1%6.2f      DENS\n",
                     n+1,n+1,
                     (float)(atoms[n].location(2)*sampling),
                     (float)(atoms[n].location(1)*sampling),


### PR DESCRIPTION
This makes volumes to pseudoatoms write a proper pdb file that other programs such as prody and the rest of xmipp can read. 

For example, xmipp_reduce_pseudoatoms makes a mess with the current files because of having the first digit of the residue number being in the chain field as the zeros in between then get removed. With the fix applied to the input file, the test actually gives a more sensible result. 