### PR TITLE
Refactor readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,137 +1,75 @@
 [![Build Status](https://github.com/I2PC/xmipp/actions/workflows/main.yml/badge.svg)](https://github.com/I2PC/xmipp/actions/workflows/main.yml)
 
 # Xmipp
-<a href="https://github.com/I2PC/xmipp"><img src="https://github.com/I2PC/scipion-em-xmipp/blob/devel/xmipp3/xmipp_logo_original.png" alt="drawing" width="330" align="left"></a>
+<a href="https://github.com/I2PC/xmipp"><img src="https://github.com/I2PC/scipion-em-xmipp/blob/devel/xmipp3/xmipp_logo_original.png" alt="drawing" width="320" align="left"></a>
 
 
   
-Welcome to Xmipp. 
 Xmipp is a suite of image processing programs, primarily aimed at single-particle 3D electron microscopy, designed and managed by the [Biocomputing Unit](http://biocomputingunit.es/) located in Madrid, Spain.
 
 The Xmipp project is divided into four repositories. 
 This is the main repository, which contains the majority of the source code for the programs, additional scripts, and tests. Three remaining repositories, [XmippCore](https://github.com/I2PC/xmippCore/), [XmippViz](https://github.com/I2PC/xmippViz/), and [Scipion-em-xmipp](https://github.com/I2PC/scipion-em-xmipp), are automatically downloaded during the compilation/installation process.
 
 
-
 # Getting started
-The recommended way for users (not developers) to install and use Xmipp is via the [Scipion](http://scipion.i2pc.es/) framework, where you can use Xmipp with other Cryo-EM-related software.
+The recommended way for users (not developers) to install and use Xmipp is via the [Scipion](http://scipion.i2pc.es/) framework, where you can use Xmipp with other Cryo-EM-related software. Xmipp  will be installed during Scipion installation (pay attemption on the -noXmipp flag). The Scipion installer should take care of all dependencies for you, however, you can make its life easier if you have your compiler, CUDA and HDF5 library ready and available in the standard paths. Read below for more details about these softwares requirements. Follow the official [installation guide](https://scipion-em.github.io/docs/release-3.0.0/docs/scipion-modes/how-to-install.html#installation) of Scipion for more details.
 
-Xmipp consists of multiple standalone programs written primarily in C++. For that reason, the Xmipp suite has to be compiled before its use. The compilation process is driven by the xmipp script located in this repository. 
-
-Xmipp script automatically downloads several dependencies and then creates a configuration file that contains paths and flags used during the compilation. Please refer to the [Xmipp configuration](https://github.com/I2PC/xmipp/wiki/Xmipp-configuration) guide for more info.
-
-Have a look at the Supported OS and dependencies below, before you install Xmipp as a Scipion package or as a standalone installation. You can also Link your Standalone version to Scipion later.
-
-## Supported OS
+## Installation
+### Supported OS
 We have tested Xmipp compilation on the following operating systems:
-- [Installation guide for Ubuntu 16.04](https://github.com/I2PC/xmipp/wiki/Installing-Xmipp-on-Ubuntu-16.04)
-- [Installation guide for Ubuntu 18.04](https://github.com/I2PC/xmipp/wiki/Installing-Xmipp-on-Ubuntu-18.04)
-- [Installation guide for Ubuntu 20.04](https://github.com/I2PC/xmipp/wiki/Installing-Xmipp-on-Ubuntu-20.04)
-- [Installation guide for Ubuntu 22.04](https://github.com/I2PC/xmipp/wiki/Installing-Xmipp-on-Ubuntu-22.04)
-- [Installation guide for Centos 7](https://github.com/I2PC/xmipp/wiki/Installing-Xmipp-on-CentOS-7-9.2009)
+[Ubuntu 16.04](https://github.com/I2PC/xmipp/wiki/Installing-Xmipp-on-Ubuntu-16.04), [Ubuntu 18.04](https://github.com/I2PC/xmipp/wiki/Installing-Xmipp-on-Ubuntu-18.04), [Ubuntu 20.04](https://github.com/I2PC/xmipp/wiki/Installing-Xmipp-on-Ubuntu-20.04), [Ubuntu 22.04](https://github.com/I2PC/xmipp/wiki/Installing-Xmipp-on-Ubuntu-22.04), [Centos 7](https://github.com/I2PC/xmipp/wiki/Installing-Xmipp-on-CentOS-7-9.2009). Visit the OS wiki page for more details.
 
-While compilation and execution might be possible on other systems, it might not be straightforward. If you encounter a problem, please refer to known and fixed [issues](https://github.com/I2PC/xmipp/issues?q=is%3Aissue). Let us know if something is not working!
+While compilation and execution might be possible on other systems, it might not be straightforward. If you encounter a problem, please refer to known and fixed [issues](https://github.com/I2PC/xmipp/issues?q=is%3Aissue). Let us know if something is not working.
 
-## Hardware requirements
+### Hardware requirements
 At least 2 processors are required to run Xmipp. In some virtual machine tools only one is assigned, please check that at least two processors are assigned to the virtual machine
 
-## Additional dependencies
-### Compiler
-Xmipp requires C++17 compatible compiler. We recommend either GCC or CLANG, in the newest version possible. We have good experience with GCC-8 and bad experience with GCC-7, in any case a version > 6 is required. If use GCC-11 and experience issues, [please visit this.](https://github.com/I2PC/xmipp/issues/583)
+### Software dependencies
+#### Compiler
+Xmipp requires C++17 compatible compiler. We recommend either GCC or CLANG, in the newest version possible. We have good experience with GCC-8 and bad experience with GCC-7, in any case a version > 6 is required. If use GCC-11 and experience issues, [please visit this.](https://github.com/I2PC/xmipp/issues/583). For more details about the compilation proces and installation of gcc, please visit [compiler](https://github.com/I2PC/xmipp/wiki/Compiler)
 
-We strongly recommend you to have this compiler linked to `gcc` and `g++`. Otherwise it might not be properly picked up by wrappers, such as MPI's wrapper.
-We have good experince with using `alternatives`:
-
-```
-sudo apt install gcc-8 g++-8
-sudo update-alternatives --remove-all gcc
-sudo update-alternatives --remove-all g++
-sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 50
-sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 50
-```
-
-### Cuda
-Xmipp supports Cuda 8 through 11.6. CUDA is optional but highly recommended. We recommend you to use the newest version available for your operating system, though Cuda 10.2 has the widest support among other Scipion plugins.
+#### Cuda
+Xmipp supports Cuda 8 through 11.7. CUDA is optional but highly recommended. We recommend you to use the newest version available for your operating system, though Cuda 10.2 has the widest support among other Scipion plugins. Pay attemption to the [compiler - CUDA](https://gist.github.com/ax3l/9489132) compatibility.
 To install CUDA for your operating system, follow the [official install guide](https://developer.nvidia.com/cuda-toolkit-archive).
 
-### OpenCV
+#### OpenCV
 OpenCV is used for some programs: movie_optical_alignment (with GPU support) and volume_homogenizer, however, it is not required.
 If you installed OpenCV via apt (`sudo apt install libopencv-dev`), it should be automatically picked up by the Xmipp script
 
-### HDF5
-We sometimes see issues regarding the HDF5 dependency.
-We recommend removing all hdf5 versions and install just hdf5-devel. To do that:
-```
-sudo apt remove hdf5
-sudo apt remove hdf5-devel
-pip uninstall h5py
-```
-Remove all files related to hdf5 in:
-* `_/usr/lib64/libhdf5*_`
-*  `_/usr/include/hdf5*_ `
-*  `_/usr/lib/x86_64-linux-gnu/hdf5_*`
-*  `_.../anaconda3/include/H5*.h_ `
-*  `_.../anaconda3/include/hdf5*.h_ `
-*  `_.../anaconda3/lib/libhdf5*_ `
-*  `_.../anaconda3/envs/.../libhdf5*_`
+#### HDF5
+We sometimes see issues regarding the HDF5 dependency. Please visit the [HDF5 Troubleshooting wiki](https://github.com/I2PC/xmipp/wiki/HDF5-Troubleshooting)
 
-We strongy recommend you to install it via your default package manager:
-`sudo apt-get install libhdf5-dev` 
-If you install it using other package management system (such as Conda), it might lead to compile/link time issues caused by incompatible version being fetched. Other option is to run"scipion3 installb xmippSrc" to force the xmipp install its own HDF5 into its desired directory.
+#### Full list of dependencies
 
-### Full list of dependencies
-`sudo apt install -y libfftw3-dev libopenmpi-dev libhdf5-dev python3-numpy python3-dev libtiff5-dev libsqlite3-dev default-jdk git cmake gcc-8 g++-8`
+`sudo apt install -y libfftw3-dev libopenmpi-dev libhdf5-dev python3-numpy python3-dev libtiff5-dev libsqlite3-dev default-jdk git cmake`
 
 `pip install scons numpy`
 
-# Installing Xmipp as a Scipion plugin
-This is a recommended way for end users.
-Xmipp can (and will) be installed during Scipion installation. The Scipion installer should take care of all dependencies for you, however, you can make its life easier if you have your compiler, CUDA and HDF5 library ready and available in the standard paths.
+Also a compiler will be required (`sudo apt install gcc-8 g++-8`)
 
-Follow the official [installation guide](https://scipion-em.github.io/docs/docs/scipion-modes/how-to-install.html#) of Scipion for more details.
+### Standalone installation
+Standalone installation of Xmipp is recommended for researchers and developers. This installation allows you to use Xmipp without Scipion. However, in the next section it is explained how to link it with Scipion. Xmipp script automatically downloads several dependencies and then creates a configuration file that contains paths and flags used during the compilation. Please refer to the [Xmipp configuration](https://github.com/I2PC/xmipp/wiki/Xmipp-configuration) guide for more info.
 
-
-# Standalone installation
-Standalone installation of Xmipp is recommended for researchers and developers. This installation allows you to use Xmipp without Scipion. However, in the next section it is explained how to link it with Scipion.
 Start by cloning the repository and then navigate to the right directory.
 
 `git clone https://github.com/I2PC/xmipp.git xmipp-bundle && cd xmipp-bundle`
 
-You might want to change the branch at this moment, however, the default branch is recommended, as it contains the latest and greatest.
-
-Next is to compile xmipp. There are to possibilities:
-1) Compile Xmipp by invoking the compilation script, which will take you through the rest of the process:`./xmipp` that way you will run xmipp out of Scipion.
-2) Compile Xmipp via Scipion `scipion3 run ./xmipp` that way you will can run Xmipp in Scipion (see linking step). To do that we need Scipion installed ([see Scipion installation web page](https://scipion-em.github.io/docs/docs/scipion-modes/how-to-install.html#))
-
-It is important to highlight that this step only compiles Xmipp, but it does not link to Scipion. The linking to Scipion is explained in the next section.
+You might want to change the branch at this moment, however, the default branch is recommended, as it contains the latest and greatest. Next is to compile xmipp. There are to possibilities and in both you will can run Xmipp in Scipion (see linking step)
+- Compile Xmipp by invoking the compilation script, which will take you through the rest of the process:`./xmipp` that way you will install Xmipp with the dependencies and thier versions that the enviroment you decide, or the default one.
+- Compile Xmipp via Scipion enviroment `scipion3 run ./xmipp` that way you will install Xmipp with the dependencies and their versions that Scipion decided. 
 
 Please refer to `./xmipp --help` for additional info on the compilation process and possible customizations.
 
+It is important to highlight that this step only compiles Xmipp, but it does not link to Scipion. The linking to Scipion is explained in the next section.
 
-# Linking standalone version to Scipion
+#### Linking standalone version to Scipion
 
-Once the Standalone version has been installed (see previous section), the user can link such installation to Scipion to have the posibility of use Xmipp inside and outside Scipion. Linking with Scipion requires to the repository of `scipion-em-xmipp` which can be found in the folder `src/scipion-em-xmipp`
-
-This repository contains the files that Scipion needs to execute Xmipp programs. However, it remains to link the Xmipp binaries with Scipion. To do that we need Scipion installed ([see Scipion installation web page](https://scipion-em.github.io/docs/docs/scipion-modes/how-to-install.html#)). With Scipion installed just just launch the next command to link the binaries
+Once the Standalone version has been installed, the user can link such installation to Scipion to have the posibility of use Xmipp inside Scipion. Linking with Scipion requires to the repository of `scipion-em-xmipp` which can be found in the folder `src/scipion-em-xmipp`. This repository contains the files that Scipion needs to execute Xmipp programs. However, it remains to link the Xmipp binaries with Scipion. To do that we need Scipion installed ([see Scipion installation web page](https://scipion-em.github.io/docs/docs/scipion-modes/how-to-install.html#)) and just launch the next command to link the binaries
 
 `scipion3 installp -p ~/scipion-em-xmipp --devel`
 
 where `scipion-em-xmipp` is the folder of the repository, it means `src/scipion-em-xmipp`.
-This command should work in most of the cases. However, if you do this and Scipion does not find Xmipp, you can link Scipion and Xmipp manually by editting the config file of Scipion. This file is located in `scipion/config/scipion.conf`, and it should looks like
-
-```
-[PYWORKFLOW]
-CONDA_ACTIVATION_CMD = eval "$(/home/username/opt/miniconda3/bin/conda shell.bash hook)"
-SCIPION_FONT_SIZE = 6
-
-[PLUGINS]
-EM_ROOT = software/em
-MAXIT_HOME = %(EM_ROOT)s/maxit-10.1
-XMIPP_HOME = /home/username/xmipp-bundle/build
-```
-
-The link between Scipion and Xmipp consist in the last line.
-```XMIPP_HOME = /home/username/xmipp-bundle/build```. If this line does not exist, it must be added.
+This command should work in most of the cases. However, if you do this and Scipion does not find Xmipp, please visit [Linking Xmipp to Scipion Troubleshooting](https://github.com/I2PC/xmipp/wiki/Linking-Xmipp-to-Scipion-Troubleshooting)
 
 # Using Xmipp
 Xmipp is installed in the build directory located in the same directory where the xmipp script is located. To set all necessary environment variables and paths to all Xmipp programs, you can simply 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Start by cloning the repository and then navigate to the right directory.
 
 `git clone https://github.com/I2PC/xmipp.git xmipp-bundle && cd xmipp-bundle`
 
-You might want to change the branch at this moment, however, the default branch is recommended, as it contains the latest and greatest. Next is to compile xmipp. There are to possibilities and in both you will can run Xmipp in Scipion (see linking step)
+You might want to change the branch at this moment, however, the default branch is recommended, as it contains the latest and greatest. Next is to compile xmipp. There are to possibilities and in both you will can run Xmipp in Scipion (see [linking step](https://github.com/I2PC/xmipp/edit/agm_refactoring_readme/README.md#linking-xmipp-standalone-to-scipion))
 - Compile Xmipp by invoking the compilation script, which will take you through the rest of the process:`./xmipp` that way you will install Xmipp with the dependencies and thier versions that the enviroment you decide, or the default one.
 - Compile Xmipp via Scipion enviroment `scipion3 run ./xmipp` that way you will install Xmipp with the dependencies and their versions that Scipion decided. 
 
@@ -62,7 +62,7 @@ Please refer to `./xmipp --help` for additional info on the compilation process 
 
 It is important to highlight that this step only compiles Xmipp, but it does not link to Scipion. The linking to Scipion is explained in the next section.
 
-#### Linking standalone version to Scipion
+#### Linking Xmipp standalone to Scipion
 
 Once the Standalone version has been installed, the user can link such installation to Scipion to have the posibility of use Xmipp inside Scipion. Linking with Scipion requires to the repository of `scipion-em-xmipp` which can be found in the folder `src/scipion-em-xmipp`. This repository contains the files that Scipion needs to execute Xmipp programs. However, it remains to link the Xmipp binaries with Scipion. To do that we need Scipion installed ([see Scipion installation web page](https://scipion-em.github.io/docs/docs/scipion-modes/how-to-install.html#)) and just launch the next command to link the binaries
 
@@ -71,13 +71,13 @@ Once the Standalone version has been installed, the user can link such installat
 where `scipion-em-xmipp` is the folder of the repository, it means `src/scipion-em-xmipp`.
 This command should work in most of the cases. However, if you do this and Scipion does not find Xmipp, please visit [Linking Xmipp to Scipion Troubleshooting](https://github.com/I2PC/xmipp/wiki/Linking-Xmipp-to-Scipion-Troubleshooting)
 
-# Using Xmipp
+## Using Xmipp
 Xmipp is installed in the build directory located in the same directory where the xmipp script is located. To set all necessary environment variables and paths to all Xmipp programs, you can simply 
 `source build/xmipp.bashrc`
 
 
 # That's all
 
-If you find a bug or you miss some feature, [please create an issue]([url](https://github.com/I2PC/xmipp/issues/new)) and we will have a look at it. For more details and information visit the [wikip page.](https://github.com/I2PC/xmipp/wiki)
+If you find a bug or you miss some feature, [please create an issue]([url](https://github.com/I2PC/xmipp/issues/new)) and we will have a look at it. For more details, troubleshootings and information visit the [wikip page.](https://github.com/I2PC/xmipp/wiki)
 
 If you like this project, Watch or Star it! We are also looking for new collaborators, so contact us if you’re interested

--- a/README.md
+++ b/README.md
@@ -78,6 +78,6 @@ Xmipp is installed in the build directory located in the same directory where th
 
 # That's all
 
-If you miss some feature or find a bug, please [create an issue](https://github.com/I2PC/xmipp/issues/new) and we will have a look at it. For more details, troubleshootings and information visit the [wikip page.](https://github.com/I2PC/xmipp/wiki)
+If you miss some feature or find a bug, please [create an issue](https://github.com/I2PC/xmipp/issues/new) and we will have a look at it, you can also contact us by xmipp@cnb.csic.es. For more details, troubleshootings and information visit the [wikip page.](https://github.com/I2PC/xmipp/wiki)
 
 If you like this project, Watch or Star it! We are also looking for new collaborators, so contact us if you’re interested

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is the main repository, which contains the majority of the source code for 
 # Getting started
 The recommended way for users (not developers) to install and use Xmipp is via the [Scipion](http://scipion.i2pc.es/) framework, where you can use Xmipp with other Cryo-EM-related software. Xmipp  will be installed during Scipion installation (pay attemption on the -noXmipp flag). The Scipion installer should take care of all dependencies for you, however, you can make its life easier if you have your compiler, CUDA and HDF5 library ready and available in the standard paths. Read below for more details about these softwares requirements. Follow the official [installation guide](https://scipion-em.github.io/docs/release-3.0.0/docs/scipion-modes/how-to-install.html#installation) of Scipion for more details.
 
-## Installation
+## Installation requirements
 ### Supported OS
 We have tested Xmipp compilation on the following operating systems:
 [Ubuntu 16.04](https://github.com/I2PC/xmipp/wiki/Installing-Xmipp-on-Ubuntu-16.04), [Ubuntu 18.04](https://github.com/I2PC/xmipp/wiki/Installing-Xmipp-on-Ubuntu-18.04), [Ubuntu 20.04](https://github.com/I2PC/xmipp/wiki/Installing-Xmipp-on-Ubuntu-20.04), [Ubuntu 22.04](https://github.com/I2PC/xmipp/wiki/Installing-Xmipp-on-Ubuntu-22.04), [Centos 7](https://github.com/I2PC/xmipp/wiki/Installing-Xmipp-on-CentOS-7-9.2009). Visit the OS wiki page for more details.
@@ -47,7 +47,7 @@ We sometimes see issues regarding the HDF5 dependency. Please visit the [HDF5 Tr
 
 Also a compiler will be required (`sudo apt install gcc-8 g++-8`)
 
-### Standalone installation
+## Standalone installation
 Standalone installation of Xmipp is recommended for researchers and developers. This installation allows you to use Xmipp without Scipion. However, in the next section it is explained how to link it with Scipion. Xmipp script automatically downloads several dependencies and then creates a configuration file that contains paths and flags used during the compilation. Please refer to the [Xmipp configuration](https://github.com/I2PC/xmipp/wiki/Xmipp-configuration) guide for more info.
 
 Start by cloning the repository and then navigate to the right directory.
@@ -62,7 +62,7 @@ Please refer to `./xmipp --help` for additional info on the compilation process 
 
 It is important to highlight that this step only compiles Xmipp, but it does not link to Scipion. The linking to Scipion is explained in the next section.
 
-#### Linking Xmipp standalone to Scipion
+### Linking Xmipp standalone to Scipion
 
 Once the Standalone version has been installed, the user can link such installation to Scipion to have the posibility of use Xmipp inside Scipion. Linking with Scipion requires to the repository of `scipion-em-xmipp` which can be found in the folder `src/scipion-em-xmipp`. This repository contains the files that Scipion needs to execute Xmipp programs. However, it remains to link the Xmipp binaries with Scipion. To do that we need Scipion installed ([see Scipion installation web page](https://scipion-em.github.io/docs/docs/scipion-modes/how-to-install.html#)) and just launch the next command to link the binaries
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,6 @@ Xmipp is installed in the build directory located in the same directory where th
 
 # That's all
 
-If you find a bug or you miss some feature, [please create an issue]([url](https://github.com/I2PC/xmipp/issues/new)) and we will have a look at it. For more details, troubleshootings and information visit the [wikip page.](https://github.com/I2PC/xmipp/wiki)
+If you miss some feature or find a bug, please [create an issue](https://github.com/I2PC/xmipp/issues/new) and we will have a look at it. For more details, troubleshootings and information visit the [wikip page.](https://github.com/I2PC/xmipp/wiki)
 
 If you like this project, Watch or Star it! We are also looking for new collaborators, so contact us if you’re interested

--- a/README.md
+++ b/README.md
@@ -48,17 +48,17 @@ We sometimes see issues regarding the HDF5 dependency. Please visit the [HDF5 Tr
 Also a compiler will be required (`sudo apt install gcc-8 g++-8`)
 
 ## Standalone installation
-Standalone installation of Xmipp is recommended for researchers and developers. This installation allows you to use Xmipp without Scipion. However, in the next section it is explained how to link it with Scipion. Xmipp script automatically downloads several dependencies and then creates a configuration file that contains paths and flags used during the compilation. Please refer to the [Xmipp configuration](https://github.com/I2PC/xmipp/wiki/Xmipp-configuration) guide for more info.
+Standalone installation of Xmipp is recommended for researchers and developers. This installation allows you to use Xmipp without Scipion, however, in the next section it is explained how to link it with Scipion. Xmipp script automatically downloads several dependencies and then creates a configuration file that contains paths and flags used during the compilation. Please refer to the [Xmipp configuration](https://github.com/I2PC/xmipp/wiki/Xmipp-configuration) guide for more info.
 
 Start by cloning the repository and then navigate to the right directory.
 
 `git clone https://github.com/I2PC/xmipp.git xmipp-bundle && cd xmipp-bundle`
 
-You might want to change the branch at this moment, however, the default branch is recommended, as it contains the latest and greatest. Next is to compile xmipp. There are to possibilities and in both you will can run Xmipp in Scipion (see [linking step](https://github.com/I2PC/xmipp/edit/agm_refactoring_readme/README.md#linking-xmipp-standalone-to-scipion))
+Refer to `./xmipp --help` for additional info on the compilation process and possible customizations.
+
+Next is to compile xmipp. There are to possibilities and in both you will can run Xmipp in Scipion (see [linking step](https://github.com/I2PC/xmipp/edit/agm_refactoring_readme/README.md#linking-xmipp-standalone-to-scipion))
 - Compile Xmipp by invoking the compilation script, which will take you through the rest of the process:`./xmipp` that way you will install Xmipp with the dependencies and thier versions that the enviroment you decide, or the default one.
 - Compile Xmipp via Scipion enviroment `scipion3 run ./xmipp` that way you will install Xmipp with the dependencies and their versions that Scipion decided. 
-
-Please refer to `./xmipp --help` for additional info on the compilation process and possible customizations.
 
 It is important to highlight that this step only compiles Xmipp, but it does not link to Scipion. The linking to Scipion is explained in the next section.
 


### PR DESCRIPTION
Trying to simplify the readme. Extracting details to wiki pages, simplifying the installation explanation (people just read it) and reducing the page size.
Please check for grammatical errors and any details you consider.
Easier way to read: https://github.com/I2PC/xmipp/blob/agm_refactoring_readme/README.md