### PR TITLE
Improvements for xmipp_matrix_dimred

### DIFF
--- a/src/xmipp/libraries/dimred/matrix_dimred.cpp
+++ b/src/xmipp/libraries/dimred/matrix_dimred.cpp
@@ -177,6 +177,10 @@ void ProgMatrixDimRed::readParams()
 	ProgDimRed::readParams();
     inputDim  = getIntParam("--din");
     Nsamples  = getIntParam("--samples");
+
+    if (outputDim != -1 && outputDim > inputDim)
+        throw std::invalid_argument("Error, output dimension should be smaller or equal to input dimension");
+
 }
 
 void ProgMatrixDimRed::show()
@@ -194,7 +198,8 @@ void ProgMatrixDimRed::show()
 void ProgMatrixDimRed::defineParams()
 {
 	addUsageLine("This program takes an input matrix, whose rows are individual observations and ");
-	addUsageLine("projects each sample onto a lower dimensional space using the selected method");
+	addUsageLine("projects each sample onto a lower dimensional space using the selected method. Note: ");
+    addUsageLine("that each observation component in a row should be separated by white spaces.");
 	setDefaultComment("-i","Input matrix with data. Each observation is a row.");
 	setDefaultComment("-o","Output matrix with projected data");
 	ProgDimRed::defineParams();


### PR DESCRIPTION
- Program help improved to detail the kin of input file format needed to execute properly the code
- Exception is now thrown when the number of output dimensions is larger than the input dimensions

The modifications try to solve the possible errors of #683.