### PR TITLE
remove removeDisabled in new residuals program

### DIFF
--- a/src/xmipp/libraries/reconstruction/continuous_create_residuals.cpp
+++ b/src/xmipp/libraries/reconstruction/continuous_create_residuals.cpp
@@ -651,7 +651,6 @@ void ProgContinuousCreateResiduals::processImage(const FileName &fnImg, const Fi
 void ProgContinuousCreateResiduals::postProcess()
 {
 	MetaData &ptrMdOut = getOutputMd();
-	ptrMdOut.removeDisabled();
 	if (contCost==CONTCOST_L1)
 	{
 		double minCost=1e38;


### PR DESCRIPTION
Otherwise, we can lose particles, which happened reproducibly using correlations and was fixed by removing this line.