### PR TITLE
Fix WEDGE option in FourierFilter

### DIFF
--- a/src/xmipp/libraries/data/fourier_filter.cpp
+++ b/src/xmipp/libraries/data/fourier_filter.cpp
@@ -766,6 +766,10 @@ void FourierFilter::applyMaskFourierSpace(const MultidimArray<double> &v, Multid
             }
         }
     }
+	else if (FilterShape==WEDGE) {
+		FOR_ALL_DIRECT_ELEMENTS_IN_MULTIDIMARRAY(V)
+		DIRECT_MULTIDIM_ELEM(V,n)*=DIRECT_MULTIDIM_ELEM(maskFourier,n);
+	}
     else
     {
         w.resizeNoCopy(3);


### PR DESCRIPTION
`FourierFilter` did not implement properly the logic to apply a missing wedge filter, falling on a default execution resulting in a bug.

`WEDGE` option is now properly handled as a specific case when executing `FourierFilter` with the `--fourier wedge` option.