### PR TITLE
Using conda update in case conda create fails

### DIFF
--- a/src/xmipp/bindings/python/xmipp_base.py
+++ b/src/xmipp/bindings/python/xmipp_base.py
@@ -320,7 +320,7 @@ class CondaEnvManager(object):
         
         target = name + '.yml'
         commands = [] 
-        commands.append('conda env create --yes -f %s' % requirementsFn)
+        commands.append('conda env create -f %s || conda env update -f %s' % (requirementsFn, requirementsFn))
         commands.append('conda env export -f %s' % target)
         return ' && '.join(commands), target
 


### PR DESCRIPTION
Using conda update when conda create fails. In this manner, we are able to handle issue https://github.com/I2PC/xmipp/issues/925 without parsing the conda version.