### PR TITLE
Skipping empty program directories

### DIFF
--- a/src/xmipp/applications/programs/CMakeLists.txt
+++ b/src/xmipp/applications/programs/CMakeLists.txt
@@ -58,6 +58,11 @@ foreach(PROGRAM_DIRECTORY ${PROGRAM_DIRECTORIES})
 
 		file(GLOB_RECURSE PROGRAM_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/${PROGRAM_DIRECTORY}/*.cpp)	
 
+		if (NOT PROGRAM_SOURCES)
+			message(WARNING "${PROGRAM_DIRECTORY} directory is empty. Skipping program.")
+			continue()
+		endif()
+
 		add_executable(
 			${PROGRAM_NAME}
 			${PROGRAM_SOURCES}


### PR DESCRIPTION
As mentioned in https://github.com/I2PC/xmipp/issues/915, the installer crashes with empty programs. This PR checks for the program to be populated before attempting to compile. 

This empty program behavior is common when deprecating a program, as this will erase the `cpp` files but not the folder.

How to verify:

1. Create a empty directory in `src/xmipp/applications/programs`
2. Try to compile.
3. Ensure that the installer does not crash and observe a warning in the log which mentions the empty program directory.