### PR TITLE
Remove SonarCloud cache and threads configuration as it is now by default

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,17 +42,6 @@ jobs:
         with:
           python-version: '3.9.15' # Version range or exact version of a Python version to use, using SemVer's version range syntax
           architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
-
-          
-      # This will try to fetch cache for current commit
-      # Since no such cache exists, it will try to bring newest restore-key one
-      # i.e. the one from latest build. See https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows#matching-a-cache-key
-      - name: Fetch cache
-        uses: actions/cache@v2.1.5
-        with:
-          path: sonarCache
-          key: ${{ runner.os }}-sonarCache-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-sonarCache-
       
       - name: Prepare Sonar scanner
         run: |

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -12,6 +12,8 @@ sonar.scm.exclusions.disabled=true
 sonar.inclusions=**/xmipp/**, **/xmippViz/**
 sonar.exclusions=**/external/**, **/programs/**, **/tests/**, **/legacy/**
 
+# see https://docs.travis-ci.com/user/reference/overview/#virtualisation-environment-vs-operating-system
+
 sonar.java.binaries=./src/xmippViz/java/build/xmipp
 sonar.java.libraries=./src/xmippViz/java/lib/*.jar
 sonar.cfamily.build-wrapper-output=bw-outputs

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -12,14 +12,6 @@ sonar.scm.exclusions.disabled=true
 sonar.inclusions=**/xmipp/**, **/xmippViz/**
 sonar.exclusions=**/external/**, **/programs/**, **/tests/**, **/legacy/**
 
-# see https://docs.travis-ci.com/user/reference/overview/#virtualisation-environment-vs-operating-system
-# see https://docs.github.com/en/github/developing-online-with-codespaces/about-billing-for-codespaces
-# to determine max no of threads
-sonar.cfamily.threads=2
-
 sonar.java.binaries=./src/xmippViz/java/build/xmipp
 sonar.java.libraries=./src/xmippViz/java/lib/*.jar
 sonar.cfamily.build-wrapper-output=bw-outputs
-
-sonar.cfamily.cache.enabled=true
-sonar.cfamily.cache.path=sonarCache


### PR DESCRIPTION
No need to configure the cache and threads anymore,
SonarCloud now has automatic analysis caching. See:
https://docs.sonarcloud.io/advanced-setup/languages/c-c-objective-c/#analysis-cache