### PR TITLE
Fixed conda environment installation

### DIFF
--- a/src/xmipp/bindings/python/envs_DLTK/xmipp_DLTK_v0.3-gpu.yml
+++ b/src/xmipp/bindings/python/envs_DLTK/xmipp_DLTK_v0.3-gpu.yml
@@ -11,3 +11,4 @@ dependencies:
   - pip
   - pip:
       - numpy==1.21
+      - h5py==2.10.0

--- a/src/xmipp/bindings/python/envs_DLTK/xmipp_DLTK_v0.3.yml
+++ b/src/xmipp/bindings/python/envs_DLTK/xmipp_DLTK_v0.3.yml
@@ -11,3 +11,4 @@ dependencies:
   - pip
   - pip:
       - numpy==1.21
+      - h5py==2.10.0

--- a/src/xmipp/bindings/python/xmipp_base.py
+++ b/src/xmipp/bindings/python/xmipp_base.py
@@ -284,8 +284,8 @@ class CondaEnvManager(object):
 
     @staticmethod
     def yieldInstallAllCmds(useGpu):
-        for env in CondaEnvManager.XMIPP_CONDA_ENVS.values():
-            yield CondaEnvManager.installEnvironCmd(env['requirements'], gpu=useGpu)
+        for name, env in CondaEnvManager.XMIPP_CONDA_ENVS.items():
+            yield CondaEnvManager.installEnvironCmd(name, env['requirements'], gpu=useGpu)
 
     @staticmethod
     def getCurInstalledDep(dependency, defaultVersion=None, environ=None):
@@ -308,7 +308,7 @@ class CondaEnvManager(object):
         return dependency+'=='+defaultVersion if defaultVersion else dependency
 
     @staticmethod
-    def installEnvironCmd(requirementsFn: str, gpu=False):
+    def installEnvironCmd(name: str, requirementsFn: str, gpu=False):
         # Consider the gpu version if requested
         if gpu:
             root, ext = os.path.splitext(requirementsFn)
@@ -317,7 +317,7 @@ class CondaEnvManager(object):
             if os.path.exists(gpuRequirementsFn):
                 requirementsFn = gpuRequirementsFn
         
-        target = os.path.basename(requirementsFn)
+        target = name + '.yml'
         commands = [] 
         commands.append('conda env create --force -f %s' % requirementsFn)
         commands.append('conda env export -f %s' % target)


### PR DESCRIPTION
Targets of the conda environments were not named properly when using the GPU version of the environment. As a consequence, some programs failed to run.