### PR TITLE
fix issue 709 empty metadata union - CHANGE PREVIOUS BEHAVIOUR

### DIFF
--- a/src/xmipp/libraries/reconstruction/metadata_utilities.cpp
+++ b/src/xmipp/libraries/reconstruction/metadata_utilities.cpp
@@ -221,24 +221,14 @@ protected:
 
         if (operation == "union")
         {
-            std::cout << "mdIn.size() " << mdIn.size() << std::endl;
-            std::cout << "md2.size() " << md2.size() << std::endl;
-            std::cout << "label " << label << std::endl;
-            std::cout << "label2 " << label2 << std::endl;
             if(mdIn.isEmpty())
-            {
-                std::cout << "METADATA IS EMPTY!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" << std::endl;
                 mdIn = md2;
-            }
             else
                 mdIn.unionDistinct(md2, label);
         }
         else if (operation == "union_all")
             if(mdIn.isEmpty())
-            {
-                std::cout << "METADATA IS EMPTY!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" << std::endl;
                 mdIn = md2;
-            }
             else
                 mdIn.unionAll(md2);
         else if (operation == "intersection")

--- a/src/xmipp/libraries/reconstruction/metadata_utilities.cpp
+++ b/src/xmipp/libraries/reconstruction/metadata_utilities.cpp
@@ -220,7 +220,12 @@ protected:
         MDLabel label2 = MDL::str2Label(getParam("--set", 3));
 
         if (operation == "union")
-            mdIn.unionDistinct(md2, label);
+        {
+            if(mdIn.isEmpty())
+                mdIn = md2;
+            else
+                mdIn.unionDistinct(md2, label);
+        }
         else if (operation == "union_all")
             mdIn.unionAll(md2);
         else if (operation == "intersection")

--- a/src/xmipp/libraries/reconstruction/metadata_utilities.cpp
+++ b/src/xmipp/libraries/reconstruction/metadata_utilities.cpp
@@ -540,7 +540,7 @@ public:
     {
         if (checkParam("--set"))
             doSet();
-        else if (mdIn.size()==0)
+        else if (mdIn.size()==0)  // Only set operationts allow an empty input md file
     		return;
         else if (checkParam("--operate"))
             doOperate();

--- a/src/xmipp/libraries/reconstruction/metadata_utilities.cpp
+++ b/src/xmipp/libraries/reconstruction/metadata_utilities.cpp
@@ -221,13 +221,26 @@ protected:
 
         if (operation == "union")
         {
+            std::cout << "mdIn.size() " << mdIn.size() << std::endl;
+            std::cout << "md2.size() " << md2.size() << std::endl;
+            std::cout << "label " << label << std::endl;
+            std::cout << "label2 " << label2 << std::endl;
             if(mdIn.isEmpty())
+            {
+                std::cout << "METADATA IS EMPTY!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" << std::endl;
                 mdIn = md2;
+            }
             else
                 mdIn.unionDistinct(md2, label);
         }
         else if (operation == "union_all")
-            mdIn.unionAll(md2);
+            if(mdIn.isEmpty())
+            {
+                std::cout << "METADATA IS EMPTY!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" << std::endl;
+                mdIn = md2;
+            }
+            else
+                mdIn.unionAll(md2);
         else if (operation == "intersection")
             mdIn.intersection(md2, label);
         else if (operation == "subtraction")
@@ -535,10 +548,10 @@ protected:
 public:
     void run()
     {
-    	if (mdIn.size()==0)
-    		return;
         if (checkParam("--set"))
             doSet();
+        else if (mdIn.size()==0)
+    		return;
         else if (checkParam("--operate"))
             doOperate();
         else if (checkParam("--file"))


### PR DESCRIPTION
This PR fixes issue #709 

**IMPORTANT!!! This PR changes the previous behavior of the code. Now join operations with an empty set will return a new empty set (previously no output file was generated).** 