### PR TITLE
Removed numerical_recipes function

### DIFF
--- a/src/xmipp/libraries/data/numerical_tools.cpp
+++ b/src/xmipp/libraries/data/numerical_tools.cpp
@@ -22,6 +22,7 @@
  *  All comments concerning this program package may be sent to the
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
+#include <vector>
 #include "numerical_tools.h"
 #include "core/matrix2d.h"
 #include "core/numerical_recipes.h"

--- a/src/xmipp/libraries/data/numerical_tools.cpp
+++ b/src/xmipp/libraries/data/numerical_tools.cpp
@@ -45,14 +45,13 @@ void powellOptimizer(Matrix1D<double> &p, int i0, int n,
                      double ftol, double &fret,
                      int &iter, const Matrix1D<double> &steps, bool show)
 {
-    double *xi = nullptr;
-
     // Adapt indexes of p
     double *pptr = p.adaptForNumericalRecipes();
     double *auxpptr = pptr + (i0 - 1);
 
     // Form direction matrix
-    ask_Tvector(xi, 1, n*n);
+    std::vector<double> buffer(n*n);
+    auto *xi= buffer.data()-1;
     for (int i = 1, ptr = 1; i <= n; i++)
         for (int j = 1; j <= n; j++, ptr++)
             xi[ptr] = (i == j) ? steps(i - 1) : 0;
@@ -61,9 +60,6 @@ void powellOptimizer(Matrix1D<double> &p, int i0, int n,
     xi -= n; // This is because NR works with matrices starting at [1,1]
     powell(auxpptr, xi, n, ftol, iter, fret, f, prm, show);
     xi += n;
-
-    // Exit
-    free_Tvector(xi, 1, n*n);
 }
 
 /* Gaussian interpolator -------------------------------------------------- */

--- a/src/xmipp/libraries/data/numerical_tools.cpp
+++ b/src/xmipp/libraries/data/numerical_tools.cpp
@@ -58,9 +58,7 @@ void powellOptimizer(Matrix1D<double> &p, int i0, int n,
             xi[ptr] = (i == j) ? steps(i - 1) : 0;
 
     // Optimize
-    xi -= n; // This is because NR works with matrices starting at [1,1]
-    powell(auxpptr, xi, n, ftol, iter, fret, f, prm, show);
-    xi += n;
+    powell(auxpptr, xi -n, n, ftol, iter, fret, f, prm, show); // xi - n because NR works with matrices starting at [1,1]
 }
 
 /* Gaussian interpolator -------------------------------------------------- */


### PR DESCRIPTION
In a PR in xmippCore, this function is going to be removed, so, it is better to remove all of its calls here too.
Anyway, it is better to declare the data types with the standard library constructors, so memory is handled by the library itself and we do not need to think about freeing it.