### PR TITLE
Not sorting data in split

### DIFF
--- a/src/xmipp/libraries/reconstruction/metadata_split.cpp
+++ b/src/xmipp/libraries/reconstruction/metadata_split.cpp
@@ -125,7 +125,7 @@ public:
         size_t Num_images = mdPtr->size();
         size_t Num_groups = XMIPP_MIN(N, Num_images);
         if (!use_cc)
-        	mdPtr->split(Num_groups, mdVector); //Split MD in Num_groups
+        	mdPtr->split(Num_groups, mdVector, MDL_UNDEFINED); //Split MD in Num_groups
         else
         {
         	Image<double> cc;


### PR DESCRIPTION
Randomize action was undone when sorting data inside the `split` function. Passing `MDL_UNDEFINED` to avoid this