### PR TITLE
Fixed issue with image_convert when providing a metadata file as input

### DIFF
--- a/src/xmipp/libraries/data/xmipp_image_convert.cpp
+++ b/src/xmipp/libraries/data/xmipp_image_convert.cpp
@@ -291,7 +291,10 @@ void ProgConvImg::preProcess()
     {
         if (depth.empty())
             depth = "%"+datatype2Str(datatypeOut);
-        imIn.read(fn_in, DATA, FIRST_IMAGE, true);
+        
+        FileName first_image;
+        getInputMd()->getValue(image_label, first_image, 1);
+        imIn.read(first_image, DATA, FIRST_IMAGE, true);
         createEmptyFile(fn_out+depth, xdimOut, ydimOut, zdimOut, mdInSize, true, WRITE_OVERWRITE, swap, &imIn.image->MDMainHeader);
     }
     create_empty_stackfile = false;


### PR DESCRIPTION
Avoided reading the input as an image file when input is a metadata file. Merge first https://github.com/I2PC/xmippCore/pull/182