### PR TITLE
Fixing FRM's Python binding

### DIFF
--- a/src/xmipp/CMakeLists.txt
+++ b/src/xmipp/CMakeLists.txt
@@ -123,6 +123,10 @@ install(
 	DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/external/sh_alignment/python/
 	DESTINATION bindings/python/sh_alignment
 )
+install(
+	FILES ${CMAKE_CURRENT_SOURCE_DIR}/external/sh_alignment/swig_frm.py
+	DESTINATION bindings/python/sh_alignment
+)
 
 # Create the shared library
 add_library(Xmipp SHARED ${SOURCES})


### PR DESCRIPTION
Align volumes protocol was broken due to a missing file in the FRM's Python binding. Added missing file to the CMake script to fix the issue