### PR TITLE
Wipe out memory ouptut in cuFFT

### DIFF
--- a/src/xmipp/libraries/reconstruction_cuda/cuda_fft.cpp
+++ b/src/xmipp/libraries/reconstruction_cuda/cuda_fft.cpp
@@ -156,6 +156,9 @@ std::complex<T>* CudaFFT<T>::fft(const T *h_in,
                 toProcess * m_settings->sBytesSingle(),
                 cudaMemcpyHostToDevice, *(cudaStream_t*)m_gpu->stream()));
 
+    	// Wipe out memory before calling transformation
+    	gpuErrchk(cudaMemset(m_d_FD, 0., m_settings->fBytesBatch()));
+
         fft(*m_plan, m_d_SD, m_d_FD);
 
         // copy data back
@@ -188,6 +191,9 @@ T* CudaFFT<T>::ifft(const std::complex<T> *h_in,
                 h_in + offset * m_settings->fDim().xyzPadded(),
                 toProcess * m_settings->fBytesSingle(),
                 cudaMemcpyHostToDevice, *(cudaStream_t*)m_gpu->stream()));
+
+    	// Wipe out memory before calling transformation
+    	gpuErrchk(cudaMemset(m_d_SD, 0., m_settings->sBytesBatch()));
 
         ifft(*m_plan, m_d_FD, m_d_SD);
 


### PR DESCRIPTION
Memory of output block is preset to zero before calling trasnformations to ensure proper outputs.

This changes are a fix for [689](https://github.com/I2PC/xmipp/issues/689).