### PR TITLE
Highres-GPU "failure when using masks" fix

### DIFF
--- a/src/xmipp/libraries/reconstruction_adapt_cuda/volume_halves_restoration_gpu.cpp
+++ b/src/xmipp/libraries/reconstruction_adapt_cuda/volume_halves_restoration_gpu.cpp
@@ -99,15 +99,6 @@ template< typename T >
 void ProgVolumeHalvesRestorationGpu<T>::readMaskParams() {
     if (checkParam("--mask")) {
         mask.readParams(this);
-        //mask.fn_mask = getParam("--mask");
-        //mask.mask_type = "binary_file";
-        //mask.type = READ_BINARY_MASK;
-
-        //if (checkParam("--center")) {
-        //    mask.x0 = getDoubleParam("--center", 0);
-        //    mask.y0 = getDoubleParam("--center", 1);
-        //    mask.z0 = getDoubleParam("--center", 2);
-        //}
     }
 }
 
@@ -139,8 +130,6 @@ void ProgVolumeHalvesRestorationGpu<T>::defineParams() {
     addParamsLine("                                : Weight function (0=mean, 1=min, 2=mean*diff");
     addParamsLine("  [--difference <N=0> <K=1.5>]  : Number of iterations of difference evaluation in real space");
     Mask::defineParams(this, INT_MASK);
-    // addParamsLine("  [--mask <binary_file>]        : Read from file and cast to binary");
-    // addParamsLine("  [--center <x0=0> <y0=0> <z0=0>]           : Mask center");
 }
 
 template< typename T >

--- a/src/xmipp/libraries/reconstruction_adapt_cuda/volume_halves_restoration_gpu.cpp
+++ b/src/xmipp/libraries/reconstruction_adapt_cuda/volume_halves_restoration_gpu.cpp
@@ -32,6 +32,7 @@ void ProgVolumeHalvesRestorationGpu<T>::readParams() {
     readFilterBankParams();
     readDifferenceParams();
     readMaskParams();
+    
 }
 
 template< typename T >
@@ -97,15 +98,16 @@ void ProgVolumeHalvesRestorationGpu<T>::readDifferenceParams() {
 template< typename T >
 void ProgVolumeHalvesRestorationGpu<T>::readMaskParams() {
     if (checkParam("--mask")) {
-        mask.fn_mask = getParam("--mask");
-        mask.mask_type = "binary_file";
-        mask.type = READ_BINARY_MASK;
+        mask.readParams(this);
+        //mask.fn_mask = getParam("--mask");
+        //mask.mask_type = "binary_file";
+        //mask.type = READ_BINARY_MASK;
 
-        if (checkParam("--center")) {
-            mask.x0 = getDoubleParam("--center", 0);
-            mask.y0 = getDoubleParam("--center", 1);
-            mask.z0 = getDoubleParam("--center", 2);
-        }
+        //if (checkParam("--center")) {
+        //    mask.x0 = getDoubleParam("--center", 0);
+        //    mask.y0 = getDoubleParam("--center", 1);
+        //    mask.z0 = getDoubleParam("--center", 2);
+        //}
     }
 }
 
@@ -136,8 +138,9 @@ void ProgVolumeHalvesRestorationGpu<T>::defineParams() {
     addParamsLine("                                        : filter overlap is between 0 (no overlap) and 1 (full overlap)");
     addParamsLine("                                : Weight function (0=mean, 1=min, 2=mean*diff");
     addParamsLine("  [--difference <N=0> <K=1.5>]  : Number of iterations of difference evaluation in real space");
-    addParamsLine("  [--mask <binary_file>]        : Read from file and cast to binary");
-    addParamsLine("  [--center <x0=0> <y0=0> <z0=0>]           : Mask center");
+    Mask::defineParams(this, INT_MASK);
+    // addParamsLine("  [--mask <binary_file>]        : Read from file and cast to binary");
+    // addParamsLine("  [--center <x0=0> <y0=0> <z0=0>]           : Mask center");
 }
 
 template< typename T >


### PR DESCRIPTION
HighRes has a problem where using GPU for processing does not work if masks are used. The problem comes from how the `--mask` parametar was handled in the program. This PR contains the changes to handle the parameter in the same fashion as the CPU version, using the Mask::defineParams and Mask::readParams functions.

After fix, it no longer fails (red box) and finishes properly with good results. Masks are visibly used in the results's slices.