### PR TITLE
Using C-style null pointer in PyObject_HEAD_INIT

### DIFF
--- a/src/xmipp/bindings/python/python_filename.cpp
+++ b/src/xmipp/bindings/python/python_filename.cpp
@@ -68,7 +68,7 @@ PyMethodDef FileName_methods[] =
 /*FileName Type */
 PyTypeObject FileNameType =
 {
-   PyObject_HEAD_INIT(nullptr)
+   PyObject_HEAD_INIT(NULL)
    "xmipp.FileName", /*tp_name*/
    sizeof(FileNameObject), /*tp_basicsize*/
    0, /*tp_itemsize*/

--- a/src/xmipp/bindings/python/python_filename.cpp
+++ b/src/xmipp/bindings/python/python_filename.cpp
@@ -68,7 +68,7 @@ PyMethodDef FileName_methods[] =
 /*FileName Type */
 PyTypeObject FileNameType =
 {
-   PyObject_HEAD_INIT(NULL)
+   PyObject_HEAD_INIT(0)
    "xmipp.FileName", /*tp_name*/
    sizeof(FileNameObject), /*tp_basicsize*/
    0, /*tp_itemsize*/

--- a/src/xmipp/bindings/python/python_fourierprojector.cpp
+++ b/src/xmipp/bindings/python/python_fourierprojector.cpp
@@ -42,7 +42,7 @@
  /*FourierProjector Type */
  PyTypeObject FourierProjectorType =
  {
-     PyObject_HEAD_INIT(NULL)
+     PyObject_HEAD_INIT(0)
      "xmipp.FourierProjector", /*tp_name*/
      sizeof(FourierProjectorObject), /*tp_basicsize*/
      0, /*tp_itemsize*/

--- a/src/xmipp/bindings/python/python_fourierprojector.cpp
+++ b/src/xmipp/bindings/python/python_fourierprojector.cpp
@@ -42,7 +42,7 @@
  /*FourierProjector Type */
  PyTypeObject FourierProjectorType =
  {
-     PyObject_HEAD_INIT(nullptr)
+     PyObject_HEAD_INIT(NULL)
      "xmipp.FourierProjector", /*tp_name*/
      sizeof(FourierProjectorObject), /*tp_basicsize*/
      0, /*tp_itemsize*/

--- a/src/xmipp/bindings/python/python_image.cpp
+++ b/src/xmipp/bindings/python/python_image.cpp
@@ -161,7 +161,7 @@ PyMethodDef Image_methods[] =
 
 /*Image Type */
 PyTypeObject ImageType = {
-                             PyObject_HEAD_INIT(nullptr)
+                             PyObject_HEAD_INIT(NULL)
                              "xmipp.Image", /*tp_name*/
                              sizeof(ImageObject), /*tp_basicsize*/
                              0, /*tp_itemsize*/

--- a/src/xmipp/bindings/python/python_image.cpp
+++ b/src/xmipp/bindings/python/python_image.cpp
@@ -161,7 +161,7 @@ PyMethodDef Image_methods[] =
 
 /*Image Type */
 PyTypeObject ImageType = {
-                             PyObject_HEAD_INIT(NULL)
+                             PyObject_HEAD_INIT(0)
                              "xmipp.Image", /*tp_name*/
                              sizeof(ImageObject), /*tp_basicsize*/
                              0, /*tp_itemsize*/

--- a/src/xmipp/bindings/python/python_metadata.cpp
+++ b/src/xmipp/bindings/python/python_metadata.cpp
@@ -445,7 +445,7 @@ PyMethodDef MetaData_methods[] =
 
 PyTypeObject MetaDataType =
     {
-        PyObject_HEAD_INIT(nullptr)
+        PyObject_HEAD_INIT(0)
         "xmipp.MetaData", /*tp_name*/
         sizeof(MetaDataObject), /*tp_basicsize*/
         0, /*tp_itemsize*/

--- a/src/xmipp/bindings/python/python_metadata.cpp
+++ b/src/xmipp/bindings/python/python_metadata.cpp
@@ -34,7 +34,7 @@
 
 PyTypeObject MDQueryType =
     {
-        PyObject_HEAD_INIT(NULL)
+        PyObject_HEAD_INIT(0)
         "xmipp.MDQuery", /*tp_name*/
         sizeof(MDQueryObject), /*tp_basicsize*/
         0, /*tp_itemsize*/

--- a/src/xmipp/bindings/python/python_metadata.cpp
+++ b/src/xmipp/bindings/python/python_metadata.cpp
@@ -34,7 +34,7 @@
 
 PyTypeObject MDQueryType =
     {
-        PyObject_HEAD_INIT(nullptr)
+        PyObject_HEAD_INIT(NULL)
         "xmipp.MDQuery", /*tp_name*/
         sizeof(MDQueryObject), /*tp_basicsize*/
         0, /*tp_itemsize*/

--- a/src/xmipp/bindings/python/python_program.cpp
+++ b/src/xmipp/bindings/python/python_program.cpp
@@ -96,7 +96,7 @@ PyMethodDef Program_methods[] =
 /*Program Type */
 PyTypeObject ProgramType =
 {
-    PyObject_HEAD_INIT(NULL)
+    PyObject_HEAD_INIT(0)
     "xmipp.Program", /*tp_name*/
     sizeof(ProgramObject), /*tp_basicsize*/
     0, /*tp_itemsize*/

--- a/src/xmipp/bindings/python/python_program.cpp
+++ b/src/xmipp/bindings/python/python_program.cpp
@@ -96,7 +96,7 @@ PyMethodDef Program_methods[] =
 /*Program Type */
 PyTypeObject ProgramType =
 {
-    PyObject_HEAD_INIT(nullptr)
+    PyObject_HEAD_INIT(NULL)
     "xmipp.Program", /*tp_name*/
     sizeof(ProgramObject), /*tp_basicsize*/
     0, /*tp_itemsize*/

--- a/src/xmipp/bindings/python/python_symmetry.cpp
+++ b/src/xmipp/bindings/python/python_symmetry.cpp
@@ -294,7 +294,7 @@ PyMethodDef SymList_methods[] =
 /*SymList Type */
 PyTypeObject SymListType =
 {
-    PyObject_HEAD_INIT(nullptr)
+    PyObject_HEAD_INIT(NULL)
     "xmipp.SymList", /*tp_name*/
     sizeof(SymListObject), /*tp_basicsize*/
     0, /*tp_itemsize*/

--- a/src/xmipp/bindings/python/python_symmetry.cpp
+++ b/src/xmipp/bindings/python/python_symmetry.cpp
@@ -294,7 +294,7 @@ PyMethodDef SymList_methods[] =
 /*SymList Type */
 PyTypeObject SymListType =
 {
-    PyObject_HEAD_INIT(NULL)
+    PyObject_HEAD_INIT(0)
     "xmipp.SymList", /*tp_name*/
     sizeof(SymListObject), /*tp_basicsize*/
     0, /*tp_itemsize*/


### PR DESCRIPTION
Preferring to use C-Style null pointer in Python binding, as this is a C API