### PR TITLE
Removed unnecessary condition and instruction

### DIFF
--- a/src/xmipp/external/condor/Poly.cpp
+++ b/src/xmipp/external/condor/Poly.cpp
@@ -427,7 +427,6 @@ double Polynomial::operator()( Vector Point )
     {
 	printf( "Polynomial::operator()( Vector& ) : Warning -> 100 variables\n");
     }
-    if ((rbufp != rbuf) && rbufp) delete rbufp;
 
     lsize=dim;
     rbufp = (double*)malloc(lsize*sizeof(double));	// So be it ...


### PR DESCRIPTION
Looking at the logs of the last action for another [PR I posted](https://github.com/I2PC/xmipp/actions/runs/5268100166/jobs/9524293672?pr=764), I found this warning:
```c++
external/condor/Poly.cpp: In member function 'operator()':
external/condor/Poly.cpp:430:42: warning: 'operator delete' called on unallocated object 'rbuf' [-Wfree-nonheap-object]
  430 |     if ((rbufp != rbuf) && rbufp) delete rbufp;
      |                                          ^
external/condor/Poly.cpp:400:10: note: declared here
  400 |   double rbuf[100];     // That should suffice // no static here because of the 2 threads !
      |          ^
```
I took a look at the code, and, indeed, `rbufp` is declared as a pointer to the first element of the `rbuf` array in this code:
```c++
double rbuf[100];	// That should suffice // no static here because of the 2 threads !
double *rbufp = rbuf;
```
If I'm not missing anything, as `rbufp` has not been allocated in the heap, it should not be freed using neither `free` or `delete`, as it will automatically be destroyed once the function exits without additional cost, and manually deleting it can cause undefined behaviour, so I just removed that line, as that condition should never be fulfilled and thus that line of code never executed.