### PR TITLE
Added support for half precision float micrographs

### DIFF
--- a/src/xmipp/libraries/data/micrograph.cpp
+++ b/src/xmipp/libraries/data/micrograph.cpp
@@ -117,6 +117,11 @@ void Micrograph::open_micrograph(const FileName &_fn_micrograph)
         result = IFloat.readMapped(fn_micrograph, FIRST_IMAGE);
         pixelDesvFilter(IFloat.data, stdevFilter);
         break;
+    case DT_HalfFloat:
+        datatype = DT_Float; // Converting
+        result = IFloat.read(fn_micrograph, DATA, FIRST_IMAGE);
+        pixelDesvFilter(IFloat.data, stdevFilter);
+        break;
     default:
         std::cerr << "Micrograph::open_micrograph: Unknown datatype "
         << datatype << std::endl;


### PR DESCRIPTION
Users reported that aligned micrographs produced by Relion 5.0 do not work with the Xmipp auto-picker