### PR TITLE
Add compilation database to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ xmippEnv.json
 compileLOG.txt
 reportInstallation.tar.gz
 xmipp_version.txt
+
+# Compilation database
+compile_commands.json


### PR DESCRIPTION
Adding `compilation_database.json` to `.gitignore` so it does not appear as a committable file.