### PR TITLE
new CUDA compability

### DIFF
--- a/scripts/config.py
+++ b/scripts/config.py
@@ -55,7 +55,7 @@ class Config:
         '11.0-11.0': vGCC[vGCC.index('9.4'):],
         '11.1-11.4': vGCC[vGCC.index('10.4'):],
         '11.5-11.8': vGCC[vGCC.index('11.2'):],
-        '12.0-12.1': vGCC[vGCC.index('12.2'):],
+        '12.0-12.2': vGCC[vGCC.index('12.2'):],
     }
     CMAKE_VERSION_REQUIRED = '3.16'
 


### PR DESCRIPTION
https://stackoverflow.com/questions/6622454/cuda-incompatible-with-my-gcc-version
Not checked, but there is no reason to avoid that 12.2  new version