### PR TITLE
Upgraded CUDA toolkit in DLTK 1.0

### DIFF
--- a/src/xmipp/bindings/python/envs_DLTK/xmipp_DLTK_v1.0-gpu.yml
+++ b/src/xmipp/bindings/python/envs_DLTK/xmipp_DLTK_v1.0-gpu.yml
@@ -5,11 +5,13 @@ name: xmipp_DLTK_v1.0
 channels:
   - anaconda
   - conda-forge
+  - nvidia
   - defaults
 dependencies:
   - python=3.8
   - tensorflow-gpu=2.7
   - keras=2.7
+  - cudatoolkit=11.6
   - pip
   - pip:
       - numpy==1.23


### PR DESCRIPTION
Default was CUDA 10.2 (too old for this env's purpose), so specifying version 11.6 was needed.

**NOTE**: Nvidia drivers 450 or higher are required for this to work. It should be specified in the Wiki and in the inital checks when installing DLTK.