### PR TITLE
Update xmipp_pyTorch-gpu.yml

### DIFF
--- a/src/xmipp/bindings/python/envs_DLTK/xmipp_pyTorch-gpu.yml
+++ b/src/xmipp/bindings/python/envs_DLTK/xmipp_pyTorch-gpu.yml
@@ -1,4 +1,4 @@
-#Protocols ussing the enviroment: protocol_deepHand
+#Protocols ussing the enviroment: protocol_deepHand, protocol_classify_pca
 
 name: xmipp_pyTorch
 channels:
@@ -9,10 +9,12 @@ channels:
   - nvidia
 dependencies:
   - python=3.10
-  - numpy=1.23
   - mrcfile=1.4.3
-  - kornia=0.6.8  #The last that is provided as *.bz2 extension
-  - starfile=0.4.11 #The last that that is provided as *.bz2 extension
   - pytorch==1.13.1
-  - pytorch-cuda=11.7
   - torchvision=0.14
+  - pytorch-cuda=11.7
+  - pip  
+  - pip:
+      - numpy==1.23 
+      - kornia==0.6.8    #The last that is provided as *.bz2 extension
+      - starfile==0.4.11  #The last that that is provided as *.bz2 extension

--- a/src/xmipp/bindings/python/envs_DLTK/xmipp_pyTorch-gpu.yml
+++ b/src/xmipp/bindings/python/envs_DLTK/xmipp_pyTorch-gpu.yml
@@ -13,8 +13,9 @@ dependencies:
   - pytorch==1.13.1
   - torchvision=0.14
   - pytorch-cuda=11.7
+  - kornia=0.6.8    #The last that is provided as *.bz2 extension
+  - starfile=0.4.11  #The last that is provided as *.bz2 extension
   - pip  
   - pip:
       - numpy==1.23 
-      - kornia==0.6.8    #The last that is provided as *.bz2 extension
-      - starfile==0.4.11  #The last that that is provided as *.bz2 extension
+

--- a/src/xmipp/bindings/python/envs_DLTK/xmipp_pyTorch.yml
+++ b/src/xmipp/bindings/python/envs_DLTK/xmipp_pyTorch.yml
@@ -1,4 +1,4 @@
-#Protocols ussing the enviroment: protocol_deepHand
+#Protocols ussing the enviroment: protocol_deepHand, protocol_classify_pca
 
 name: xmipp_pyTorch
 channels:
@@ -8,11 +8,13 @@ channels:
   - pytorch
 dependencies:
   - python=3.10
-  - numpy=1.23
   - mrcfile=1.4.3
-  - kornia=0.6.8 #The last that that is provided as *.bz2 extension
-  - starfile=0.4.11 #The last that that is provided as *.bz2 extension
   - pytorch==1.13.1
   - torchvision=0.14
+  - pip  
+  - pip:
+      - numpy==1.23 
+      - kornia==0.6.8    #The last that is provided as *.bz2 extension
+      - starfile==0.4.11  #The last that that is provided as *.bz2 extension
 
 


### PR DESCRIPTION
Forcing to install numpy with pip. Previously there were two numpy installations;

-  conda: numpy=1.23
-   pip: numpy=2.2