### PR TITLE
DLTK fixing version extension 

### DIFF
--- a/src/xmipp/bindings/python/envs_DLTK/condaVersionRestriction.md
+++ b/src/xmipp/bindings/python/envs_DLTK/condaVersionRestriction.md
@@ -1,0 +1,2 @@
+Conda >= 4.7 is required to admit *.conda packages (*.bz2 is always admited)
+https://docs.conda.io/projects/conda/en/latest/user-guide/concepts/packages.html

--- a/src/xmipp/bindings/python/envs_DLTK/xmipp_pyTorch-gpu.yml
+++ b/src/xmipp/bindings/python/envs_DLTK/xmipp_pyTorch-gpu.yml
@@ -11,8 +11,8 @@ dependencies:
   - python=3.8
   - numpy=1.23
   - mrcfile=1.4.3
-  - kornia=0.6.8
-  - starfile=0.4.11
+  - kornia=0.6.8  #The last that is provided as *.bz2 extension
+  - starfile=0.4.11 #The last that that is provided as *.bz2 extension
   - pytorch==1.11
   - pytorch-cuda=11.7
   - torchvision=0.12

--- a/src/xmipp/bindings/python/envs_DLTK/xmipp_pyTorch-gpu.yml
+++ b/src/xmipp/bindings/python/envs_DLTK/xmipp_pyTorch-gpu.yml
@@ -11,8 +11,8 @@ dependencies:
   - python=3.8
   - numpy=1.23
   - mrcfile=1.4.3
-  - kornia=0.6.12
-  - starfile=0.4.12
+  - kornia=0.6.8
+  - starfile=0.4.11
   - pytorch==1.11
   - pytorch-cuda=11.7
   - torchvision=0.12

--- a/src/xmipp/bindings/python/envs_DLTK/xmipp_pyTorch.yml
+++ b/src/xmipp/bindings/python/envs_DLTK/xmipp_pyTorch.yml
@@ -10,8 +10,8 @@ dependencies:
   - python=3.8
   - numpy=1.23
   - mrcfile=1.4.3
-  - kornia=0.6.8
-  - starfile=0.4.11
+  - kornia=0.6.8 #The last that that is provided as *.bz2 extension
+  - starfile=0.4.11 #The last that that is provided as *.bz2 extension
   - pytorch==1.11
   - torchvision=0.12
 

--- a/src/xmipp/bindings/python/envs_DLTK/xmipp_pyTorch.yml
+++ b/src/xmipp/bindings/python/envs_DLTK/xmipp_pyTorch.yml
@@ -10,8 +10,8 @@ dependencies:
   - python=3.8
   - numpy=1.23
   - mrcfile=1.4.3
-  - kornia=0.6.12
-  - starfile=0.4.12
+  - kornia=0.6.8
+  - starfile=0.4.11
   - pytorch==1.11
   - torchvision=0.12
 


### PR DESCRIPTION
Avoid *.conda packages extension (only available for conda >=4.7)