### PR TITLE
Allow build on demand

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: Build Xmipp
 
 on:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
This change will allow running build action on demand (additionally to on every Pull Request).
This will allow developers that want to use it, to test their changes without the need of creating a PR.