### PR TITLE
Allowing re-compilation without internet

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,9 @@ option(XMIPP_SAVE_VERSIONS "Save versions.txt with dependency versions" ON)
 # Avoid installing to lib64 directory
 set(CMAKE_INSTALL_LIBDIR lib)
 
+# Do not check for updates in installation
+set(FETCHCONTENT_UPDATES_DISCONNECTED ON)
+
 # Set C++ 17
 if(NOT DEFINED CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17)


### PR DESCRIPTION
Not updating external git repositories once they have been downloaded. Using CMake variable [FETCHCONTENT_UPDATES_DISCONNECTED]( https://cmake.org/cmake/help/latest/module/FetchContent.html#variable:FETCHCONTENT_UPDATES_DISCONNECTED). This allows to re-compile xmipp without internet

