### PR TITLE
Maintenance: fixing dangling pointer in xmipp_error

### DIFF
--- a/src/xmipp/applications/programs/angular_commonline/angular_commonline_main.cpp
+++ b/src/xmipp/applications/programs/angular_commonline/angular_commonline_main.cpp
@@ -29,22 +29,9 @@
 int main(int argc, char **argv)
 {
     Prog_Angular_CommonLine prm;
-    try {
-        prm.read(argc,(const char **)argv);
-    } catch (XmippError &xe)
-    {
-        std::cout << xe << std::endl;
-        prm.usage();
-        return 1;
-    }
-    try {
-        prm.show();
-        prm.produceSideInfo();
-        prm.run();
-    } catch (XmippError &xe)
-    {
-        std::cout << xe << std::endl;
-        return 2;
-    }
+    prm.read(argc,(const char **)argv);
+    prm.show();
+    prm.produceSideInfo();
+    prm.run();
     return 0;
 }

--- a/src/xmipp/applications/programs/mpi_angular_project_library/mpi_angular_project_library_main.cpp
+++ b/src/xmipp/applications/programs/mpi_angular_project_library/mpi_angular_project_library_main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
         }
         catch (XmippError &XE)
         {
-            std::cerr << XE;
+            std::cerr << XE.what();
             MPI_Finalize();
             exit(1);
         }
@@ -62,7 +62,7 @@ int main(int argc, char *argv[])
         }
         catch (XmippError &XE)
         {
-            std::cerr << XE;
+            std::cerr << XE.what();
             MPI_Finalize();
             exit(1);
         }

--- a/src/xmipp/applications/tests/function_tests/aiterative_alignment_tests.h
+++ b/src/xmipp/applications/tests/function_tests/aiterative_alignment_tests.h
@@ -384,30 +384,22 @@ TYPED_TEST_P( IterativeAlignmentEstimator_Test, clearStatisticsNoNoise)
 
 TYPED_TEST_P( IterativeAlignmentEstimator_Test, align2DOneToOneNoise)
 {
-    XMIPP_TRY
     IterativeAlignmentEstimator_Test<TypeParam>::template generateAndTestStatistics2D<true>(1, 1);
-    XMIPP_CATCH
 }
 
 TYPED_TEST_P( IterativeAlignmentEstimator_Test, align2DOneToManyNoiseNoBatch)
 {
-    XMIPP_TRY
     IterativeAlignmentEstimator_Test<TypeParam>::template generateAndTestStatistics2D<true>(100, 1);
-    XMIPP_CATCH
 }
 
 TYPED_TEST_P( IterativeAlignmentEstimator_Test, align2DOneToManyNoiseBatch)
 {
-    XMIPP_TRY
     IterativeAlignmentEstimator_Test<TypeParam>::template generateAndTestStatistics2D<true>(100, 50);
-    XMIPP_CATCH
 }
 
 TYPED_TEST_P( IterativeAlignmentEstimator_Test, align2DOneToManyNoiseBatchNotMultiple)
 {
-    XMIPP_TRY
     IterativeAlignmentEstimator_Test<TypeParam>::template generateAndTestStatistics2D<true>(100, 60);
-    XMIPP_CATCH
 }
 
 TYPED_TEST_P( IterativeAlignmentEstimator_Test, checkStatisticsNoise)
@@ -424,13 +416,11 @@ TYPED_TEST_P( IterativeAlignmentEstimator_Test, clearStatisticsNoise)
 
 //TYPED_TEST_P( IterativeAlignmentEstimator_Test, debug)
 //{
-//    XMIPP_TRY
 //    auto dims = Dimensions(680, 680, 1, 100);
 ////    auto dims = Dimensions(64, 64, 1, 50);
 //    size_t batch = 50;
 //    IterativeAlignmentEstimator_Test<TypeParam>::template testStatistics<false>(dims, batch);
 ////    IterativeAlignmentEstimator_Test<TypeParam>::template test<false>(dims, batch);
-//    XMIPP_CATCH
 //}
 
 REGISTER_TYPED_TEST_SUITE_P(IterativeAlignmentEstimator_Test,

--- a/src/xmipp/applications/tests/function_tests/arotation_estimator_tests.h
+++ b/src/xmipp/applications/tests/function_tests/arotation_estimator_tests.h
@@ -140,10 +140,8 @@ std::mt19937 ARotationEstimator_Test<T>::mt(42); // fixed seed to ensure reprodu
 
 TYPED_TEST_P( ARotationEstimator_Test, rotate2DOneToOne)
 {
-    XMIPP_TRY
     // test one reference vs one image
     ARotationEstimator_Test<TypeParam>::template generateAndTest2D<false>(1, 1);
-    XMIPP_CATCH
 }
 
 TYPED_TEST_P( ARotationEstimator_Test, rotate2DOneToMany)

--- a/src/xmipp/applications/tests/function_tests/ashift_corr_estimator_tests.h
+++ b/src/xmipp/applications/tests/function_tests/ashift_corr_estimator_tests.h
@@ -80,10 +80,8 @@ std::vector<HW*> AShiftCorrEstimator_Test<T>::hw;
 
 TYPED_TEST_P( AShiftCorrEstimator_Test, correlate2DOneToOne)
  {
-    XMIPP_TRY
      // test one reference vs one image
     AShiftCorrEstimator_Test<TypeParam>::correlate2DNoCenter(1, 1);
-    XMIPP_CATCH
 }
 
 TYPED_TEST_P( AShiftCorrEstimator_Test, correlate2DOneToMany)

--- a/src/xmipp/applications/tests/function_tests/ashift_estimator_tests.h
+++ b/src/xmipp/applications/tests/function_tests/ashift_estimator_tests.h
@@ -118,10 +118,8 @@ std::mt19937 AShiftEstimator_Test<T>::mt(42); // fixed seed to ensure reproducib
 
 TYPED_TEST_P( AShiftEstimator_Test, shift2DOneToOne)
 {
-    XMIPP_TRY
     // test one reference vs one image
     AShiftEstimator_Test<TypeParam>::generateAndTest2D(1, 1);
-    XMIPP_CATCH
 }
 
 TYPED_TEST_P( AShiftEstimator_Test, shift2DOneToMany)

--- a/src/xmipp/applications/tests/function_tests/asingle_extrema_finder_tests.h
+++ b/src/xmipp/applications/tests/function_tests/asingle_extrema_finder_tests.h
@@ -494,7 +494,6 @@ TYPED_TEST_P( SingleExtremaFinder_Test, findLowest3DMany)
 
 TYPED_TEST_P( SingleExtremaFinder_Test, findMax2DAroundCenter)
 {
-    XMIPP_TRY
     auto mt = std::mt19937(42);
     auto nBatch = std::vector<std::pair<size_t, size_t>>(); // n, batch
     nBatch.emplace_back(1, 1);
@@ -513,7 +512,6 @@ TYPED_TEST_P( SingleExtremaFinder_Test, findMax2DAroundCenter)
             SingleExtremaFinder_Test<TypeParam>::test(settings);
         }
     }
-    XMIPP_CATCH
 }
 
 TYPED_TEST_P( SingleExtremaFinder_Test, findMax2DAroundCenterMany)
@@ -534,7 +532,6 @@ TYPED_TEST_P( SingleExtremaFinder_Test, findMax2DAroundCenterMany)
 
 TYPED_TEST_P( SingleExtremaFinder_Test, findLowest2DAroundCenter)
 {
-    XMIPP_TRY
     auto mt = std::mt19937(42);
     auto nBatch = std::vector<std::pair<size_t, size_t>>(); // n, batch
     nBatch.emplace_back(1, 1);
@@ -553,7 +550,6 @@ TYPED_TEST_P( SingleExtremaFinder_Test, findLowest2DAroundCenter)
             SingleExtremaFinder_Test<TypeParam>::test(settings);
         }
     }
-    XMIPP_CATCH
 }
 
 TYPED_TEST_P( SingleExtremaFinder_Test, findLowest2DAroundCenterMany)
@@ -574,7 +570,6 @@ TYPED_TEST_P( SingleExtremaFinder_Test, findLowest2DAroundCenterMany)
 
 //TYPED_TEST_P( SingleExtremaFinder_Test, debug)
 //{
-//    XMIPP_TRY
 //    auto mt = std::mt19937(42);
 //    std::uniform_int_distribution<> dist(1, 500);
 //    for (int i = 0; i < 5; ++i) {
@@ -587,7 +582,6 @@ TYPED_TEST_P( SingleExtremaFinder_Test, findLowest2DAroundCenterMany)
 //        settings.maxDistFromCenter = 0;
 //        SingleExtremaFinder_Test<TypeParam>::test(settings);
 //    }
-//    XMIPP_CATCH;
 //}
 
 REGISTER_TYPED_TEST_SUITE_P(SingleExtremaFinder_Test,

--- a/src/xmipp/applications/tests/function_tests/test_ctf_main.cpp
+++ b/src/xmipp/applications/tests/function_tests/test_ctf_main.cpp
@@ -15,33 +15,19 @@ protected:
     //init metadatas
     virtual void SetUp()
     {
-
-        try
-        {
-            //get example images/staks
-            if (chdir(((String)(getXmippPath() + (String)"/resources/test")).c_str())==-1)
-                REPORT_ERROR(ERR_UNCLASSIFIED,"Could not change directory");
-            // testBaseName = xmippPath + "/resources/test";
-            imageName = "image/singleImage.spi";
-
-        }
-        catch (XmippError &xe)
-        {
-            std::cerr << xe;
-            exit(-1);
-        }
+        //get example images/staks
+        if (chdir(((String)(getXmippPath() + (String)"/resources/test")).c_str())==-1)
+            REPORT_ERROR(ERR_UNCLASSIFIED,"Could not change directory");
+        // testBaseName = xmippPath + "/resources/test";
+        imageName = "image/singleImage.spi";
     }
-
     // virtual void TearDown() {}//Destructor
     Image<double> myImageFloat;
     FileName imageName;
-
-
 };
 
 TEST_F( CtfTest, generateImageWithTwoCTFs)
 {
-    XMIPP_TRY
     MetaDataVec metadata1;
     long objectId = metadata1.addObject();
     metadata1.setValue(MDL_CTF_SAMPLING_RATE, 1., objectId);
@@ -57,12 +43,10 @@ TEST_F( CtfTest, generateImageWithTwoCTFs)
     img().alias(in);
     //img.write("/tmp/kk.mrc");
     EXPECT_TRUE(true);
-    XMIPP_CATCH
 }
 
 TEST_F( CtfTest, errorBetween2CTFs)
 {
-    XMIPP_TRY
     MetaDataVec metadata1;
     long objectId = metadata1.addObject();
     metadata1.setValue(MDL_CTF_SAMPLING_RATE, 2.1, objectId);
@@ -88,12 +72,10 @@ TEST_F( CtfTest, errorBetween2CTFs)
                              256,
                              0.05,0.25);
     EXPECT_FLOAT_EQ(error,7121.4971);
-    XMIPP_CATCH
 }
 
 TEST_F( CtfTest, errorMaxFreqCTFs)
 {
-    XMIPP_TRY
     MetaDataVec metadata1;
     long objectId = metadata1.addObject();
     metadata1.setValue(MDL_CTF_SAMPLING_RATE, 2., objectId);
@@ -111,12 +93,10 @@ TEST_F( CtfTest, errorMaxFreqCTFs)
 //    }
     resolution = errorMaxFreqCTFs(metadata1,HALFPI);
     EXPECT_FLOAT_EQ(resolution,7.6852355);
-    XMIPP_CATCH
 }
 
 TEST_F( CtfTest, errorMaxFreqCTFs2D)
 {
-    XMIPP_TRY
     MetaDataVec metadata1;
     long objectId = metadata1.addObject();
     metadata1.setValue(MDL_CTF_SAMPLING_RATE, 2., objectId);
@@ -140,12 +120,10 @@ TEST_F( CtfTest, errorMaxFreqCTFs2D)
     double resolution = errorMaxFreqCTFs2D(metadata1,
                              metadata2,256,HALFPI);
     EXPECT_NEAR(resolution,13.921659080780355,0.00001);
-    XMIPP_CATCH
 }
 
 TEST_F( CtfTest, phaseFlip)
 {
-    XMIPP_TRY
     MetaDataVec metadata1;
     long objectId = metadata1.addObject();
     metadata1.setValue(MDL_CTF_SAMPLING_RATE, 1., objectId);
@@ -169,6 +147,4 @@ TEST_F( CtfTest, phaseFlip)
     delta().computeStats(avgval, devval, minval, maxval);
     EXPECT_NEAR(devval,0.003906,0.0001);
     EXPECT_NEAR(maxval,0.017565,0.0001);
-
-    XMIPP_CATCH
 }

--- a/src/xmipp/applications/tests/function_tests/test_geometry_main.cpp
+++ b/src/xmipp/applications/tests/function_tests/test_geometry_main.cpp
@@ -139,7 +139,6 @@ TEST_F(GeometryTest, rotateAngleAroundAxis)
 // check the plane fit is right
 TEST_F( GeometryTest, least_squares_plane_fit_All_Points)
 {
-    XMIPP_TRY
     MultidimArray<double> img;
 
     img.resize(4,4);
@@ -151,12 +150,10 @@ TEST_F( GeometryTest, least_squares_plane_fit_All_Points)
     EXPECT_NEAR(a,1,XMIPP_EQUAL_ACCURACY);
     EXPECT_NEAR(b,1,XMIPP_EQUAL_ACCURACY);
     EXPECT_NEAR(c,0,XMIPP_EQUAL_ACCURACY);
-    XMIPP_CATCH
 }
 
 TEST_F( GeometryTest, normalize_ramp)
 {
-    XMIPP_TRY
     MultidimArray<double> img;
 
     img.resize(4,4);
@@ -166,5 +163,4 @@ TEST_F( GeometryTest, normalize_ramp)
     normalize_ramp(img);
     img.selfABS();
     EXPECT_NEAR(img.sum(),0,XMIPP_EQUAL_ACCURACY);
-    XMIPP_CATCH
 }

--- a/src/xmipp/applications/tests/function_tests/test_image_generic_main.cpp
+++ b/src/xmipp/applications/tests/function_tests/test_image_generic_main.cpp
@@ -14,23 +14,14 @@ protected:
     //init metadatas
     virtual void SetUp()
     {
-
-        try
-        {
-            //get example images/staks
-            if (chdir(((String)(getXmippPath() + (String)"/resources/test")).c_str())==-1)
-                REPORT_ERROR(ERR_UNCLASSIFIED,"Could not change directory");
-            // testBaseName = xmippPath + "/resources/test";
-            imageName = "image/singleImage.spi";
-            stackName = "image/smallStack.stk";
-            myImageGeneric.readMapped(imageName);
-            myImageGeneric2.readMapped(stackName, 1);
-        }
-        catch (XmippError &xe)
-        {
-            std::cerr << xe;
-            exit(-1);
-        }
+        //get example images/staks
+        if (chdir(((String)(getXmippPath() + (String)"/resources/test")).c_str())==-1)
+            REPORT_ERROR(ERR_UNCLASSIFIED,"Could not change directory");
+        // testBaseName = xmippPath + "/resources/test";
+        imageName = "image/singleImage.spi";
+        stackName = "image/smallStack.stk";
+        myImageGeneric.readMapped(imageName);
+        myImageGeneric2.readMapped(stackName, 1);
     }
 
     // virtual void TearDown() {}//Destructor
@@ -48,18 +39,15 @@ protected:
 TEST_F( ImageGenericTest, equalsOperator)
 {
 
-    XMIPP_TRY
     ImageGeneric auxImageG;
     auxImageG.readMapped(imageName);
     ASSERT_TRUE(myImageGeneric==myImageGeneric);
     ASSERT_TRUE(myImageGeneric==auxImageG);
     ASSERT_FALSE(myImageGeneric==myImageGeneric2);
-    XMIPP_CATCH
 }
 
 TEST_F( ImageGenericTest, equalsFunction)
 {
-    XMIPP_TRY
     ImageGeneric auxImageG;
     auxImageG.read(imageName);
     ASSERT_TRUE (myImageGeneric.equal(auxImageG) );
@@ -71,7 +59,6 @@ TEST_F( ImageGenericTest, equalsFunction)
     //std::cerr << *((MultidimArray<float>*)auxImageG.data->im) <<std::endl;
     ASSERT_FALSE(myImageGeneric.equal(auxImageG));
     ASSERT_TRUE(myImageGeneric.equal(auxImageG,XMIPP_EQUAL_ACCURACY*4.));
-    XMIPP_CATCH
 }
 
 TEST_F( ImageGenericTest, copy)
@@ -86,19 +73,16 @@ TEST_F( ImageGenericTest, copy)
 // Check if swapped images are read correctly, mapped and unmapped.
 TEST_F( ImageGenericTest, readMapSwapFile)
 {
-    XMIPP_TRY
     FileName auxFn = imageName.insertBeforeExtension("_swap");
     ImageGeneric auxImageGeneric;
     auxImageGeneric.read(auxFn);
     EXPECT_EQ(myImageGeneric,auxImageGeneric);
     auxImageGeneric.readMapped(auxFn);
     EXPECT_EQ(myImageGeneric,auxImageGeneric);
-    XMIPP_CATCH
 }
 
 TEST_F( ImageGenericTest, add)
 {
-    XMIPP_TRY
     FileName auxFilename1((String)"1@"+stackName);
     FileName auxFilename2((String)"2@"+stackName);
     ImageGeneric auxImageGeneric1(auxFilename1);
@@ -109,8 +93,6 @@ TEST_F( ImageGenericTest, add)
     EXPECT_TRUE(auxImageGeneric1==auxImageGeneric2);
     auxImageGeneric1.add(auxImageGeneric2);
     EXPECT_FALSE(auxImageGeneric1==auxImageGeneric2);
-
-    XMIPP_CATCH
 }
 
 TEST_F( ImageGenericTest, subtract)
@@ -151,7 +133,6 @@ TEST_F( ImageGenericTest, multiplyDivide)
 // check if an empty file is correctly created
 TEST_F( ImageGenericTest, createEmptyFile)
 {
-    XMIPP_TRY
     FileName tempFn;
     tempFn.initUniqueName("/tmp/emptyFile_XXXXXX");
     tempFn = tempFn + ":stk";
@@ -170,7 +151,6 @@ TEST_F( ImageGenericTest, createEmptyFile)
     EXPECT_DOUBLE_EQ(min, 0);
     EXPECT_DOUBLE_EQ(max, 0);
     tempFn.deleteFile();
-    XMIPP_CATCH
 }
 
 TEST_F( ImageGenericTest, initConstant)
@@ -207,7 +187,6 @@ TEST_F( ImageGenericTest, initRandom)
 // check if a pointer to data array is correctly passed
 TEST_F( ImageGenericTest, getArrayPointer)
 {
-    XMIPP_TRY
     ImageGeneric img, img2;
     img.read(imageName);
     MultidimArrayGeneric & mag = MULTIDIM_ARRAY_GENERIC(img);
@@ -224,13 +203,11 @@ TEST_F( ImageGenericTest, getArrayPointer)
     memcpy(data2, data, info.adim.nzyxdim*sizeof(float));
 
     EXPECT_TRUE(img == img2);
-    XMIPP_CATCH
 }
 
 // check if a pointer to MultidimArray is correctly passed
 TEST_F( ImageGenericTest, getMultidimArrayPointer)
 {
-    XMIPP_TRY
     ImageGeneric img, img2;
     img.read(imageName);
     MultidimArrayGeneric & mag = MULTIDIM_ARRAY_GENERIC(img);
@@ -247,7 +224,6 @@ TEST_F( ImageGenericTest, getMultidimArrayPointer)
     typeCast(*data, *data2);
 
     EXPECT_TRUE(img == img2);
-    XMIPP_CATCH
 }
 
 /* check if an image declared as one kind of datatype is correctly
@@ -255,7 +231,6 @@ TEST_F( ImageGenericTest, getMultidimArrayPointer)
  */
 TEST_F( ImageGenericTest, convert2Datatype)
 {
-    XMIPP_TRY
     ImageGeneric img;
     img.read(imageName);
     MultidimArray<float> * ma;
@@ -321,13 +296,11 @@ TEST_F( ImageGenericTest, convert2Datatype)
     MULTIDIM_ARRAY_GENERIC(myImageGeneric).getMultidimArrayPointer(uintMaP);
 
     EXPECT_EQ(*uintMaP, uintMa);
-    XMIPP_CATCH
 }
 
 // check the reslicing is right
 TEST_F( ImageGenericTest, reslice)
 {
-    XMIPP_TRY
     FileName fnVol = "image/progVol.vol";
     ImageGeneric imgSliced, imgRef;
     imgSliced.read(fnVol);
@@ -360,12 +333,10 @@ TEST_F( ImageGenericTest, reslice)
     imgSliced().getMultidimArrayPointer(dataS);
 
     EXPECT_EQ(*dataR, *dataS);
-    XMIPP_CATCH
 }
 
 TEST_F( ImageGenericTest, getPreview)
 {
-    XMIPP_TRY
     FileName auxFn = "image/smallVolume.vol";
     ImageGeneric img1, img2, imgTemp;
     imgTemp.read(auxFn);
@@ -384,12 +355,10 @@ TEST_F( ImageGenericTest, getPreview)
         img2().setXmippOrigin();
         EXPECT_EQ(img1, img2) << "getPreview a specific slice";
     }
-    XMIPP_CATCH
 }
 
 TEST_F( ImageGenericTest, movePointerTo)
 {
-    XMIPP_TRY
     FileName auxFn= "image/smallVolumeStack.stk";
     ImageGeneric img1, img2;
     img1.read(auxFn);
@@ -412,12 +381,10 @@ TEST_F( ImageGenericTest, movePointerTo)
             EXPECT_TRUE(img1 == img2);
         }
     }
-    XMIPP_CATCH
 }
 
 TEST_F( ImageGenericTest, MovePointerToCheckDimensions)
 {
-    XMIPP_TRY
     ImageGeneric img1, img2;
 
     img1.setDatatype(DT_Float);
@@ -453,5 +420,4 @@ TEST_F( ImageGenericTest, MovePointerToCheckDimensions)
             EXPECT_TRUE(aDim == newADim);
         }
     }
-    XMIPP_CATCH
 }

--- a/src/xmipp/applications/tests/function_tests/test_image_main.cpp
+++ b/src/xmipp/applications/tests/function_tests/test_image_main.cpp
@@ -15,7 +15,6 @@ protected:
     //init metadatas
     virtual void SetUp()
     {
-        XMIPP_TRY
         //get example images/staks
         xmippPath = getXmippPath();
         if (chdir(((String)(xmippPath + "/resources/test")).c_str())==-1)
@@ -28,7 +27,6 @@ protected:
         myImage.read(imageName);
         myStack.read(stackName);
         myVolStack.read(stackVolName);
-        XMIPP_CATCH
     }
 
     // virtual void TearDown() {}//Destructor
@@ -81,7 +79,6 @@ TEST_F( ImageTest, getEulerAngles)
 
 TEST_F( ImageTest, readApplyGeo)
 {
-    XMIPP_TRY
     FileName auxFn = "image/test2.spi";
     MetaDataVec md;
     size_t id = md.addObject();
@@ -98,13 +95,11 @@ TEST_F( ImageTest, readApplyGeo)
     auxImage.readApplyGeo(md, id, params);
     auxImage2.read(auxFn.insertBeforeExtension("_wrap_true"));
     EXPECT_TRUE(auxImage == auxImage2);
-    XMIPP_CATCH
 }
 
 TEST_F( ImageTest, readApplyGeoFromMatrix)
 {
   // Same as readApplyGeo, but using the transformation matrix
-    XMIPP_TRY
     FileName auxFn = "image/test2.spi";
     MetaDataVec md;
     size_t id = md.addObject();
@@ -126,12 +121,10 @@ TEST_F( ImageTest, readApplyGeoFromMatrix)
     auxImage.readApplyGeo(md, id, params);
     auxImage2.read(auxFn.insertBeforeExtension("_wrap_true"));
     EXPECT_EQ(auxImage, auxImage2);
-    XMIPP_CATCH
 }
 
 TEST_F( ImageTest, readImageFromStackMetadata)
 {
-    XMIPP_TRY
     FileName stackSliceFn, auxFn;
     stackSliceFn.compose(2, stackName);
     Image<double> img1;
@@ -143,13 +136,11 @@ TEST_F( ImageTest, readImageFromStackMetadata)
     img2.read(auxFn);
 
     EXPECT_TRUE(img1 == img2);
-    XMIPP_CATCH
 }
 
 //ROB ask kino is angles are saved in header
 TEST_F( ImageTest, saveImageinStackwithHeaderAngleRot)
 {
-    XMIPP_TRY
     FileName stackSliceFn, auxFn;
     stackSliceFn.compose(2, stackName);
     Image<double> img1;
@@ -169,12 +160,10 @@ TEST_F( ImageTest, saveImageinStackwithHeaderAngleRot)
     EXPECT_DOUBLE_EQ(20.,tilt);
     EXPECT_DOUBLE_EQ(30. ,psi);
     stackSliceFn.deleteFile();
-    XMIPP_CATCH
 }
 
 TEST_F( ImageTest, writeIMAGICimage)
 {
-    XMIPP_TRY
     FileName auxFn;
     auxFn.initUniqueName("/tmp/temp_img_XXXXXX");
     auxFn.deleteFile();
@@ -186,12 +175,10 @@ TEST_F( ImageTest, writeIMAGICimage)
     auxFn.deleteFile();
     auxFn = auxFn.replaceSubstring(".img", ".hed");
     auxFn.deleteFile();
-    XMIPP_CATCH
 }
 
 TEST_F( ImageTest, mirrorY)
 {
-    XMIPP_TRY
     Image<double> auxImage(3,3);
     Image<double> auxImageY(3,3);
     int dim ;
@@ -215,12 +202,10 @@ TEST_F( ImageTest, mirrorY)
             DIRECT_IMGPIXEL(auxImage2Y,dim-i-1,j)=(double) dim*i+j;
     auxImage2.mirrorY();
     EXPECT_EQ(auxImage2,auxImage2Y);
-    XMIPP_CATCH
 }
 
 TEST_F( ImageTest, writeIMAGICstack)
 {
-    XMIPP_TRY
     FileName auxFn;
     auxFn.initUniqueName("/tmp/temp_imgstk_XXXXXX");
     auxFn.deleteFile();
@@ -232,12 +217,10 @@ TEST_F( ImageTest, writeIMAGICstack)
     auxFn.deleteFile();
     auxFn = auxFn.replaceSubstring(".img", ".hed");
     auxFn.deleteFile();
-    XMIPP_CATCH
 }
 
 void checkMRC(Image<double> &myImage, const FileName &suffixIn, const FileName &suffixOut)
 {
-    XMIPP_TRY
     FileName auxFn;
     auxFn.initUniqueName("/tmp/temp_mrc_XXXXXX");
     myImage.write(auxFn+suffixIn);
@@ -245,7 +228,6 @@ void checkMRC(Image<double> &myImage, const FileName &suffixIn, const FileName &
     auxImage.read(auxFn+suffixOut);
     EXPECT_EQ(myImage,auxImage);
     auxFn.deleteFile();
-    XMIPP_CATCH
 }
 
 TEST_F( ImageTest, writeMRCimage)
@@ -265,7 +247,6 @@ TEST_F( ImageTest, writeMRCstack)
 
 TEST_F( ImageTest, writeMRCVOLstack)
 {
-    XMIPP_TRY
     FileName auxFn;
     auxFn.initUniqueName("/tmp/temp_mrcvolstk_XXXXXX");
     auxFn = auxFn + ":mrc";
@@ -279,12 +260,10 @@ TEST_F( ImageTest, writeMRCVOLstack)
     auxStack.getDimensions(auxStackArrayDim);
     EXPECT_TRUE(StackArrayDim==auxStackArrayDim);
     auxFn.deleteFile();
-    XMIPP_CATCH
 }
 
 TEST_F( ImageTest, writeMRCVOLstack2)
 {
-    XMIPP_TRY
     FileName auxFn;
     auxFn.initUniqueName("/tmp/temp_mrcvol_XXXXXX");
     auxFn = auxFn + ".rec";
@@ -300,12 +279,10 @@ TEST_F( ImageTest, writeMRCVOLstack2)
     EXPECT_TRUE(stackArrayDim.ydim==volArrayDim.ydim);
     EXPECT_TRUE(stackArrayDim.ndim==volArrayDim.zdim);
     auxFn.deleteFile();
-    XMIPP_CATCH
 }
 
 TEST_F( ImageTest, writeTIFimage)
 {
-    XMIPP_TRY
     FileName auxFn;
     auxFn.initUniqueName("/tmp/temp_tif_XXXXXX");
     auxFn = auxFn + ":tif";
@@ -314,12 +291,10 @@ TEST_F( ImageTest, writeTIFimage)
     auxImage.read(auxFn);
     EXPECT_EQ(myImage,auxImage);
     auxFn.deleteFile();
-    XMIPP_CATCH
 }
 
 TEST_F( ImageTest, writeINFimage)
 {
-    XMIPP_TRY
     FileName auxFn;
     auxFn.initUniqueName("/tmp/temp_inf_XXXXXX");
     auxFn.deleteFile();
@@ -331,12 +306,10 @@ TEST_F( ImageTest, writeINFimage)
     auxFn.deleteFile();
     auxFn = auxFn.addExtension("inf");
     auxFn.deleteFile();
-    XMIPP_CATCH
 }
 
 TEST_F( ImageTest, readRAWimage)
 {
-    XMIPP_TRY
     FileName auxFn;
     auxFn.initUniqueName("/tmp/temp_raw_XXXXXX");
     myImage.write(auxFn + ":spi");
@@ -345,7 +318,6 @@ TEST_F( ImageTest, readRAWimage)
     auxImage.read(auxFn);
     EXPECT_EQ(myImage,auxImage);
     auxFn.deleteFile();
-    XMIPP_CATCH
 }
 
 TEST_F( ImageTest, readMRC) {
@@ -360,7 +332,6 @@ TEST_F( ImageTest, readMRC) {
 
 TEST_F( ImageTest, readPreview)
 {
-    XMIPP_TRY
     FileName auxFn = "image/smallVolume.vol";
     Image<double> img1, img2;
     img1.read(auxFn);
@@ -373,12 +344,10 @@ TEST_F( ImageTest, readPreview)
     img2().setXmippOrigin();
 
     EXPECT_TRUE(img1 == img2);
-    XMIPP_CATCH
 }
 
 TEST_F( ImageTest, getPreview)
 {
-    XMIPP_TRY
     FileName auxFn = "image/smallVolume.vol";
     Image<double> img1, img2;
     img1.read(auxFn);
@@ -391,12 +360,10 @@ TEST_F( ImageTest, getPreview)
     img1().setXmippOrigin();
     img2().setXmippOrigin();
     EXPECT_TRUE(img1 == img2);
-    XMIPP_CATCH
 }
 
 TEST_F( ImageTest, mapFile2Write)
 {
-    XMIPP_TRY
     FileName auxFn = "image/smallVolume.vol";
     FileName auxMappedFilename;
     auxMappedFilename.initUniqueName("/tmp/temp_vol_XXXXXX");
@@ -415,11 +382,9 @@ TEST_F( ImageTest, mapFile2Write)
     EXPECT_TRUE(img1 == img2);
 
     auxMappedFilename.deleteFile();
-    XMIPP_CATCH
 }
 TEST_F( ImageTest, movePointerTo)
 {
-    XMIPP_TRY
     FileName auxFn= "image/smallVolumeStack.stk";
     Image<double> img1, img2;
     img1.read(auxFn);
@@ -442,13 +407,10 @@ TEST_F( ImageTest, movePointerTo)
             EXPECT_TRUE(img1 == img2);
         }
     }
-    XMIPP_CATCH
 }
 
 TEST_F( ImageTest, checkImageFileSize)
 {
-    XMIPP_TRY
     EXPECT_TRUE(checkImageFileSize("image/smallVolumeStack.stk"));
     EXPECT_FALSE(checkImageFileSize("image/smallVolumeStackCorrupted.stk"));
-    XMIPP_CATCH
 }

--- a/src/xmipp/applications/tests/function_tests/test_metadata_db_main.cpp
+++ b/src/xmipp/applications/tests/function_tests/test_metadata_db_main.cpp
@@ -519,8 +519,6 @@ TEST_F( MetadataTest, MDInfo)
     FileName fnSTAR;
     fnSTAR = fn + ".xmd";
 
-    XMIPP_TRY
-
     mDsource.write(fnDB);
     mDsource.write(fnSTAR);
 
@@ -542,8 +540,6 @@ TEST_F( MetadataTest, MDInfo)
     for (size_t i = 0; i < labels.size(); ++i)
       EXPECT_TRUE(mdOnlyOne.containsLabel(labels[i]));
 
-    XMIPP_CATCH
-
     unlink(fn.c_str());
     unlink(fnDB.c_str());
     unlink(fnSTAR.c_str());
@@ -564,11 +560,9 @@ TEST_F( MetadataTest,multiWrite)
     FileName fnXMLref  =(String)"metadata/mDsource.xml";
     FileName fnSTARref =(String)"metadata/mDsource.xmd";
 
-    XMIPP_TRY
     // mDsource.write((String)"myblock@"+fnDB);
     mDsource.write((String)"myblock@"+fnXML);
     mDsource.write((String)"myblock@"+fnSTAR);
-    XMIPP_CATCH
 
     // EXPECT_TRUE(compareTwoFiles(fnDB, fnDBref));
     EXPECT_TRUE(compareTwoFiles(fnXML, fnXMLref));
@@ -610,7 +604,6 @@ TEST_F( MetadataTest,multiWriteSqlite)
     md.addRow(row);
 
     FileName fileNameA = FileName();
-    XMIPP_TRY
     fileNameA.compose("block001", fnDB);
 
     md.setValue(MDL_ORDER,(size_t)11, md.firstRowId());
@@ -642,7 +635,6 @@ TEST_F( MetadataTest,multiWriteSqlite)
     EXPECT_EQ(readBlockList[1],"block002");
     EXPECT_EQ(readBlockList[2],"block003");
 
-    XMIPP_CATCH
     unlink(fn.c_str());
     unlink(fnDB.c_str());
 }
@@ -781,7 +773,6 @@ TEST_F( MetadataTest, CheckRegularExpression2)
 
 TEST_F( MetadataTest, compareTwoMetadataFiles)
 {
-    XMIPP_TRY
     char sfn[64] = "";
     strncpy(sfn, "/tmp/testGetBlocks_XXXXXX", sizeof sfn);
     if (mkstemp(sfn)==-1)
@@ -833,12 +824,10 @@ TEST_F( MetadataTest, compareTwoMetadataFiles)
     unlink(sfn);
     unlink(sfn2);
     unlink(sfn3);
-    XMIPP_CATCH
 }
 
 TEST_F( MetadataTest, FillExpand)
 {
-    XMIPP_TRY
     //create 2 temporary CTFs plus a metadata with dependences
     char sfn1[64] = "";
     strncpy(sfn1, "/tmp/FillExpandCTF2_XXXXXX", sizeof sfn1);
@@ -910,7 +899,6 @@ TEST_F( MetadataTest, FillExpand)
 
     unlink(sfn1);
     unlink(sfn2);
-    XMIPP_CATCH
 }
 
 TEST_F( MetadataTest, ImportObject)
@@ -1088,28 +1076,21 @@ TEST_F( MetadataTest, JoinVector)
 
 TEST_F( MetadataTest, MDValueEQ)
 {
-    try
-    {
-        MetaDataDb md;
-        md.setValue(MDL_IMAGE, (String)"a", md.addObject());
-        md.setValue(MDL_IMAGE, (String)"b", md.addObject());
-        md.setValue(MDL_IMAGE, (String)"c", md.addObject());
-        md.setValue(MDL_IMAGE, (String)"a", md.addObject());
+    MetaDataDb md;
+    md.setValue(MDL_IMAGE, (String)"a", md.addObject());
+    md.setValue(MDL_IMAGE, (String)"b", md.addObject());
+    md.setValue(MDL_IMAGE, (String)"c", md.addObject());
+    md.setValue(MDL_IMAGE, (String)"a", md.addObject());
 
-        MetaDataDb md2;
-        md2.setValue(MDL_IMAGE, (String)"a", md2.addObject());
-        md2.setValue(MDL_IMAGE, (String)"a", md2.addObject());
+    MetaDataDb md2;
+    md2.setValue(MDL_IMAGE, (String)"a", md2.addObject());
+    md2.setValue(MDL_IMAGE, (String)"a", md2.addObject());
 
-        MDValueEQ eq(MDL_IMAGE,(String)"a");
-        //Test empty query
-        MetaDataDb md3;
-        md3.importObjects(md, eq);
-        EXPECT_EQ(md2, md3);
-    }
-    catch (XmippError &xe)
-    {
-        std::cerr << "DEBUG_JM: xe: " << xe << std::endl;
-    }
+    MDValueEQ eq(MDL_IMAGE,(String)"a");
+    //Test empty query
+    MetaDataDb md3;
+    md3.importObjects(md, eq);
+    EXPECT_EQ(md2, md3);
 }
 
 TEST_F( MetadataTest, NaturalJoin)
@@ -1167,8 +1148,6 @@ TEST_F( MetadataTest, OperateExt)
 
 TEST_F( MetadataTest, RegularExp)
 {
-    XMIPP_TRY
-
     //create temporal file with three metadas
     //char sfnStar[64] = "";
     //char sfnSqlite[64] = "";
@@ -1228,8 +1207,6 @@ TEST_F( MetadataTest, RegularExp)
     unlink(fn.c_str());
     unlink(sfnStar.c_str());
     //unlink(sfnSqlite);
-
-    XMIPP_CATCH
 }
 
 TEST_F( MetadataTest, Query)
@@ -1477,7 +1454,6 @@ TEST_F( MetadataTest, ExistsBlock)
 
 TEST_F( MetadataTest, ReadWriteAppendBlock)
 {
-    XMIPP_TRY
     //temp file name
     char sfn[32] = "";
     strncpy(sfn, "/tmp/testWrite_XXXXXX", sizeof sfn);
@@ -1490,7 +1466,6 @@ TEST_F( MetadataTest, ReadWriteAppendBlock)
     FileName sfn2 = "metadata/ReadWriteAppendBlock.xmd";
     EXPECT_TRUE(compareTwoFiles(sfn,sfn2,0));
     unlink(sfn);
-    XMIPP_CATCH
 }
 
 TEST_F( MetadataTest, RemoveDuplicates)
@@ -1629,7 +1604,6 @@ TEST_F( MetadataTest, setGetValue)
 }
 TEST_F( MetadataTest, Comment)
 {
-    XMIPP_TRY
     char sfn[64] = "";
     MetaDataDb md1(mDsource);
     strncpy(sfn, "/tmp/testComment_XXXXXX", sizeof sfn);
@@ -1646,13 +1620,10 @@ TEST_F( MetadataTest, Comment)
     s2=md2.getComment();
     EXPECT_EQ(s1, s2);
     unlink(sfn);
-
-    XMIPP_CATCH
 }
 //read file with vector
 TEST_F( MetadataTest, getValue)
 {
-    XMIPP_TRY
     std::vector<double> v1(3);
     std::vector<double> v2(3);
     MetaDataDb auxMD1;
@@ -1667,12 +1638,10 @@ TEST_F( MetadataTest, getValue)
     EXPECT_EQ(v1[0],v2[0]);
     EXPECT_EQ(v1[1],v2[1]);
     EXPECT_EQ(v1[2],v2[2]);
-    XMIPP_CATCH
 }
 
 TEST_F( MetadataTest, getValueDefault)
 {
-    XMIPP_TRY
     MetaDataDb auxMD1;
     MetaDataDb auxMD2;
     double rot=1., tilt=2., psi=3.;
@@ -1699,12 +1668,9 @@ TEST_F( MetadataTest, getValueDefault)
     auxMD1.getRow2(rowIn, id);
     rowIn.getValueOrDefault(MDL_ANGLE_PSI,psi2,3.);
     EXPECT_EQ(psi,psi2);
-
-    XMIPP_CATCH
 }
 TEST_F( MetadataTest, getValueAbort)
 {
-    XMIPP_TRY
     MetaDataDb auxMD1;
     double rot=1.;
     id = auxMD1.addObject();
@@ -1717,12 +1683,10 @@ TEST_F( MetadataTest, getValueAbort)
     auxMD1.getRow(rowIn, id);
     std::cerr << "TEST COMMENT: You should get the error  Cannot find label: anglePsi" <<std::endl;
     EXPECT_THROW(rowGetValueOrAbort(rowIn,MDL_ANGLE_PSI,rot), XmippError);
-    XMIPP_CATCH
 }
 
 TEST_F( MetadataTest, CopyColumn)
 {
-    XMIPP_TRY
     MetaDataDb md1(mDsource), md2(mDsource);
     double value;
 
@@ -1735,12 +1699,10 @@ TEST_F( MetadataTest, CopyColumn)
     md2.copyColumn(MDL_Z, MDL_Y);
 
     EXPECT_EQ(md1, md2);
-    XMIPP_CATCH
 }
 
 TEST_F( MetadataTest, RenameColumn)
 {
-    XMIPP_TRY
     MetaDataDb md1(mDsource);
     MetaDataDb md2;
     md1.renameColumn(MDL_Y,MDL_Z);
@@ -1753,12 +1715,10 @@ TEST_F( MetadataTest, RenameColumn)
 
 
     EXPECT_EQ(md1, md2);
-    XMIPP_CATCH
 }
 
 TEST_F( MetadataTest, BsoftRemoveLoopBlock)
 {
-//    XMIPP_TRY
 //    FileName fnSTAR =(String)"metadata/symop.star";
 //    char sfn[64] = "";
 //    strncpy(sfn, "/tmp/BsoftRemoveLoopBlock1_XXXXXX.star", sizeof sfn);
@@ -1833,13 +1793,10 @@ TEST_F( MetadataTest, BsoftRemoveLoopBlock)
 //    EXPECT_EQ(md5090col, readMd);
 //
 //    unlink(sfn);
-//    XMIPP_CATCH
-
 }
 
 TEST_F( MetadataTest, bsoftRestoreLoopBlock)
 {
-//    XMIPP_TRY
 //    FileName fnSTAR =(String)"metadata/symop.star";
 //    char sfn[64] = "";
 //    strncpy(sfn, "/tmp/BsoftRemoveLoopBlock1_XXXXXX.star", sizeof sfn);
@@ -1876,8 +1833,6 @@ TEST_F( MetadataTest, bsoftRestoreLoopBlock)
 //    EXPECT_EQ(md1b, readMd);
 //    unlink(sfn);
 //    unlink(sfn2);
-//
-//    XMIPP_CATCH
 }
 
 TEST_F( MetadataTest, updateRow)

--- a/src/xmipp/applications/tests/function_tests/test_metadata_vec_main.cpp
+++ b/src/xmipp/applications/tests/function_tests/test_metadata_vec_main.cpp
@@ -320,8 +320,6 @@ TEST_F(MetadataTest, MDInfo)
     FileName fnSTAR;
     fnSTAR = fn + ".xmd";
 
-    XMIPP_TRY
-
     mDsource.write(fnSTAR);
 
     MetaDataVec md;
@@ -336,8 +334,6 @@ TEST_F(MetadataTest, MDInfo)
     for (size_t i = 0; i < labels.size(); ++i)
         EXPECT_TRUE(mdOnlyOne.containsLabel(labels[i]));
 
-    XMIPP_CATCH
-
     unlink(fn.c_str());
     unlink(fnSTAR.c_str());
 }
@@ -350,9 +346,7 @@ TEST_F(MetadataTest, multiWrite)
 
     FileName fnSTARref = (String)"metadata/mDsource.xmd";
 
-    XMIPP_TRY
     mDsource.write((String)"myblock@"+fnSTAR);
-    XMIPP_CATCH
 
     EXPECT_TRUE(compareTwoFiles(fnSTAR, fnSTARref));
 
@@ -493,7 +487,6 @@ TEST_F(MetadataTest, CheckRegularExpression2)
 
 TEST_F(MetadataTest, compareTwoMetadataFiles)
 {
-    XMIPP_TRY
     char sfn[64] = "";
     strncpy(sfn, "/tmp/testGetBlocks_XXXXXX", sizeof sfn);
     if (mkstemp(sfn)==-1)
@@ -545,7 +538,6 @@ TEST_F(MetadataTest, compareTwoMetadataFiles)
     unlink(sfn);
     unlink(sfn2);
     unlink(sfn3);
-    XMIPP_CATCH
 }
 
 TEST_F(MetadataTest, ImportObject)
@@ -601,35 +593,26 @@ TEST_F(MetadataTest, MultiQuery)
 
 TEST_F(MetadataTest, MDValueEQ)
 {
-    try
-    {
-        MetaDataVec md;
-        md.setValue(MDL_IMAGE, (String)"a", md.addObject());
-        md.setValue(MDL_IMAGE, (String)"b", md.addObject());
-        md.setValue(MDL_IMAGE, (String)"c", md.addObject());
-        md.setValue(MDL_IMAGE, (String)"a", md.addObject());
+    MetaDataVec md;
+    md.setValue(MDL_IMAGE, (String)"a", md.addObject());
+    md.setValue(MDL_IMAGE, (String)"b", md.addObject());
+    md.setValue(MDL_IMAGE, (String)"c", md.addObject());
+    md.setValue(MDL_IMAGE, (String)"a", md.addObject());
 
-        MetaDataVec md2;
-        md2.setValue(MDL_IMAGE, (String)"a", md2.addObject());
-        md2.setValue(MDL_IMAGE, (String)"a", md2.addObject());
+    MetaDataVec md2;
+    md2.setValue(MDL_IMAGE, (String)"a", md2.addObject());
+    md2.setValue(MDL_IMAGE, (String)"a", md2.addObject());
 
-        MDValueEQ eq(MDL_IMAGE,(String)"a");
+    MDValueEQ eq(MDL_IMAGE,(String)"a");
 
-        MetaDataVec md3;
-        md3.importObjects(md, eq);
+    MetaDataVec md3;
+    md3.importObjects(md, eq);
 
-        EXPECT_EQ(md2, md3);
-    }
-    catch (XmippError &xe)
-    {
-        std::cerr << "DEBUG_JM: xe: " << xe << std::endl;
-    }
+    EXPECT_EQ(md2, md3);
 }
 
 TEST_F(MetadataTest, RegularExp)
 {
-    XMIPP_TRY
-
     //create temporal file with three metadas
     //char sfnStar[64] = "";
     //char sfnSqlite[64] = "";
@@ -688,8 +671,6 @@ TEST_F(MetadataTest, RegularExp)
     unlink(fn.c_str());
     unlink(sfnStar.c_str());
     //unlink(sfnSqlite);
-
-    XMIPP_CATCH
 }
 
 TEST_F(MetadataTest, Query)
@@ -919,7 +900,6 @@ TEST_F(MetadataTest, WriteIntermediateBlock)
 
 TEST_F(MetadataTest, ReadWriteAppendBlock)
 {
-    XMIPP_TRY
     //temp file name
     char sfn[32] = "";
     strncpy(sfn, "/tmp/testWrite_XXXXXX", sizeof sfn);
@@ -932,7 +912,6 @@ TEST_F(MetadataTest, ReadWriteAppendBlock)
     FileName sfn2 = "metadata/ReadWriteAppendBlock.xmd";
     EXPECT_TRUE(compareTwoFiles(sfn,sfn2,0));
     unlink(sfn);
-    XMIPP_CATCH
 }
 
 TEST_F(MetadataTest, RemoveDuplicates)
@@ -1049,7 +1028,6 @@ TEST_F(MetadataTest, setGetValue)
 }
 TEST_F(MetadataTest, Comment)
 {
-    XMIPP_TRY
     char sfn[64] = "";
     MetaDataVec md1(mDsource);
     strncpy(sfn, "/tmp/testComment_XXXXXX", sizeof sfn);
@@ -1066,13 +1044,10 @@ TEST_F(MetadataTest, Comment)
     s2=md2.getComment();
     EXPECT_EQ(s1, s2);
     unlink(sfn);
-
-    XMIPP_CATCH
 }
 //read file with vector
 TEST_F(MetadataTest, getValue)
 {
-    XMIPP_TRY
     std::vector<double> v1(3);
     std::vector<double> v2(3);
     MetaDataVec auxMD1;
@@ -1087,12 +1062,10 @@ TEST_F(MetadataTest, getValue)
     EXPECT_EQ(v1[0],v2[0]);
     EXPECT_EQ(v1[1],v2[1]);
     EXPECT_EQ(v1[2],v2[2]);
-    XMIPP_CATCH
 }
 
 TEST_F(MetadataTest, getValueDefault)
 {
-    XMIPP_TRY
     MetaDataVec auxMD1;
     MetaDataVec auxMD2;
     double rot=1., tilt=2., psi=3.;
@@ -1119,13 +1092,10 @@ TEST_F(MetadataTest, getValueDefault)
     auxMD1.getRow(rowIn, id);
     rowIn.getValueOrDefault(MDL_ANGLE_PSI,psi2,3.);
     EXPECT_EQ(psi,psi2);
-
-    XMIPP_CATCH
 }
 
 TEST_F(MetadataTest, getValueAbort)
 {
-    XMIPP_TRY
     size_t id;
     MetaDataVec auxMD1;
     double rot=1.;
@@ -1140,13 +1110,10 @@ TEST_F(MetadataTest, getValueAbort)
     auxMD1.getRow(rowIn, id);
     std::cerr << "TEST COMMENT: You should get the error  Cannot find label: anglePsi" << std::endl;
     EXPECT_THROW(rowGetValueOrAbort(rowIn, MDL_ANGLE_PSI, rot), XmippError);
-
-    XMIPP_CATCH
 }
 
 TEST_F(MetadataTest, CopyColumn)
 {
-    XMIPP_TRY
     MetaDataVec md1(mDsource), md2(mDsource);
     double value;
 
@@ -1159,13 +1126,11 @@ TEST_F(MetadataTest, CopyColumn)
     md2.copyColumn(MDL_Z, MDL_Y);
 
     EXPECT_EQ(md1, md2);
-    XMIPP_CATCH
 }
 
 TEST_F(MetadataTest, RenameColumn)
 {
     size_t id;
-    XMIPP_TRY
     MetaDataVec md1(mDsource);
     MetaDataVec md2;
     md1.renameColumn(MDL_Y,MDL_Z);
@@ -1178,13 +1143,11 @@ TEST_F(MetadataTest, RenameColumn)
 
 
     EXPECT_EQ(md1, md2);
-    XMIPP_CATCH
 }
 
 //Copy images on metadata using ImageConvert logic
 TEST_F(MetadataTest, copyImages)
 {
-    XMIPP_TRY
     FileName fn = "metadata/smallStack.stk";
     FileName out;
     FileName oroot;
@@ -1246,7 +1209,6 @@ TEST_F(MetadataTest, copyImages)
         EXPECT_TRUE(imgStk == imgVol);
     }
     out.deleteFile();
-    XMIPP_CATCH
 }
 
 TEST_F(MetadataTest, updateRow)

--- a/src/xmipp/applications/tests/function_tests/test_multidim_main.cpp
+++ b/src/xmipp/applications/tests/function_tests/test_multidim_main.cpp
@@ -249,7 +249,6 @@ TEST( MultidimTest, modulo)
 // check the reslicing is right
 TEST( MultidimTest, getImage)
 {
-    XMIPP_TRY
     MultidimArray<float> imgTgt, imgRef;
 
     imgRef.resize(3,1,3,3);
@@ -278,14 +277,11 @@ TEST( MultidimTest, getImage)
         EXPECT_EQ(DIRECT_NZYX_ELEM(imgRef,1,k,i,j), DIRECT_NZYX_ELEM(imgTgt,3,k,i,j));
         EXPECT_EQ(DIRECT_NZYX_ELEM(imgRef,2,k,i,j), DIRECT_NZYX_ELEM(imgTgt,1,k,i,j));
     }
-
-    XMIPP_CATCH
 }
 
 // check the reslicing is right
 TEST( MultidimTest, reslice)
 {
-    XMIPP_TRY
     MultidimArray<float> imgSliced, imgRef;
 
     imgRef.resize(3,3,3);
@@ -309,14 +305,12 @@ TEST( MultidimTest, reslice)
     {
         EXPECT_EQ(DIRECT_ZYX_ELEM(imgRef,k,i,j), DIRECT_ZYX_ELEM(imgSliced,ZSIZE(imgSliced)-1-j,i,k));
     }
-    XMIPP_CATCH
 }
 
 
 
 TEST( MultidimTest, mapFile)
 {
-    XMIPP_TRY
     MultidimArray<double> mda, mdaMap;
 
     mda.resize(32,32,32);
@@ -328,13 +322,11 @@ TEST( MultidimTest, mapFile)
     mdaMap = mda;
 
     ASSERT_EQ(mda, mdaMap);
-    XMIPP_CATCH
 }
 
 // check the window2D is right
 TEST( MultidimTest, window2D)
 {
-    XMIPP_TRY
     MultidimArray<double> imgLarge, imgSmall, imgWindow;
 
     imgLarge.resize(4,4);
@@ -350,6 +342,4 @@ TEST( MultidimTest, window2D)
     imgWindow-=imgSmall;
     imgWindow.selfABS();
     EXPECT_EQ(imgWindow.sum(),0);
-
-    XMIPP_CATCH
 }

--- a/src/xmipp/applications/tests/function_tests/test_polynomials_main.cpp
+++ b/src/xmipp/applications/tests/function_tests/test_polynomials_main.cpp
@@ -20,15 +20,7 @@ protected:
         path+="/xmipp/resources/test";
         if (chdir(path.c_str()) != 0 ) FAIL() << "Could not change path to: " << path;
         imageName =  "polynomials/down1_42_Periodogramavg.psd";
-        try
-        {
-            im.read(imageName);
-        }
-        catch (XmippError &xe)
-        {
-            std::cerr << xe;
-            exit(-1);
-        }
+        im.read(imageName);
     }
     //Image to be fitted:
     Image<double> im;

--- a/src/xmipp/applications/tests/function_tests/test_resolution_frc.cpp
+++ b/src/xmipp/applications/tests/function_tests/test_resolution_frc.cpp
@@ -10,18 +10,7 @@
 // This test is named "Size", and belongs to the "MetadataTest"
 // test case.
 class ResolutionFSCTest : public ::testing::Test
-{
-protected:
-    //init metadatas
-    virtual void SetUp()
-    {
-        XMIPP_TRY
-        ;
-        XMIPP_CATCH
-    }
-
-
-};
+{};
 
 
 TEST_F( ResolutionFSCTest, copy)

--- a/src/xmipp/applications/tests/function_tests/test_sampling_main.cpp
+++ b/src/xmipp/applications/tests/function_tests/test_sampling_main.cpp
@@ -43,7 +43,6 @@ protected:
 
 TEST_F(SamplingTest, computeSamplingPoints)
 {
-    XMIPP_TRY
     Sampling s1;
     //by default no sampling points are read
     s1.readSamplingFile(fn_root + "ref");
@@ -53,12 +52,10 @@ TEST_F(SamplingTest, computeSamplingPoints)
     //s1.saveSamplingFile("/tmp/s1");
     //s2.saveSamplingFile("/tmp/s2");
     EXPECT_EQ(s1, s2);
-    XMIPP_CATCH
 }
 
 TEST_F(SamplingTest, removeRedundantPointsI3H)
 {
-    XMIPP_TRY
     int  symmetry, sym_order;
     Sampling s1;//<- check number of sampling points...
     s1.readSamplingFile(fn_root + "ref_i3h",true,false);
@@ -73,12 +70,10 @@ TEST_F(SamplingTest, removeRedundantPointsI3H)
     //s2.saveSamplingFile("/tmp/s2");
     //s1.saveSamplingFile("/tmp/s1");
     EXPECT_EQ(s1, s2);
-    XMIPP_CATCH
 }
 
 TEST_F(SamplingTest, removeRedundantPointsC1)
 {
-    XMIPP_TRY
     int  symmetry, sym_order;
     Sampling s1;
     s1.readSamplingFile(fn_root + "ref_c1");
@@ -91,12 +86,10 @@ TEST_F(SamplingTest, removeRedundantPointsC1)
     s2.removeRedundantPoints(symmetry, sym_order);
     //s2.saveSamplingFile("/tmp/removeRedundantPointsC1");
     EXPECT_EQ(s1, s2);
-    XMIPP_CATCH
 }
 
 TEST_F(SamplingTest, removePointsFarAwayFromExperimentalDataI3H)
 {
-    XMIPP_TRY
     int  symmetry, sym_order;
     Sampling s1;
     s1.readSamplingFile(fn_root + "ref_i3h_exp");
@@ -111,12 +104,10 @@ TEST_F(SamplingTest, removePointsFarAwayFromExperimentalDataI3H)
     s2.fillExpDataProjectionDirectionByLR(fn_root + "experimental_images.xmd");
     s2.removePointsFarAwayFromExperimentalData();
     EXPECT_EQ(s1, s2);
-    XMIPP_CATCH
 }
 
 TEST_F(SamplingTest, removePointsFarAwayFromExperimentalDataC1)
 {
-    XMIPP_TRY
     int  symmetry, sym_order;
     Sampling s1;
     s1.readSamplingFile(fn_root + "ref_c1_exp");
@@ -132,12 +123,10 @@ TEST_F(SamplingTest, removePointsFarAwayFromExperimentalDataC1)
     s2.removePointsFarAwayFromExperimentalData();
     //s2.saveSamplingFile("/tmp/removePointsFarAwayFromExperimentalDataC1");
     EXPECT_EQ(s1, s2);
-    XMIPP_CATCH
 }
 
 TEST_F(SamplingTest, saveReadSamplingFile)
 {
-    XMIPP_TRY
     FileName fn;
     fn.initUniqueName("/tmp/temp_XXXXXX");
     mysampling.saveSamplingFile(fn, true, true);
@@ -147,12 +136,10 @@ TEST_F(SamplingTest, saveReadSamplingFile)
     fn.deleteFile();
     fn = fn + "_sampling.xmd";
     fn.deleteFile();
-    XMIPP_CATCH
 }
 
 TEST_F(SamplingTest, computeNeighborsI3H)
 {
-    XMIPP_TRY
     int  symmetry, sym_order;
     Sampling s1;
     s1.readSamplingFile(fn_root + "neigh_ref_i3h_exp");
@@ -169,12 +156,10 @@ TEST_F(SamplingTest, computeNeighborsI3H)
     s2.computeNeighbors();
     //s2.saveSamplingFile("/tmp/computeNeighborsI3H");
     EXPECT_EQ(s1, s2);
-    XMIPP_CATCH
 }
 
 TEST_F(SamplingTest, computeNeighborsC1)
 {
-    XMIPP_TRY
     int  symmetry, sym_order;
     Sampling s1;
     s1.readSamplingFile(fn_root + "neigh_ref_c1_exp");
@@ -191,5 +176,4 @@ TEST_F(SamplingTest, computeNeighborsC1)
     s2.computeNeighbors();
     //    s2.saveSamplingFile(fn_root + "/tmp/ref_c1_computeNeighborsC1");
     EXPECT_EQ(s1, s2);
-    XMIPP_CATCH
 }

--- a/src/xmipp/applications/tests/function_tests/test_symmetries_main.cpp
+++ b/src/xmipp/applications/tests/function_tests/test_symmetries_main.cpp
@@ -30,7 +30,6 @@ protected:
 
 TEST_F(SamplingTest, isSymmetryGroup)
 {
-    XMIPP_TRY
     int symmetry, sym_order;
     FileName fn_sym("i3h");
     SL.isSymmetryGroup(fn_sym, symmetry, sym_order);
@@ -40,24 +39,19 @@ TEST_F(SamplingTest, isSymmetryGroup)
     SL.isSymmetryGroup(fn_sym, symmetry, sym_order);
     EXPECT_EQ(symmetry, pg_CN);
     EXPECT_EQ(sym_order, 5);
-
-    XMIPP_CATCH
 }
 
 TEST_F(SamplingTest, readSymmetryFile)
 {
-    XMIPP_TRY
     int trueSymsNo;
     FileName fn_sym("i3h");
     SL.readSymmetryFile(fn_sym);
     trueSymsNo = SL.trueSymsNo();//true_symNo;
     EXPECT_EQ(trueSymsNo, 119);
-    XMIPP_CATCH
 }
 
 TEST_F(SamplingTest, computeDistance)
 {
-    XMIPP_TRY
     FileName fn_sym("i3h");
     SL.readSymmetryFile(fn_sym);
     double rot2=6.;
@@ -66,12 +60,10 @@ TEST_F(SamplingTest, computeDistance)
     double total;
     total = SL.computeDistance(1., 2., 3., rot2, tilt2, psi2,false,false,false);
     EXPECT_NEAR (total, 5.23652,0.00001);
-    XMIPP_CATCH
 }
 
 TEST_F(SamplingTest, BreakSymmetry)
 {
-    XMIPP_TRY
     FileName fn_sym("i3");
     SL.readSymmetryFile(fn_sym);
     double rot2=0.;
@@ -92,13 +84,11 @@ TEST_F(SamplingTest, BreakSymmetry)
     double total = SL.computeDistance(0., 5., 0., rot2, tilt2, psi2,false,false,false);
     EXPECT_NEAR (0, total,0.001);
     }
-    XMIPP_CATCH
 }
 
 
 TEST_F(SamplingTest, computeDistanceMetadata)
 {
-    XMIPP_TRY
     FileName fn_sym("i3h");
     SL.readSymmetryFile(fn_sym);
     MetaDataVec md,mdOut;
@@ -123,5 +113,4 @@ TEST_F(SamplingTest, computeDistanceMetadata)
     size_t id = md.firstRowId();
     md.getValue(MDL_ANGLE_DIFF,total,id);
     EXPECT_NEAR (total, 5.23652,0.00001);
-    XMIPP_CATCH
 }

--- a/src/xmipp/applications/tests/function_tests/test_transform_window.cpp
+++ b/src/xmipp/applications/tests/function_tests/test_transform_window.cpp
@@ -111,15 +111,7 @@ sph  + 1.   0.000 -1.618 0.000 .10\n";
 
 
 class TransformWindowTest : public ::testing::Test
-{
-protected:
-    virtual void SetUp()
-    {
-        XMIPP_TRY
-        ;
-        XMIPP_CATCH
-    }
-};
+{};
 
 
 TEST_F( TransformWindowTest, unitcell)
@@ -143,12 +135,10 @@ TEST_F( TransformWindowTest, unitcell)
     Image<double>     vol;
     const char  inFn[] = "/tmp/inTransformWindowTest.mrc";
     const char  outFn[] ="/tmp/outTransformWindowTest.mrc";
-    XMIPP_TRY
-        phantom.read(filename);
-        phantom.draw_in(vol());
-        vol().addNoise(0,0.1,"gaussian");
-        vol.write(inFn);
-    XMIPP_CATCH
+    phantom.read(filename);
+    phantom.draw_in(vol());
+    vol().addNoise(0,0.1,"gaussian");
+    vol.write(inFn);
     //transform window is not in a library as it should be
     //so I need to make a system call
     char commandBuff[180];

--- a/src/xmipp/bindings/python/python_filename.cpp
+++ b/src/xmipp/bindings/python/python_filename.cpp
@@ -271,7 +271,7 @@ FileName_isMetaData(PyObject *obj, PyObject *args, PyObject *kwargs)
     }
     catch (XmippError &xe)
     {
-        PyErr_SetString(PyXmippError, xe.msg.c_str());
+        PyErr_SetString(PyXmippError, xe.what());
     }
     return nullptr;
 }

--- a/src/xmipp/bindings/python/python_fourierprojector.cpp
+++ b/src/xmipp/bindings/python/python_fourierprojector.cpp
@@ -89,8 +89,6 @@
  {
 
      auto *self = (FourierProjectorObject*)type->tp_alloc(type, 0);
-     XMIPP_TRY
-
      if (self != nullptr)
      {
          PyObject *image = nullptr;
@@ -110,8 +108,6 @@
 
          }
      }
-     XMIPP_CATCH
-
      return (PyObject *)self;
  }
 
@@ -141,7 +137,7 @@ PyObject * FourierProjector_projectVolume(PyObject * obj, PyObject *args, PyObje
           }
           catch (XmippError &xe)
           {
-              PyErr_SetString(PyXmippError, xe.msg.c_str());
+              PyErr_SetString(PyXmippError, xe.what());
           }
       }
       Py_RETURN_NONE;

--- a/src/xmipp/bindings/python/python_image.cpp
+++ b/src/xmipp/bindings/python/python_image.cpp
@@ -251,7 +251,7 @@ Image_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
                 }
                 catch (XmippError &xe)
                 {
-                    PyErr_SetString(PyXmippError, xe.msg.c_str());
+                    PyErr_SetString(PyXmippError, xe.what());
                     return nullptr;
                 }
             }
@@ -302,7 +302,7 @@ Image_RichCompareBool(PyObject * obj, PyObject * obj2, int opid)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -312,7 +312,6 @@ Image_RichCompareBool(PyObject * obj, PyObject * obj2, int opid)
 PyObject *
 Image_equal(PyObject *obj, PyObject *args, PyObject *kwargs)
 {
-    XMIPP_TRY
     const auto *self = reinterpret_cast<ImageObject*>(obj);
     if (self != nullptr)
     {
@@ -329,11 +328,10 @@ Image_equal(PyObject *obj, PyObject *args, PyObject *kwargs)
             }
             catch (XmippError &xe)
             {
-                PyErr_SetString(PyXmippError, xe.msg.c_str());
+                PyErr_SetString(PyXmippError, xe.what());
             }
         }
     }
-    XMIPP_CATCH
     return nullptr;
 }//function Image_equal
 
@@ -378,7 +376,7 @@ Image_write(PyObject *obj, PyObject *args, PyObject *kwargs)
             }
             catch (XmippError &xe)
             {
-                PyErr_SetString(PyXmippError, xe.msg.c_str());
+                PyErr_SetString(PyXmippError, xe.what());
             }
         }
     }
@@ -425,7 +423,7 @@ Image_read(PyObject *obj, PyObject *args, PyObject *kwargs)
             }
             catch (XmippError &xe)
             {
-                PyErr_SetString(PyXmippError, xe.msg.c_str());
+                PyErr_SetString(PyXmippError, xe.what());
             }
         }
     }
@@ -473,7 +471,7 @@ Image_readPreview(PyObject *obj, PyObject *args, PyObject *kwargs)
             }
             catch (XmippError &xe)
             {
-                PyErr_SetString(PyXmippError, xe.msg.c_str());
+                PyErr_SetString(PyXmippError, xe.what());
             }
         }
         else
@@ -511,7 +509,7 @@ Image_readPreviewSmooth(PyObject *obj, PyObject *args, PyObject *kwargs)
             }
             catch (XmippError &xe)
             {
-                PyErr_SetString(PyXmippError, xe.msg.c_str());
+                PyErr_SetString(PyXmippError, xe.what());
             }
         }
     }
@@ -629,7 +627,7 @@ Image_getData(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -667,7 +665,7 @@ Image_setData(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -697,7 +695,7 @@ Image_getPixel(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -727,7 +725,7 @@ Image_setPixel(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -749,7 +747,7 @@ Image_initConstant(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -767,7 +765,7 @@ Image_mirrorY(PyObject *obj, PyObject *args, PyObject *kwargs)
     }
     catch (XmippError &xe)
     {
-        PyErr_SetString(PyXmippError, xe.msg.c_str());
+        PyErr_SetString(PyXmippError, xe.what());
     }
     return nullptr;
 }//function Image_initConstant
@@ -794,7 +792,7 @@ Image_initRandom(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -819,7 +817,7 @@ Image_resize(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -849,7 +847,7 @@ Image_scale(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -871,7 +869,7 @@ Image_reslice(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -920,7 +918,7 @@ Image_writeSlices(PyObject *obj, PyObject *args, PyObject *kwargs)
             }
             catch (XmippError &xe)
             {
-                PyErr_SetString(PyXmippError, xe.msg.c_str());
+                PyErr_SetString(PyXmippError, xe.what());
             }
         }
     }
@@ -946,7 +944,7 @@ Image_patch(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -968,7 +966,7 @@ Image_getDataType(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -990,7 +988,7 @@ Image_setDataType(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -1013,7 +1011,7 @@ Image_convert2DataType(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -1037,7 +1035,7 @@ Image_getDimensions(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -1057,7 +1055,7 @@ Image_resetOrigin(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -1081,7 +1079,7 @@ Image_getEulerAngles(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -1112,7 +1110,7 @@ Image_getMainHeaderValue(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -1141,7 +1139,7 @@ Image_setMainHeaderValue(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -1171,7 +1169,7 @@ Image_getHeaderValue(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -1199,7 +1197,7 @@ Image_setHeaderValue(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -1223,7 +1221,7 @@ Image_computeStats(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -1261,7 +1259,7 @@ Image_computePSD(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         return (PyObject *)result;
     } catch (XmippError &xe) {
-        PyErr_SetString(PyXmippError, xe.msg.c_str());
+        PyErr_SetString(PyXmippError, xe.what());
     }
     return Py_BuildValue("");
 }
@@ -1288,7 +1286,7 @@ Image_adjustAndSubtract(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return (PyObject *)result;
@@ -1323,7 +1321,7 @@ Image_correlation(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -1363,7 +1361,7 @@ Image_correlationAfterAlignment(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -1384,7 +1382,7 @@ Image_add(PyObject *obj1, PyObject *obj2)
         catch (XmippError &xe)
         {
         	result=nullptr;
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return (PyObject *)result;
@@ -1405,7 +1403,7 @@ Image_iadd(PyObject *obj1, PyObject *obj2)
     catch (XmippError &xe)
     {
     	result=nullptr;
-        PyErr_SetString(PyXmippError, xe.msg.c_str());
+        PyErr_SetString(PyXmippError, xe.what());
     }
     return (PyObject *)result;
 }//operator +=
@@ -1438,7 +1436,7 @@ Image_inplaceAdd(PyObject *self, PyObject *args, PyObject *kwargs)
     }
     catch (XmippError &xe)
     {
-        PyErr_SetString(PyXmippError, xe.msg.c_str());
+        PyErr_SetString(PyXmippError, xe.what());
     }
     return nullptr;
 }// similar to -=
@@ -1459,7 +1457,7 @@ Image_subtract(PyObject *obj1, PyObject *obj2)
         catch (XmippError &xe)
         {
             result = nullptr;
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return (PyObject *)result;
@@ -1479,7 +1477,7 @@ Image_isubtract(PyObject *obj1, PyObject *obj2)
     catch (XmippError &xe)
     {
         result = nullptr;
-        PyErr_SetString(PyXmippError, xe.msg.c_str());
+        PyErr_SetString(PyXmippError, xe.what());
     }
     return (PyObject *)result;
 }//operator -=
@@ -1505,7 +1503,7 @@ Image_inplaceSubtract(PyObject *self, PyObject *args, PyObject *kwargs)
   }
   catch (XmippError &xe)
   {
-      PyErr_SetString(PyXmippError, xe.msg.c_str());
+      PyErr_SetString(PyXmippError, xe.what());
   }
   return nullptr;
 }
@@ -1526,7 +1524,7 @@ Image_multiply(PyObject *obj1, PyObject *obj2)
         catch (XmippError &xe)
         {
             result = nullptr;
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return (PyObject *)result;
@@ -1547,7 +1545,7 @@ Image_imultiply(PyObject *obj1, PyObject *obj2)
     }
     catch (XmippError &xe)
     {
-        PyErr_SetString(PyXmippError, xe.msg.c_str());
+        PyErr_SetString(PyXmippError, xe.what());
     }
     return nullptr;
 }//operator *=
@@ -1579,7 +1577,7 @@ Image_inplaceMultiply(PyObject *self, PyObject *args, PyObject *kwargs)
   }
   catch (XmippError &xe)
   {
-      PyErr_SetString(PyXmippError, xe.msg.c_str());
+      PyErr_SetString(PyXmippError, xe.what());
   }
   return nullptr;
 }// similar to *=
@@ -1601,7 +1599,7 @@ Image_true_divide(PyObject *obj1, PyObject *obj2)
         catch (XmippError &xe)
         {
             result = nullptr;
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return (PyObject *)result;
@@ -1627,7 +1625,7 @@ Image_idivide(PyObject *obj1, PyObject *obj2)
     }
     catch (XmippError &xe)
     {
-        PyErr_SetString(PyXmippError, xe.msg.c_str());
+        PyErr_SetString(PyXmippError, xe.what());
     }
     return nullptr;
 }//operator /=
@@ -1659,7 +1657,7 @@ Image_inplaceDivide(PyObject *self, PyObject *args, PyObject *kwargs)
   }
   catch (XmippError &xe)
   {
-      PyErr_SetString(PyXmippError, xe.msg.c_str());
+      PyErr_SetString(PyXmippError, xe.what());
   }
   return nullptr;
 
@@ -1728,7 +1726,7 @@ Image_applyTransforMatScipion(PyObject *obj, PyObject *args, PyObject *kwargs)
     }
     catch (XmippError &xe)
     {
-        PyErr_SetString(PyXmippError, xe.msg.c_str());
+        PyErr_SetString(PyXmippError, xe.what());
     }
     return nullptr;
 }//operator +=
@@ -1772,7 +1770,7 @@ Image_readApplyGeo(PyObject *obj, PyObject *args, PyObject *kwargs)
             }
             catch (XmippError &xe)
             {
-                PyErr_SetString(PyXmippError, xe.msg.c_str());
+                PyErr_SetString(PyXmippError, xe.what());
             }
         }
     }
@@ -1848,7 +1846,7 @@ Image_warpAffine(PyObject *obj, PyObject *args, PyObject *kwargs)
     }
     catch (XmippError &xe)
     {
-        PyErr_SetString(PyXmippError, xe.msg.c_str());
+        PyErr_SetString(PyXmippError, xe.what());
     }
     return nullptr;
 }
@@ -1888,7 +1886,7 @@ Image_applyGeo(PyObject *obj, PyObject *args, PyObject *kwargs)
             }
             catch (XmippError &xe)
             {
-                PyErr_SetString(PyXmippError, xe.msg.c_str());
+                PyErr_SetString(PyXmippError, xe.what());
             }
         }
     }
@@ -1929,7 +1927,7 @@ Image_window2D(PyObject *obj, PyObject *args, PyObject *kwargs)
             }
             return (PyObject *)result;
         } catch (XmippError &xe) {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -1963,7 +1961,7 @@ Image_radialAvgAxis(PyObject *obj, PyObject *args, PyObject *kwargs)
 	        }
 	        return (PyObject *)result;
 	    } catch (XmippError &xe) {
-	        PyErr_SetString(PyXmippError, xe.msg.c_str());
+	        PyErr_SetString(PyXmippError, xe.what());
 	    }
     return Py_BuildValue("");
 }
@@ -1986,7 +1984,7 @@ Image_centerOfMass(PyObject *obj)
         }
         catch (const XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;

--- a/src/xmipp/bindings/python/python_metadata.cpp
+++ b/src/xmipp/bindings/python/python_metadata.cpp
@@ -231,7 +231,7 @@ xmipp_addLabelAlias(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
 
@@ -264,7 +264,7 @@ xmipp_getNewAlias(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
 
@@ -524,7 +524,7 @@ MetaData_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
             }
             catch (XmippError &xe)
             {
-                PyErr_SetString(PyXmippError, xe.msg.c_str());
+                PyErr_SetString(PyXmippError, xe.what());
                 return nullptr;
             }
         }
@@ -547,7 +547,7 @@ int MetaData_print(PyObject *obj, FILE *fp, int flags)
     }
     catch (XmippError &xe)
     {
-        PyErr_SetString(PyXmippError, xe.msg.c_str());
+        PyErr_SetString(PyXmippError, xe.what());
         return -1;
     }
     return 0;
@@ -593,7 +593,7 @@ MetaData_RichCompareBool(PyObject * obj, PyObject * obj2, int opid)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -655,7 +655,7 @@ MetaData_read(PyObject *obj, PyObject *args, PyObject *kwargs)
             }
             catch (XmippError &xe)
             {
-                PyErr_SetString(PyXmippError, xe.msg.c_str());
+                PyErr_SetString(PyXmippError, xe.what());
                 return nullptr;
             }
         }
@@ -699,7 +699,7 @@ MetaData_readPlain(PyObject *obj, PyObject *args, PyObject *kwargs)
             }
             catch (XmippError &xe)
             {
-                PyErr_SetString(PyXmippError, xe.msg.c_str());
+                PyErr_SetString(PyXmippError, xe.what());
                 return NULL;
             }
         }
@@ -741,7 +741,7 @@ MetaData_addPlain(PyObject *obj, PyObject *args, PyObject *kwargs)
             }
             catch (XmippError &xe)
             {
-                PyErr_SetString(PyXmippError, xe.msg.c_str());
+                PyErr_SetString(PyXmippError, xe.what());
                 return NULL;
             }
         }
@@ -782,7 +782,7 @@ MetaData_readBlock(PyObject *obj, PyObject *args, PyObject *kwargs)
             }
             catch (XmippError &xe)
             {
-                PyErr_SetString(PyXmippError, xe.msg.c_str());
+                PyErr_SetString(PyXmippError, xe.what());
                 return NULL;
             }
         }
@@ -817,7 +817,7 @@ MetaData_write(PyObject *obj, PyObject *args, PyObject *kwargs)
             }
             catch (XmippError &xe)
             {
-                PyErr_SetString(PyXmippError, xe.msg.c_str());
+                PyErr_SetString(PyXmippError, xe.what());
                 return NULL;
             }
         }
@@ -851,7 +851,7 @@ MetaData_append(PyObject *obj, PyObject *args, PyObject *kwargs)
             }
             catch (XmippError &xe)
             {
-                PyErr_SetString(PyXmippError, xe.msg.c_str());
+                PyErr_SetString(PyXmippError, xe.what());
                 return nullptr;
             }
         }
@@ -890,7 +890,7 @@ MetaData_size(PyObject *obj, PyObject *args, PyObject *kwargs)
     }
     catch (XmippError &xe)
     {
-        PyErr_SetString(PyXmippError, xe.msg.c_str());
+        PyErr_SetString(PyXmippError, xe.what());
     }
     return nullptr;
 }
@@ -906,7 +906,7 @@ MetaData_getParsedLines(PyObject *obj, PyObject *args, PyObject *kwargs)
     }
     catch (XmippError &xe)
     {
-        PyErr_SetString(PyXmippError, xe.msg.c_str());
+        PyErr_SetString(PyXmippError, xe.what());
     }
     return nullptr;
 }
@@ -925,7 +925,7 @@ MetaData_isEmpty(PyObject *obj, PyObject *args, PyObject *kwargs)
     }
     catch (XmippError &xe)
     {
-        PyErr_SetString(PyXmippError, xe.msg.c_str());
+        PyErr_SetString(PyXmippError, xe.what());
     }
     return nullptr;
 }
@@ -943,7 +943,7 @@ MetaData_getColumnFormat(PyObject *obj, PyObject *args, PyObject *kwargs)
     }
     catch (XmippError &xe)
     {
-        PyErr_SetString(PyXmippError, xe.msg.c_str());
+        PyErr_SetString(PyXmippError, xe.what());
     }
     return nullptr;
 }
@@ -968,7 +968,7 @@ MetaData_setColumnFormat(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -995,7 +995,7 @@ MetaData_setValue(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -1023,7 +1023,7 @@ MetaData_setRow(PyObject *obj, PyObject *args, PyObject *)
         }
         catch (const XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -1049,7 +1049,7 @@ MetaData_setValueCol(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -1072,7 +1072,7 @@ MetaData_removeLabel(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -1104,7 +1104,7 @@ MetaData_getValue(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -1127,7 +1127,7 @@ MetaData_getRow(PyObject *obj, PyObject *args, PyObject *)
         }
         catch (const XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -1158,7 +1158,7 @@ MetaData_getColumnValues(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -1201,7 +1201,7 @@ MetaData_setColumnValues(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
             return nullptr;
         }
     }
@@ -1227,7 +1227,7 @@ MetaData_getActiveLabels(PyObject *obj, PyObject *args, PyObject *kwargs)
     }
     catch (XmippError &xe)
     {
-        PyErr_SetString(PyXmippError, xe.msg.c_str());
+        PyErr_SetString(PyXmippError, xe.what());
     }
     return nullptr;
 }
@@ -1266,7 +1266,7 @@ xmipp_getBlocksInMetaDataFile(PyObject *obj, PyObject *args)
     }
     catch (XmippError &xe)
     {
-        PyErr_SetString(PyXmippError, xe.msg.c_str());
+        PyErr_SetString(PyXmippError, xe.what());
     }
     return NULL;
 }
@@ -1287,7 +1287,7 @@ MetaData_getMaxStringLength(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -1310,7 +1310,7 @@ MetaData_containsLabel(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -1332,7 +1332,7 @@ MetaData_addLabel(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -1350,7 +1350,7 @@ MetaData_addItemId(PyObject *obj, PyObject *args, PyObject *kwargs)
     }
     catch (XmippError &xe)
     {
-        PyErr_SetString(PyXmippError, xe.msg.c_str());
+        PyErr_SetString(PyXmippError, xe.what());
     }
     return nullptr;
 }
@@ -1380,7 +1380,7 @@ MetaData_fillConstant(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -1402,7 +1402,7 @@ MetaData_fillExpand(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -1437,7 +1437,7 @@ MetaData_fillRandom(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -1459,7 +1459,7 @@ MetaData_copyColumn(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -1513,7 +1513,7 @@ MetaData_renameColumn(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -1545,7 +1545,7 @@ MetaData_removeObjects(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -1563,7 +1563,7 @@ MetaData_removeDisabled(PyObject *obj, PyObject *args, PyObject *kwargs)
     }
     catch (XmippError &xe)
     {
-        PyErr_SetString(PyXmippError, xe.msg.c_str());
+        PyErr_SetString(PyXmippError, xe.what());
     }
     return nullptr;
 }
@@ -1583,7 +1583,7 @@ MetaData_makeAbsPath(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -1601,7 +1601,7 @@ MetaData_clear(PyObject *obj, PyObject *args, PyObject *kwargs)
     }
     catch (XmippError &xe)
     {
-        PyErr_SetString(PyXmippError, xe.msg.c_str());
+        PyErr_SetString(PyXmippError, xe.what());
         return nullptr;
     }
 }
@@ -1621,7 +1621,7 @@ MetaData_iter(PyObject *obj)
     }
     catch (XmippError &xe)
     {
-        PyErr_SetString(PyXmippError, xe.msg.c_str());
+        PyErr_SetString(PyXmippError, xe.what());
     }
     return nullptr;
 }
@@ -1640,7 +1640,7 @@ MetaData_iternext(PyObject *obj)
     }
     catch (XmippError &xe)
     {
-        PyErr_SetString(PyXmippError, xe.msg.c_str());
+        PyErr_SetString(PyXmippError, xe.what());
     }
     return nullptr;
 }
@@ -1667,7 +1667,7 @@ MetaData_sort(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -1691,7 +1691,7 @@ MetaData_removeDuplicates(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -1727,7 +1727,7 @@ MetaData_importObjects(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -1753,7 +1753,7 @@ MetaData_aggregateSingle(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -1779,7 +1779,7 @@ MetaData_aggregateSingleInt(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -1815,7 +1815,7 @@ MetaData_aggregate(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -1875,7 +1875,7 @@ MetaData_aggregateMdGroupBy(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -1903,7 +1903,7 @@ MetaData_unionAll(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -1931,7 +1931,7 @@ MetaData_merge(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -1952,7 +1952,7 @@ MetaData_setComment(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -1981,7 +1981,7 @@ MetaData_addIndex(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -2020,7 +2020,7 @@ MetaData_join1(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -2061,7 +2061,7 @@ MetaData_join2(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -2097,7 +2097,7 @@ MetaData_joinNatural(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -2126,7 +2126,7 @@ MetaData_intersection(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -2149,7 +2149,7 @@ MetaData_operate(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     // free(str);
@@ -2175,7 +2175,7 @@ MetaData_replace(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     //free(oldStr);
@@ -2205,7 +2205,7 @@ MetaData_randomize(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -2236,7 +2236,7 @@ MetaData_selectPart(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -2300,7 +2300,7 @@ createMDObject(int label, PyObject *pyValue)
     }
     catch (XmippError &xe)
     {
-        PyErr_SetString(PyXmippError, xe.msg.c_str());
+        PyErr_SetString(PyXmippError, xe.what());
     }
     return nullptr;
 }
@@ -2324,7 +2324,7 @@ MetaData_copyColumnTo(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -2373,7 +2373,7 @@ void setMDObjectValue(MDObject *obj, PyObject *pyValue)
     }
     catch (XmippError &xe)
     {
-        PyErr_SetString(PyXmippError, xe.msg.c_str());
+        PyErr_SetString(PyXmippError, xe.what());
     }
 }
 

--- a/src/xmipp/bindings/python/python_program.cpp
+++ b/src/xmipp/bindings/python/python_program.cpp
@@ -164,7 +164,7 @@ Program_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
             }
             catch (XmippError &xe)
             {
-                PyErr_SetString(PyXmippError, xe.msg.c_str());
+                PyErr_SetString(PyXmippError, xe.what());
             }
         }
     }
@@ -194,7 +194,7 @@ Program_addUsageLine(PyObject *obj, PyObject *args, PyObject *kwargs)
             }
             catch (XmippError &xe)
             {
-                PyErr_SetString(PyXmippError, xe.msg.c_str());
+                PyErr_SetString(PyXmippError, xe.what());
             }
         }
     }
@@ -224,7 +224,7 @@ Program_addExampleLine(PyObject *obj, PyObject *args, PyObject *kwargs)
             }
             catch (XmippError &xe)
             {
-                PyErr_SetString(PyXmippError, xe.msg.c_str());
+                PyErr_SetString(PyXmippError, xe.what());
             }
         }
     }
@@ -248,7 +248,7 @@ Program_addParamsLine(PyObject *obj, PyObject *args, PyObject *kwargs)
             }
             catch (XmippError &xe)
             {
-                PyErr_SetString(PyXmippError, xe.msg.c_str());
+                PyErr_SetString(PyXmippError, xe.what());
             }
         }
     }
@@ -272,7 +272,7 @@ Program_usage(PyObject *obj, PyObject *args, PyObject *kwargs)
             }
             catch (XmippError &xe)
             {
-                PyErr_SetString(PyXmippError, xe.msg.c_str());
+                PyErr_SetString(PyXmippError, xe.what());
             }
         }
     }
@@ -293,7 +293,7 @@ Program_endDefinition(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -368,7 +368,7 @@ Program_checkParam(PyObject *obj, PyObject *args, PyObject *kwargs)
             }
             catch (XmippError &xe)
             {
-                PyErr_SetString(PyXmippError, xe.msg.c_str());
+                PyErr_SetString(PyXmippError, xe.what());
             }
         }
     }
@@ -393,7 +393,7 @@ Program_getParam(PyObject *obj, PyObject *args, PyObject *kwargs)
             }
             catch (XmippError &xe)
             {
-                PyErr_SetString(PyXmippError, xe.msg.c_str());
+                PyErr_SetString(PyXmippError, xe.what());
             }
         }
     }
@@ -423,7 +423,7 @@ Program_getListParam(PyObject *obj, PyObject *args, PyObject *kwargs)
             }
             catch (XmippError &xe)
             {
-                PyErr_SetString(PyXmippError, xe.msg.c_str());
+                PyErr_SetString(PyXmippError, xe.what());
             }
         }
     }

--- a/src/xmipp/bindings/python/python_symmetry.cpp
+++ b/src/xmipp/bindings/python/python_symmetry.cpp
@@ -68,7 +68,7 @@ SymList_readSymmetryFile(PyObject * obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -129,7 +129,7 @@ SymList_getSymmetryMatrices(PyObject * obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -172,7 +172,7 @@ SymList_computeDistance(PyObject * obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -215,7 +215,7 @@ SymList_computeDistanceAngles(PyObject * obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -267,7 +267,7 @@ SymList_symmetricAngles(PyObject * obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;

--- a/src/xmipp/bindings/python/xmippmodule.cpp
+++ b/src/xmipp/bindings/python/xmippmodule.cpp
@@ -215,7 +215,7 @@ xmipp_createEmptyFile(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
      catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -243,7 +243,7 @@ xmipp_getImageSize(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -301,7 +301,7 @@ PyObject * xmipp_MetaDataInfo(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -332,7 +332,7 @@ xmipp_existsBlockInMetaDataFile(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
             return nullptr;
         }
     }
@@ -360,7 +360,7 @@ xmipp_CheckImageFileSize(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -386,7 +386,7 @@ xmipp_CheckImageCorners(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -417,7 +417,7 @@ xmipp_ImgCompare(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -448,7 +448,7 @@ xmipp_compareTwoFiles(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -476,7 +476,7 @@ xmipp_bsoftRemoveLoopBlock(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -504,7 +504,7 @@ xmipp_bsoftRestoreLoopBlock(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -555,7 +555,7 @@ xmipp_compareTwoImageTolerance(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -597,7 +597,7 @@ xmipp_readMetaDataWithTwoPossibleImages(PyObject *obj, PyObject *args,
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -654,7 +654,7 @@ xmipp_substituteOriginalImages(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -718,7 +718,7 @@ xmipp_compareTwoMetadataFiles(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -745,7 +745,7 @@ data.resetOrigin();\
 MULTIDIM_ARRAY_GENERIC(Image_Value(pyImage)).setImage(data);\
 Py_RETURN_NONE;\
 }} catch (XmippError &xe)\
-{ PyErr_SetString(PyXmippError, xe.msg.c_str());}\
+{ PyErr_SetString(PyXmippError, xe.what());}\
 
 
 /* dump metadatas to database*/
@@ -858,7 +858,7 @@ xmipp_activateMathExtensions(PyObject *obj, PyObject *args, PyObject *kwargs)
     }
     catch (XmippError &xe)
     {
-        PyErr_SetString(PyXmippError, xe.msg.c_str());
+        PyErr_SetString(PyXmippError, xe.what());
     }
     return nullptr;
 }
@@ -876,7 +876,7 @@ xmipp_activateRegExtensions(PyObject *obj, PyObject *args, PyObject *kwargs)
     }
     catch (XmippError &xe)
     {
-        PyErr_SetString(PyXmippError, xe.msg.c_str());
+        PyErr_SetString(PyXmippError, xe.what());
     }
     return nullptr;
 }
@@ -909,7 +909,7 @@ xmipp_fastEstimateEnhancedPSD(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -937,7 +937,7 @@ data.resetOrigin();\
 MULTIDIM_ARRAY_GENERIC(Image_Value(pyImage)).setImage(data);\
 Py_RETURN_NONE;\
 }} catch (XmippError &xe)\
-{ PyErr_SetString(PyXmippError, xe.msg.c_str());}\
+{ PyErr_SetString(PyXmippError, xe.what());}\
 
 
 /* calculate enhanced psd and return preview
@@ -1057,7 +1057,7 @@ xmipp_errorBetween2CTFs(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -1087,7 +1087,7 @@ xmipp_errorMaxFreqCTFs(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -1120,7 +1120,7 @@ xmipp_errorMaxFreqCTFs2D(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -1147,7 +1147,7 @@ Image_convertPSD(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;
@@ -1189,7 +1189,7 @@ Image_align(PyObject *obj, PyObject *args, PyObject *kwargs)
 	}
 	catch (XmippError &xe)
 	{
-		PyErr_SetString(PyXmippError, xe.msg.c_str());
+		PyErr_SetString(PyXmippError, xe.what());
 	}
     return (PyObject *)result;
 }//function Image_align
@@ -1243,7 +1243,7 @@ Image_applyCTF(PyObject *obj, PyObject *args, PyObject *kwargs)
     }
     catch (XmippError &xe)
     {
-        PyErr_SetString(PyXmippError, xe.msg.c_str());
+        PyErr_SetString(PyXmippError, xe.what());
     }
     return nullptr;
 }
@@ -1284,7 +1284,7 @@ Image_projectVolumeDouble(PyObject *obj, PyObject *args, PyObject *kwargs)
         }
         catch (XmippError &xe)
         {
-            PyErr_SetString(PyXmippError, xe.msg.c_str());
+            PyErr_SetString(PyXmippError, xe.what());
         }
     }
     return nullptr;

--- a/src/xmipp/libraries/data/grids.h
+++ b/src/xmipp/libraries/data/grids.h
@@ -1077,7 +1077,7 @@ public:
             arrayByArray((*this)(i)(),GV(i)(),(*Vol_aux)(),op); \
             result.LV.push_back(Vol_aux); \
         } catch (XmippError XE) {\
-            std::cout << XE; \
+            std::cout << XE.what(); \
             REPORT_ERROR(ERR_GRID_SIZE,(std::string)"GridVolume::"+op+": Different shape of volume " +\
                          integerToString(i)); \
         } \
@@ -1133,7 +1133,7 @@ public:
         try { \
             arrayByArray((*this)(i)(),GV(i)(),(*this)(i)(),op); \
         } catch (XmippError XE) {\
-            std::cout << XE; \
+            std::cout << XE.what(); \
             REPORT_ERROR(ERR_GRID_SIZE,(std::string)"GridVolume::"+op+"=: Different shape of volume " +\
                          integerToString(i)); \
         } \

--- a/src/xmipp/libraries/parallel/mpi_angular_project_library.cpp
+++ b/src/xmipp/libraries/parallel/mpi_angular_project_library.cpp
@@ -238,15 +238,7 @@ public:
 
         if (rank != 0)
         {
-            try
-            {
-                inputVol.read(input_volume);
-            }
-            catch (XmippError &XE)
-            {
-                std::cout << XE;
-                error_exit("Error reading reference volume\n\n");
-            }
+            inputVol.read(input_volume);
             inputVol().setXmippOrigin();
             Xdim = XSIZE(inputVol());
             Ydim = YSIZE(inputVol());
@@ -510,7 +502,7 @@ public:
       catch (XmippError &XE)
       {
           std::cerr << "Error!" <<std::endl;
-          std::cerr << XE;
+          std::cerr << XE.what();
           MPI_Finalize();
           exit(1);
       }

--- a/src/xmipp/libraries/parallel/mpi_classify_CL2D_core_analysis.cpp
+++ b/src/xmipp/libraries/parallel/mpi_classify_CL2D_core_analysis.cpp
@@ -228,7 +228,7 @@ void ProgClassifyCL2DCore::computeStableCores()
                        coocurrence.initZeros(NthisClass,NthisClass);
                     } catch (XmippError &e)
                     {
-                       std::cerr << e << std::endl;
+                       std::cerr << e.what() << std::endl;
                        std::cerr << "There is a memory allocation error. Most likely there are too many images in this class ("
                                  << NthisClass << " images). Consider increasing the number of initial and final classes\n";
                        REPORT_ERROR(ERR_MEM_NOTENOUGH,"While computing stable class");

--- a/src/xmipp/libraries/parallel/xmipp_mpi.cpp
+++ b/src/xmipp/libraries/parallel/xmipp_mpi.cpp
@@ -268,7 +268,7 @@ int XmippMpiProgram::tryRun()
     }
     catch (XmippError &xe)
     {
-        std::cerr << xe;
+        std::cerr << xe.what();
         errorCode = xe.__errno;
         MPI_Abort(MPI_COMM_WORLD, xe.__errno);
     }

--- a/src/xmipp/libraries/reconstruction/angular_continuous_assign2.cpp
+++ b/src/xmipp/libraries/reconstruction/angular_continuous_assign2.cpp
@@ -614,7 +614,7 @@ void ProgAngularContinuousAssign2::processImage(const FileName &fnImg, const Fil
 		}
 		catch (XmippError &XE)
 		{
-			std::cerr << XE << std::endl;
+			std::cerr << XE.what() << std::endl;
 			std::cerr << "Warning: Cannot refine " << fnImg << std::endl;
 			rowOut.setValue(MDL_ENABLED,-1);
 		}

--- a/src/xmipp/libraries/reconstruction/angular_project_library.cpp
+++ b/src/xmipp/libraries/reconstruction/angular_project_library.cpp
@@ -334,15 +334,7 @@ void ProgAngularProjectLibrary::run()
     mysampling.createAsymUnitFile(output_file_root);
     //all nodes
     //If there is no reference available exit
-    try
-    {
-        inputVol.read(input_volume);
-    }
-    catch (XmippError XE)
-    {
-        std::cout << XE;
-        exit(0);
-    }
+    inputVol.read(input_volume);
     inputVol().setXmippOrigin();
     Xdim = XSIZE(inputVol());
     Ydim = YSIZE(inputVol());

--- a/src/xmipp/libraries/reconstruction/angular_sph_alignment.cpp
+++ b/src/xmipp/libraries/reconstruction/angular_sph_alignment.cpp
@@ -408,7 +408,7 @@ void ProgAngularSphAlignment::processImage(const FileName &fnImg, const FileName
 		}
 		catch (XmippError &XE)
 		{
-			std::cerr << XE << std::endl;
+			std::cerr << XE.what() << std::endl;
 			std::cerr << "Warning: Cannot refine " << fnImg << std::endl;
 			flagEnabled=-1;
 		}

--- a/src/xmipp/libraries/reconstruction/forward_zernike_images.cpp
+++ b/src/xmipp/libraries/reconstruction/forward_zernike_images.cpp
@@ -851,7 +851,7 @@ void ProgForwardZernikeImages::processImage(const FileName &fnImg, const FileNam
 		}
 		catch (XmippError &XE)
 		{
-			std::cerr << XE << std::endl;
+			std::cerr << XE.what() << std::endl;
 			std::cerr << "Warning: Cannot refine " << fnImg << std::endl;
 			flagEnabled=-1;
 		}

--- a/src/xmipp/libraries/reconstruction/forward_zernike_images_priors.cpp
+++ b/src/xmipp/libraries/reconstruction/forward_zernike_images_priors.cpp
@@ -830,7 +830,7 @@ void ProgForwardZernikeImagesPriors::processImage(const FileName &fnImg, const F
 	}
 	catch (XmippError &XE)
 	{
-		std::cerr << XE << std::endl;
+		std::cerr << XE.what() << std::endl;
 		std::cerr << "Warning: Cannot refine " << fnImg << std::endl;
 		flagEnabled = -1;
 	}

--- a/src/xmipp/libraries/reconstruction/forward_zernike_subtomos.cpp
+++ b/src/xmipp/libraries/reconstruction/forward_zernike_subtomos.cpp
@@ -575,7 +575,7 @@ void ProgForwardZernikeSubtomos::processImage(const FileName &fnImg, const FileN
 		}
 		catch (XmippError &XE)
 		{
-			std::cerr << XE << std::endl;
+			std::cerr << XE.what() << std::endl;
 			std::cerr << "Warning: Cannot refine " << fnImg << std::endl;
 			flagEnabled=-1;
 		}

--- a/src/xmipp/libraries/reconstruction/transform_adjust_image_grey_levels.cpp
+++ b/src/xmipp/libraries/reconstruction/transform_adjust_image_grey_levels.cpp
@@ -246,7 +246,7 @@ void ProgTransformImageGreyLevels::processImage(const FileName &fnImg, const Fil
 	}
 	catch (XmippError XE)
 	{
-		std::cerr << XE << std::endl;
+		std::cerr << XE.what() << std::endl;
 		std::cerr << "Warning: Cannot refine " << fnImg << std::endl;
 		rowOut.setValue(MDL_ENABLED,-1);
 	}

--- a/src/xmipp/libraries/reconstruction_adapt_cuda/angular_sph_alignment_gpu.cpp
+++ b/src/xmipp/libraries/reconstruction_adapt_cuda/angular_sph_alignment_gpu.cpp
@@ -450,7 +450,7 @@ void ProgAngularSphAlignmentGpu::processImage(const FileName &fnImg, const FileN
 		}
 		catch (XmippError &XE)
 		{
-			std::cerr << XE << std::endl;
+			std::cerr << XE.what() << std::endl;
 			std::cerr << "Warning: Cannot refine " << fnImg << std::endl;
 			flagEnabled=-1;
 		}

--- a/src/xmipp/libraries/reconstruction_adapt_cuda/reconstruct_fourier_gpu.cpp
+++ b/src/xmipp/libraries/reconstruction_adapt_cuda/reconstruct_fourier_gpu.cpp
@@ -415,8 +415,6 @@ void ProgRecFourierGPU::prepareBuffer(RecFourierWorkThread* threadParams,
 }
 
 void* ProgRecFourierGPU::threadRoutine(void* threadArgs) {
-	XMIPP_TRY // in case some method throws a xmipp exception
-
     auto* threadParams = (RecFourierWorkThread *) threadArgs;
     ProgRecFourierGPU* parent = threadParams->parent;
     std::vector<size_t> objId;
@@ -471,8 +469,6 @@ void* ProgRecFourierGPU::threadRoutine(void* threadArgs) {
     threadParams->buffer = NULL;
     threadParams->selFile = NULL;
     barrier_wait( &parent->barrier );// notify that thread finished
-
-	XMIPP_CATCH // catch possible exception
 	return NULL;
 }
 


### PR DESCRIPTION
removing XMIPP_TRY/CATCH macros (no need for them, as xmipp_error is now runtime_exception)
See also https://github.com/I2PC/xmippCore/pull/159 (dependency)