### PR TITLE
Fixed memory pinning issue

### DIFF
--- a/src/xmipp/libraries/reconstruction_cuda/cuda_rot_polar_estimator.cpp
+++ b/src/xmipp/libraries/reconstruction_cuda/cuda_rot_polar_estimator.cpp
@@ -377,11 +377,14 @@ void CudaRotPolarEstimator<T>::computeRotation2DOneToN(T *others) {
     if ( ! isReady) {
         REPORT_ERROR(ERR_LOGIC_ERROR, "Not ready to execute. Call init() and load reference");
     }
-    if ( ! GPU::isMemoryPinned(others)) {
-        REPORT_ERROR(ERR_LOGIC_ERROR, "Input memory has to be pinned (page-locked)");
-    }
-    if (s.allowDataOverwrite && ( ! m_mainStream->isGpuPointer(others))) {
-        REPORT_ERROR(ERR_LOGIC_ERROR, "Incompatible parameters: allowDataOverwrite && 'others' data on host");
+    const auto isGpuPtr = m_mainStream->isGpuPointer(others);
+    if(!isGpuPtr) {
+        if ( ! GPU::isMemoryPinned(others)) {
+            REPORT_ERROR(ERR_LOGIC_ERROR, "Input memory has to be pinned (page-locked)");
+        }
+        if (s.allowDataOverwrite) {
+            REPORT_ERROR(ERR_LOGIC_ERROR, "Incompatible parameters: allowDataOverwrite && 'others' data on host");
+        }
     }
 
     m_mainStream->set();

--- a/src/xmipp/libraries/reconstruction_cuda/cuda_shift_corr_estimator.cpp
+++ b/src/xmipp/libraries/reconstruction_cuda/cuda_shift_corr_estimator.cpp
@@ -286,11 +286,14 @@ void CudaShiftCorrEstimator<T>::computeShift2DOneToN(
     if ( ! isReady) {
         REPORT_ERROR(ERR_LOGIC_ERROR, "Not ready to execute. Call init() before");
     }
-    if ( ! GPU::isMemoryPinned(others)) {
-        REPORT_ERROR(ERR_LOGIC_ERROR, "Input memory has to be pinned (page-locked)");
-    }
-    if (this->m_allowDataOverwrite && ( ! m_workStream->isGpuPointer(others))) {
-        REPORT_ERROR(ERR_LOGIC_ERROR, "Incompatible parameters: allowDataOverwrite && 'others' data on host");
+    const auto isGpuPtr = m_workStream->isGpuPointer(others);
+    if(!isGpuPtr) {
+        if ( ! GPU::isMemoryPinned(others)) {
+            REPORT_ERROR(ERR_LOGIC_ERROR, "Input memory has to be pinned (page-locked)");
+        }
+        if (this->m_allowDataOverwrite) {
+            REPORT_ERROR(ERR_LOGIC_ERROR, "Incompatible parameters: allowDataOverwrite && 'others' data on host");
+        }
     }
 
     m_workStream->set();


### PR DESCRIPTION
The issue was related to memory being on device memory. Added a if statement to skip memory pinning check when the pointer is on device memory. 

In the following lines, device memory check is performed once again. Therefore, the second check was grouped with the former one.