### PR TITLE
Removed auto updater from libcifpp

### DIFF
--- a/xmipp
+++ b/xmipp
@@ -640,7 +640,7 @@ def compile_libcifpp(Nproc):
     os.chdir(libcifppDir)
     # Installing
     fullDir = os.path.join(currDir, libcifppDir, '')
-    if runJob("cmake -S . -B build -DCMAKE_INSTALL_PREFIX=" + fullDir + " -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DCIFPP_DOWNLOAD_CCD=OFF",
+    if runJob("cmake -S . -B build -DCMAKE_INSTALL_PREFIX=" + fullDir + " -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DCIFPP_DOWNLOAD_CCD=OFF -DCIFPP_INSTALL_UPDATE_SCRIPT=OFF",
               show_output=False, show_command=False, log=log):
         log1 = []
         if runJob(f"cmake --build build -j {Nproc}", show_output=False, show_command=False, log=log1):


### PR DESCRIPTION
In Unix systems by default, libcifpp tries to install a script that auto updates every certain time the code (useless in our case since we are using a fork that does not get updates).

The problem with it is that it tries to write it in /etc/..., needed for the script to work properly, but that can create some permission issues for users who only have acces to their /home/user directory or others, but not the common /etc one.

Adding this flag, we are now skipping such updater therefore avoiding the issue.