### PR TITLE
Fixing linkage to Scipion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,14 +23,12 @@
 cmake_minimum_required(VERSION 3.17)
 
 # Import functions
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
-include(fetch_cifpp)
-include(fetch_ctpl)
-include(fetch_cuFFTAdvisor)
-include(fetch_googletest)
-include(fetch_libsvm)
-include(write_bashrc)
-include(link_to_scipion)
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/fetch_cifpp.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/fetch_ctpl.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/fetch_cuFFTAdvisor.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/fetch_googletest.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/fetch_libsvm.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/write_bashrc.cmake)
 
 # Define the project
 project(
@@ -142,7 +140,7 @@ install(
   DESTINATION ./
 )
 
-# Link to scipion
+# Link to scipion. Keep last so that all other install jobs are complete
 if(XMIPP_LINK_TO_SCIPION)
   if (NOT SCIPION_SOFTWARE)
     set(SCIPION_SOFTWARE "$ENV{SCIPION_SOFTWARE}")
@@ -150,7 +148,22 @@ if(XMIPP_LINK_TO_SCIPION)
 
   if (SCIPION_SOFTWARE)
     message("Scipion software directory found at ${SCIPION_SOFTWARE}")
-    link_to_scipion(${CMAKE_INSTALL_PREFIX} ${SCIPION_SOFTWARE})
+    set(
+      SCIPION_XMIPP_LIBRARIES 
+        libcifpp${CMAKE_SHARED_LIBRARY_SUFFIX}
+        libcifpp${CMAKE_SHARED_LIBRARY_SUFFIX}.3
+        libcifpp${CMAKE_SHARED_LIBRARY_SUFFIX}.5.0.9
+        libsvm.so
+        libXmippCore${CMAKE_SHARED_LIBRARY_SUFFIX}
+        libXmipp${CMAKE_SHARED_LIBRARY_SUFFIX}
+    )
+    install(
+      CODE
+        "
+        include(\"${CMAKE_CURRENT_SOURCE_DIR}/cmake/link_to_scipion.cmake\")
+        link_to_scipion(\"${CMAKE_INSTALL_PREFIX}\" \"${SCIPION_SOFTWARE}\" \"${SCIPION_XMIPP_LIBRARIES}\")
+        "
+    )
   else()
     message("Linking to scipion was requested, but SCIPION_SOFTWARE is not set")
   endif()

--- a/cmake/link_to_scipion.cmake
+++ b/cmake/link_to_scipion.cmake
@@ -20,10 +20,16 @@
 #  e-mail address 'xmipp@cnb.csic.es'
 # ***************************************************************************
 
-function(link_to_scipion INSTALL_DIRECTORY SCIPION_SOFTWARE)
+
+function(link_to_scipion INSTALL_DIRECTORY SCIPION_SOFTWARE SCIPION_XMIPP_LIBRARIES)
 	set(SCIPION_SOFTWARE_XMIPP ${SCIPION_SOFTWARE}/em/xmipp)
+	set(XMIPP_BINDINGS_DIRECTORY ${SCIPION_SOFTWARE_XMIPP}/bindings/python)
+	set(SCIPION_BINDINGS_DIRECTORY ${SCIPION_SOFTWARE}/bindings)
+	set(XMIPP_LIB_DIRECTORY ${SCIPION_SOFTWARE_XMIPP}/lib)
+	set(SCIPION_LIB_DIRECTORY ${SCIPION_SOFTWARE}/lib)
 
 	# Link installation
+	message("Linking Xmipp installation to Scipion (${INSTALL_DIRECTORY} -> ${SCIPION_SOFTWARE_XMIPP})")
 	file(
 		CREATE_LINK
 			${INSTALL_DIRECTORY}/
@@ -33,33 +39,26 @@ function(link_to_scipion INSTALL_DIRECTORY SCIPION_SOFTWARE)
 	)
 
 	# Link python binding
-	file(GLOB PYTHON_DIR_CONTENT ${SCIPION_SOFTWARE_XMIPP}/bindings/python/*)
+	message("Linking Xmipp Python bindings to Scipion (${XMIPP_BINDINGS_DIRECTORY}/* -> ${SCIPION_BINDINGS_DIRECTORY})")
+	file(GLOB PYTHON_DIR_CONTENT ${XMIPP_BINDINGS_DIRECTORY}/*)
 	foreach(x IN LISTS PYTHON_DIR_CONTENT)
 		get_filename_component(y ${x} NAME)
 		file(
 			CREATE_LINK
 				${x}
-				${SCIPION_SOFTWARE}/bindings/${y}
+				${SCIPION_BINDINGS_DIRECTORY}/${y}
 			COPY_ON_ERROR
 			SYMBOLIC
 		)
 	endforeach()
 	
 	# Link shared libraries
-	set(
-		LIBRARIES 
-			libcifpp${CMAKE_SHARED_LIBRARY_SUFFIX}
-			libcifpp${CMAKE_SHARED_LIBRARY_SUFFIX}.3
-			libcifpp${CMAKE_SHARED_LIBRARY_SUFFIX}.3.0.9
-			libsvm.so
-			libXmippCore${CMAKE_SHARED_LIBRARY_SUFFIX}
-			libXmipp${CMAKE_SHARED_LIBRARY_SUFFIX}
-	)
-	foreach(x IN LISTS LIBRARIES)
+	message("Linking Xmipp C++ libraries to Scipion (${XMIPP_LIB_DIRECTORY}/* -> ${SCIPION_LIB_DIRECTORY})")
+	foreach(x IN LISTS SCIPION_XMIPP_LIBRARIES)
 		file(
 			CREATE_LINK
-				${SCIPION_SOFTWARE_XMIPP}/${CMAKE_INSTALL_LIBDIR}/${x}
-				${SCIPION_SOFTWARE}/lib/${x}
+				${XMIPP_LIB_DIRECTORY}/${x}
+				${SCIPION_LIB_DIRECTORY}/${x}
 			COPY_ON_ERROR
 			SYMBOLIC
 		)


### PR DESCRIPTION
When installing Xmipp for the first time, it failed to properly link Python bindings to Scipion. Re-running the installation script fixed the problem. It turns out that the script was creating the Scipion linkage in "Configure time". As a consequence, directory's contents were listed before they were created, leading to missing files in the installation. Linking to Scipion has been moved to "Install time", where it should have been in the first place. 