### PR TITLE
Fix missing API calls

### DIFF
--- a/installer/api.py
+++ b/installer/api.py
@@ -76,7 +76,7 @@ def getOSReleaseName() -> str:
 	### This function returns the name of the current system OS release.
 
 	#### Returns:
-	- (str): OS release name.
+	- (str): OS release name. 
 	"""
 	# Initializing default release name 
 	releaseName = UNKNOWN_VALUE

--- a/installer/api.py
+++ b/installer/api.py
@@ -76,7 +76,7 @@ def getOSReleaseName() -> str:
 	### This function returns the name of the current system OS release.
 
 	#### Returns:
-	- (str): OS release name. 
+	- (str): OS release name.
 	"""
 	# Initializing default release name 
 	releaseName = UNKNOWN_VALUE

--- a/installer/api.py
+++ b/installer/api.py
@@ -59,10 +59,13 @@ def sendApiPOST(retCode: int=0):
 		url = API_URL.split("/", maxsplit=1)
 		path = f"/{url[1]}"
 		url = url[0]
-		conn = http.client.HTTPSConnection(url, context=ssl._create_unverified_context()) # Unverified context because url does not have an ssl certificate
+		conn = http.client.HTTPSConnection(url, timeout=2, context=ssl._create_unverified_context()) # Unverified context because url does not have an ssl certificate
 
 		# Send the POST request
 		conn.request("POST", path, params, headers)
+
+		# Get response from server
+		conn.getresponse()
 
 		# Close the connection
 		conn.close()

--- a/installer/main.py
+++ b/installer/main.py
@@ -54,24 +54,19 @@ def getSources(branch: str=None):
 		logger(f"Cloning {source}...", forceConsoleOutput=True)
 		retCode, output = __cloneSourceRepo(REPOSITORIES[source][0], path=SOURCES_PATH, branch=branch)
 		message = output if retCode else ''
-		handleRetCode(retCode, predefinedErrorCode=SOURCE_CLONE_ERROR, message=message)
+		handleRetCode(retCode, predefinedErrorCode=SOURCE_CLONE_ERROR, message=message, sendAPI=False)
 
-def exitXmipp(retCode: int=0, sendAPI: bool=True):
+def exitXmipp(retCode: int=0):
 	"""
 	### This function exits Xmipp with the given return code, processing it as a success or an error.
 
 	#### Params:
 	- retCode (int): Optional. Error code.
-	- sendAPI (bool): Optional. If True, API message will be sent.
 	"""
-	# Send API message
-	if sendAPI and os.path.exists(VERSION_FILE) and retCode != INTERRUPTED_ERROR:
-		sendApiPOST(retCode=retCode)
-	
 	# End execution
 	sys.exit(retCode)
 
-def handleRetCode(realRetCode: int, predefinedErrorCode: int=0, message: str=''):
+def handleRetCode(realRetCode: int, predefinedErrorCode: int=0, message: str='', sendAPI: bool=True):
 	"""
 	### This function checks the given return code and handles the appropiate actions.
 
@@ -79,11 +74,14 @@ def handleRetCode(realRetCode: int, predefinedErrorCode: int=0, message: str='')
 	- realRetCode (int): Real return code of the called function.
 	- predefinedErrorCode (int): Optional. Predefined error code for the caller code block in case of error.
 	- message (str): Optional. Message that will be displayed if there is an error th
+	- sendAPI (bool): Optional. If True, API message will be sent.
 	"""
 	if realRetCode:
 		resultCode = __getPredefinedError(realRetCode=realRetCode, desiredRetCode=predefinedErrorCode)
 		message = message if resultCode != realRetCode else ''
 		logger.logError(message, retCode=resultCode, addPortalLink=resultCode != realRetCode)
+		if sendAPI and os.path.exists(VERSION_FILE) and resultCode != INTERRUPTED_ERROR:
+			sendApiPOST(resultCode)
 		exitXmipp(retCode=resultCode)
 	else:
 		if message:

--- a/xmipp
+++ b/xmipp
@@ -34,13 +34,14 @@ from installer.constants import (MODE_ALL, MODE_COMPILE_AND_INSTALL, MODE_CONFIG
 	CMAKE_CONFIGURE_ERROR, CMAKE_COMPILE_ERROR, CMAKE_INSTALL_ERROR, PARAM_LOGIN, PARAM_SHORT,
 	PARAM_JOBS, PARAM_BRANCH, PARAM_GIT_COMMAND, PARAM_MODEL_PATH, PARAM_MODELS_DIRECTORY, PARAM_KEEP_OUTPUT,
 	PARAM_SHOW_TESTS, PARAM_TEST_NAME, PARAM_UPDATE, PARAM_OVERWRITE, BUILD_PATH, INSTALL_PATH,
-	BUILD_TYPE, SOURCES_PATH, XMIPP_SOURCES, XMIPP, LOG_FILE, CMAKE_ERROR, MODE_GET_SOURCES)
+	BUILD_TYPE, SOURCES_PATH, XMIPP_SOURCES, XMIPP, LOG_FILE, CMAKE_ERROR, MODE_GET_SOURCES, VERSION_FILE)
 from installer.utils import runStreamingJob, runJob
 from installer.parser import ModeHelpFormatter, GeneralHelpFormatter, ErrorHandlerArgumentParser, getParamNames
 from installer.config import readConfig, writeConfig
 from installer.cmake import getCMake, getCMakeVarsStr
 from installer.main import getSources, exitXmipp, handleRetCode, getSectionMessage, getSuccessMessage, getVersionMessage
 from installer.logger import logger, yellow, red, blue
+from installer.api import sendApiPOST
 
 ####################### EXECUTION MODES #######################
 def __getProjectRootDir() -> str:
@@ -294,12 +295,16 @@ def runSelectedMode(parser: ErrorHandlerArgumentParser, args: argparse.Namespace
 	else:
 		# If method was none of the above, exit with error
 		logger(red(f"Mode \"{args.mode}\" not recognized. {COMMON_USAGE_HELP_MESSAGE}"), forceConsoleOutput=True)
-		exitXmipp(retCode=1, sendAPI=False)
+		exitXmipp(retCode=1)
 	
+	# Send API message
+	if sendAPI and os.path.exists(VERSION_FILE):
+		sendApiPOST()
+
 	# Print success message for specific modes
 	if args.mode == MODE_ALL or args.mode == MODE_COMPILE_AND_INSTALL:
 		logger(getSuccessMessage(), forceConsoleOutput=True)
-	exitXmipp(sendAPI=sendAPI)
+	exitXmipp()
 	
 ####################### MAIN EXECUTION THREAD #######################
 if __name__ == "__main__":


### PR DESCRIPTION
Some API calls could not finish since the connection was closed after creating it.
We have had a new line to get the server response and then close the connection. In addition, we have added a timeout of 2 seconds on the client side. 

Finally, we have implemented the API call-sending process before printing the finished message to avoid user misunderstandings. 