### PR TITLE
PSD Estimator: adding executable, normalization

### DIFF
--- a/src/xmipp/applications/programs/phantom_movie/phantom_movie_main.cpp
+++ b/src/xmipp/applications/programs/phantom_movie/phantom_movie_main.cpp
@@ -23,8 +23,8 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-#include <core/xmipp_program.h>
-#include <reconstruction/phantom_movie.h>
+#include "core/xmipp_program.h"
+#include "reconstruction/phantom_movie.h"
 
 class PhantomMovieProgram final : public XmippProgram
 {

--- a/src/xmipp/applications/programs/psd_estimate/psd_estimate_main.cpp
+++ b/src/xmipp/applications/programs/psd_estimate/psd_estimate_main.cpp
@@ -1,0 +1,73 @@
+/***************************************************************************
+ *
+ * Authors:     David Strelak (davidstrelak@gmail.com)
+ *
+ * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ * 02111-1307  USA
+ *
+ *  All comments concerning this program package may be sent to the
+ *  e-mail address 'xmipp@cnb.csic.es'
+ ***************************************************************************/
+
+#include "core/xmipp_program.h"
+#include "core/xmipp_filename.h"
+#include "core/xmipp_image.h"
+#include "reconstruction/psd_estimator.h"
+
+class PSDEstimatorProgram final : public XmippProgram
+{
+private:
+    void defineParams() override
+    {
+        addParamsLine("-i <input_file>             : Micrograph to be analyzed");
+        addParamsLine("-o <output_file>            : PSD to be stored");
+        addParamsLine("[--overlap <o=0.4>]         : overlap of the patches");
+        addParamsLine("[--patches <x=384> <y=384>] :  size of the patches");
+        addParamsLine("[--threads <t=4>]           : for FFT");
+        addParamsLine("[--skipNormalization]       : if not present, FFT will be centered, and log_10 applied");
+    }
+
+    void readParams() override
+    {
+        mIn = getParam("-i");
+        mOut = getParam("-o");
+        mOverlap = getFloatParam("--overlap");
+        auto x = getIntParam("--patches", 0);
+        auto y = getIntParam("--patches", 1);
+        mDims = Dimensions(x, y);
+        mThreads = getIntParam("--threads");
+        mNormalize = !checkParam("--skipNormalization");
+    }
+
+    void run()
+    {
+        auto micrograph = Image<float>();
+        auto PSD = Image<float>();
+        micrograph.read(mIn);
+        PSDEstimator<float>::estimatePSD(micrograph(), mOverlap, mDims, PSD(), mThreads, mNormalize);
+        PSD.write(mOut);
+    }
+
+    unsigned mThreads;
+    Dimensions mDims = Dimensions(0);
+    float mOverlap;
+    FileName mIn;
+    FileName mOut;
+    bool mNormalize;
+};
+
+RUN_XMIPP_PROGRAM(PSDEstimatorProgram)

--- a/src/xmipp/bindings/python/python_image.cpp
+++ b/src/xmipp/bindings/python/python_image.cpp
@@ -1255,7 +1255,7 @@ Image_computePSD(PyObject *obj, PyObject *args, PyObject *kwargs)
             MultidimArray<double> *out;
             MULTIDIM_ARRAY_GENERIC(*result->image).getMultidimArrayPointer(out);
             // call the estimation
-            PSDEstimator<double>::estimatePSD(*in, overlap, dims, *out, threads);
+            PSDEstimator<double>::estimatePSD(*in, overlap, dims, *out, threads, false);
         } else {
             PyErr_SetString(PyXmippError, "Unknown error while allocating data for output or parsing data");
         }

--- a/src/xmipp/libraries/reconstruction/psd_estimator.cpp
+++ b/src/xmipp/libraries/reconstruction/psd_estimator.cpp
@@ -24,6 +24,11 @@
  ***************************************************************************/
 
 #include "psd_estimator.h"
+#include "data/dimensions.h"
+#include "data/rectangle.h"
+#include "reconstruction/ctf_estimate_from_micrograph.h"
+#include "fftwT.h"
+#include "core/histogram.h"
 
 template<typename T>
 std::vector<Rectangle<Point2D<size_t>>> PSDEstimator<T>::getPatchesLocation(
@@ -67,7 +72,7 @@ std::vector<Rectangle<Point2D<size_t>>> PSDEstimator<T>::getPatchesLocation(
 template<typename T>
 void PSDEstimator<T>::estimatePSD(const MultidimArray<T> &micrograph,
         float overlap, const Dimensions &patchDim, MultidimArray<T> &psd,
-        unsigned fftThreads) {
+        unsigned fftThreads, bool normalize) {
     using transformer = FFTwT<T>;
     // get patch positions
     auto patches = getPatchesLocation({0, 0},
@@ -78,12 +83,8 @@ void PSDEstimator<T>::estimatePSD(const MultidimArray<T> &micrograph,
     auto settings = FFTSettings<T>(patchDim);
 
     // prepare data for FT - set proper sizes and allocate aligned dat for faster execution
-    // XXX HACK
-    MultidimArray<T> patchData;
-    patchData.destroyData = false;
-    patchData.setDimensions(patchDim.x(), patchDim.y(), 1, 1);
-    patchData.nzyxdimAlloc = patchData.nzyxdim;
-    patchData.data = (T*)transformer::allocateAligned(settings.sBytesSingle());
+    auto *data = reinterpret_cast<T*>(transformer::allocateAligned(settings.sBytesSingle()));
+    auto patchData = MultidimArray<T>(1, 1, patchDim.y(), patchDim.x(), data);
 
     MultidimArray<T> smoother;
     ProgCTFEstimateFromMicrograph::constructPieceSmoother(patchData, smoother);
@@ -118,10 +119,31 @@ void PSDEstimator<T>::estimatePSD(const MultidimArray<T> &micrograph,
     psd.resizeNoCopy(patchData);
     half2whole(magnitudes, psd.data, settings, [&](bool mirror, T val){return val;});
 
+    if (normalize) {
+        auto min_val = std::numeric_limits<T>::max();
+        FOR_ALL_ELEMENTS_IN_ARRAY2D(psd)
+        {
+            auto pixval=A2D_ELEM(psd,i,j);
+            if (pixval > 0 && pixval < min_val)
+                min_val = pixval;
+        }
+        min_val = 10 * log10(min_val);
+        FOR_ALL_ELEMENTS_IN_ARRAY2D(psd)
+        {
+            auto pixval=A2D_ELEM(psd,i,j);
+            if (pixval > 0)
+                A2D_ELEM(psd,i,j) = 10 * log10(pixval);
+            else
+                A2D_ELEM(psd,i,j) = min_val;
+        }
+        reject_outliers(psd);
+    }
+
     delete[] magnitudes;
     transformer::release(patchFS);
     transformer::release(plan);
-    transformer::release(patchData.data);
+    transformer::release(data);
+
 }
 
 // explicit instantiation

--- a/src/xmipp/libraries/reconstruction/psd_estimator.h
+++ b/src/xmipp/libraries/reconstruction/psd_estimator.h
@@ -27,11 +27,11 @@
 #define LIBRARIES_RECONSTRUCTION_PSD_ESTIMATOR_H_
 
 #include "core/multidim_array.h"
-#include "data/dimensions.h"
-#include "data/rectangle.h"
-#include "reconstruction/ctf_estimate_from_micrograph.h"
-#include "fftwT.h"
 #include "data/fft_settings.h"
+#include "data/rectangle.h"
+
+class Dimensions;
+
 
 /**@defgroup PSDEstimator PSD Estimator
    @ingroup ReconsLibrary */
@@ -47,7 +47,7 @@ public:
 
     static void estimatePSD(const MultidimArray<T> &micrograph,
             float overlap, const Dimensions &tileDim, MultidimArray<T> &psd,
-            unsigned fftThreads);
+            unsigned fftThreads, bool normalize);
 
     template<typename F>
     static void half2whole(const T *in,


### PR DESCRIPTION
adding normalization (default for binary, skipped for Python to preserve backward compatibility)

See also https://github.com/I2PC/xmippCore/pull/160