### PR TITLE
Detection of contrast inverted maps

### DIFF
--- a/src/xmipp/libraries/reconstruction/volume_from_pdb.cpp
+++ b/src/xmipp/libraries/reconstruction/volume_from_pdb.cpp
@@ -564,6 +564,8 @@ void ProgPdbConverter::run()
     {
         createProteinUsingScatteringProfiles();
     }
+    if (Vlow().sum()<0)
+    	REPORT_ERROR(ERR_NUMERICAL,"The output volume has a negative average. This could be caused by a too large voxel size.");
     if (fn_out!="")
         Vlow.write(fn_out + ".vol");
 }


### PR DESCRIPTION
Detect contrast inverted maps when converting from a PDB to a map.