### PR TITLE
Test ProjSubtraction fix: update output

### DIFF
--- a/src/xmipp/tests/test_programs.py
+++ b/src/xmipp/tests/test_programs.py
@@ -1395,7 +1395,7 @@ class ProjSubtraction(XmippProgramTest):
     def test_case1(self):
         """Test projection subtraction"""
         self.runCase("-i input/projectionSubtraction/images.xmd  --ref input/projectionSubtraction/phantom.vol "
-                     "-o %o/output_particles --sampling 1.0 --max_resolution 3.0 "
+                     "-o %o/output_particles.xmd --sampling 1.0 --max_resolution 3.0 "
                      "--padding 2.0 --sigma 3 --limit_freq 0 --cirmaskrad -1 "
-                     "--save input/projectionSubtraction",
-                     outputs=["output_particles.mrcs"], errorthreshold=1)
+                     "--save input/projectionSubtraction --oroot %o/subtracted_part",
+                     outputs=["output_particles.xmd"], errorthreshold=1)


### PR DESCRIPTION
For this test to work it needs this PR + upload the new output file (output_particles.xmd) to /xmipp-bundle/src/xmipp/tests/data/gold/xmipp_subtract_projection_01/