### PR TITLE
Disabled downloading components.cif

### DIFF
--- a/xmipp
+++ b/xmipp
@@ -626,7 +626,7 @@ def compile_libcifpp(Nproc):
     os.chdir(libcifppDir)
     # Installing
     fullDir = os.path.join(currDir, libcifppDir, '')
-    if runJob("cmake -S . -B build -DCMAKE_INSTALL_PREFIX=" + fullDir + " -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON",
+    if runJob("cmake -S . -B build -DCMAKE_INSTALL_PREFIX=" + fullDir + " -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DCIFPP_DOWNLOAD_CCD=OFF",
               show_output=False, show_command=False, log=log):
         log1 = []
         if runJob(f"cmake --build build -j {Nproc}", show_output=False, show_command=False, log=log1):


### PR DESCRIPTION
libcifpp is downloading a big file (+380MB) which is not used. I have disabled this option in the install script so that the installation is lighter and faster.