### PR TITLE
Fix DLTK installation

### DIFF
--- a/src/xmipp/bindings/python/envs_DLTK/xmipp_pyTorch-gpu.yml
+++ b/src/xmipp/bindings/python/envs_DLTK/xmipp_pyTorch-gpu.yml
@@ -8,13 +8,11 @@ channels:
   - pytorch
   - nvidia
 dependencies:
-  - python=3.8
+  - python=3.10
   - numpy=1.23
   - mrcfile=1.4.3
   - kornia=0.6.8  #The last that is provided as *.bz2 extension
   - starfile=0.4.11 #The last that that is provided as *.bz2 extension
   - pytorch==1.13.1
   - pytorch-cuda=11.7
-  - torchvision=0.12
-
-
+  - torchvision=0.14

--- a/src/xmipp/bindings/python/envs_DLTK/xmipp_pyTorch.yml
+++ b/src/xmipp/bindings/python/envs_DLTK/xmipp_pyTorch.yml
@@ -7,12 +7,12 @@ channels:
   - conda-forge
   - pytorch
 dependencies:
-  - python=3.8
+  - python=3.10
   - numpy=1.23
   - mrcfile=1.4.3
   - kornia=0.6.8 #The last that that is provided as *.bz2 extension
   - starfile=0.4.11 #The last that that is provided as *.bz2 extension
   - pytorch==1.13.1
-  - torchvision=0.12
+  - torchvision=0.14
 
 


### PR DESCRIPTION
DLTK installation fails.

Pytorch is set to 1.13.1, but somehow no one noticed it is not compatible with python 3.7
Also not compatible with torchvision 0.12

Bumped python to 3.10 and torchvision to 0.14, after that the installer carries on