### PR TITLE
Added features to xmipp_angular_distance

### DIFF
--- a/src/xmipp/libraries/reconstruction/angular_distance.cpp
+++ b/src/xmipp/libraries/reconstruction/angular_distance.cpp
@@ -677,8 +677,8 @@ void ProgAngularDistance::quat2Euler(   const double q[4],
     const auto qzqw = qz*qw;
 
     // Ensemble the matrix
-    const double    m00 = 1 - qy2 - qz2,
-                    m01 = qxqy - qzqw,
+    const double  //m00 = 1 - qy2 - qz2,
+                  //m01 = qxqy - qzqw,
                     m02 = qxqz + qyqw,
                     m10 = qxqy + qzqw,
                     m11 = 1 - qx2 - qz2,

--- a/src/xmipp/libraries/reconstruction/angular_distance.cpp
+++ b/src/xmipp/libraries/reconstruction/angular_distance.cpp
@@ -613,6 +613,10 @@ void ProgAngularDistance::computeAverageAngles( double rot1, double tilt1, doubl
                                                 double& rot, double& tilt, double& psi )
 {
     //TODO implement
+    //Euler->Quat->Euler
+    rot = (rot1 + rot2) / 2;
+    tilt = (tilt1 + tilt2) / 2;
+    psi = (psi1 + psi2) / 2;
 }
 
 void ProgAngularDistance::computeAverageShifts( double shiftX1, double shiftY1,

--- a/src/xmipp/libraries/reconstruction/angular_distance.h
+++ b/src/xmipp/libraries/reconstruction/angular_distance.h
@@ -59,6 +59,10 @@ public:
     String idLabel;
     /// Set of angular difference
     int set;
+    /// Compute angle mean
+    bool compute_average_angle;
+    /// Compute shift mean
+    bool compute_average_shift;
 public:
     // DocFile 1
     MetaDataVec DF1;
@@ -86,6 +90,14 @@ public:
 
     /** computeWeights */
     void computeWeights();
+
+    static void computeAverageAngles(double rot1, double tilt1, double psi1,
+                                     double rot2, double tilt2, double psi2,
+                                     double& rot, double& tilt, double& psi );
+
+    static void computeAverageShifts(double shiftX1, double shiftY1,
+                                     double shiftX2, double shiftY2,
+                                     double& shiftX, double& shiftY );
 };
 //@}
 #endif

--- a/src/xmipp/libraries/reconstruction/angular_distance.h
+++ b/src/xmipp/libraries/reconstruction/angular_distance.h
@@ -59,6 +59,8 @@ public:
     String idLabel;
     /// Set of angular difference
     int set;
+    /// The set of angles to be used for output
+    int ang;
     /// Compute angle mean
     bool compute_average_angle;
     /// Compute shift mean
@@ -90,6 +92,11 @@ public:
 
     /** computeWeights */
     void computeWeights();
+
+    static void euler2quat( double rot, double tilt, double psi,
+                            double q[4] );
+    static void quat2Euler( const double q[4],
+                            double& rot, double& tilt, double& psi );
 
     static void computeAverageAngles(double rot1, double tilt1, double psi1,
                                      double rot2, double tilt2, double psi2,

--- a/src/xmipp/libraries/reconstruction/angular_distance.h
+++ b/src/xmipp/libraries/reconstruction/angular_distance.h
@@ -98,6 +98,7 @@ public:
     static void computeAverageShifts(double shiftX1, double shiftY1,
                                      double shiftX2, double shiftY2,
                                      double& shiftX, double& shiftY );
+
 };
 //@}
 #endif


### PR DESCRIPTION
Added several features to `xmipp_angular_distance`:

- Angular averaging: Providing the `--compute_average_angle` flag, it replaces angles with the average of `ang1` and `ang2`. This averaging is performed in quaternion space. The original angles are written into the secondary and tertiary angles.
- Shift averaging: Similarly, `--compute_average_shift` computes the average shift of `ang1` and `ang2`. The original shifts are written to the secondary and tertiary shifts.
- Undo symmetry: Using `--ang 2` , the angular assignment of `ang2` set is used as the primary one, but applying symmetry to be as close to `ang1` as possible. `ang1` will be written to the secondary assignment. When using `--ang 1`, which is set by default, the angular assignment of `ang1` is used, with no modifications and  `ang2` is written to the secondary angular assignment. (the behavior before these changes, which remains by default).
-  Bugfix: the PSI2 column was incorrectly written