### PR TITLE
Actions: Show compile log if compilation fails

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,4 +54,4 @@ jobs:
         env:
           CIBuild: 1
           BUILD_TESTS: True
-        run: ./xmipp noAsk || cat compileLOG.txt && false
+        run: ./xmipp noAsk || (cat compileLOG.txt && false)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,4 +54,4 @@ jobs:
         env:
           CIBuild: 1
           BUILD_TESTS: True
-        run: ./xmipp noAsk
+        run: ./xmipp noAsk || cat compileLOG.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,4 +54,4 @@ jobs:
         env:
           CIBuild: 1
           BUILD_TESTS: True
-        run: ./xmipp noAsk || cat compileLOG.txt
+        run: ./xmipp noAsk || cat compileLOG.txt && false

--- a/xmipp
+++ b/xmipp
@@ -640,7 +640,7 @@ def compile_libcifpp(Nproc):
     os.chdir(libcifppDir)
     # Installing
     fullDir = os.path.join(currDir, libcifppDir, '')
-    if runJob("cmakeee -S . -B build -DCMAKE_INSTALL_PREFIX=" + fullDir + " -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DCIFPP_DOWNLOAD_CCD=OFF",
+    if runJob("cmake -S . -B build -DCMAKE_INSTALL_PREFIX=" + fullDir + " -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DCIFPP_DOWNLOAD_CCD=OFF",
               show_output=False, show_command=False, log=log):
         log1 = []
         if runJob(f"cmake --build build -j {Nproc}", show_output=False, show_command=False, log=log1):

--- a/xmipp
+++ b/xmipp
@@ -640,7 +640,7 @@ def compile_libcifpp(Nproc):
     os.chdir(libcifppDir)
     # Installing
     fullDir = os.path.join(currDir, libcifppDir, '')
-    if runJob("cmake -S . -B build -DCMAKE_INSTALL_PREFIX=" + fullDir + " -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DCIFPP_DOWNLOAD_CCD=OFF",
+    if runJob("cmakeee -S . -B build -DCMAKE_INSTALL_PREFIX=" + fullDir + " -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DCIFPP_DOWNLOAD_CCD=OFF",
               show_output=False, show_command=False, log=log):
         log1 = []
         if runJob(f"cmake --build build -j {Nproc}", show_output=False, show_command=False, log=log1):


### PR DESCRIPTION
In the actions we cannot see what went wrong in the installation process since we cannot open the log. Let's change that.