### PR TITLE
Update libcifpp fork's ownership

### DIFF
--- a/cmake/fetch_cifpp.cmake
+++ b/cmake/fetch_cifpp.cmake
@@ -30,7 +30,7 @@ function(fetch_cifpp)
 
   FetchContent_Declare(
 		libcifpp
-		GIT_REPOSITORY https://github.com/MartinSalinas98/libcifpp.git
+		GIT_REPOSITORY https://github.com/I2PC/libcifpp.git
 		GIT_TAG ms_feature_ciflibrary
 	)
 	FetchContent_MakeAvailable(libcifpp)


### PR DESCRIPTION
It will be more stable if this dependency was owned by I2PC instead of me, as I recently thought of changing username and that would break all existing installations.

This change would still require everyone to pull the latest devel version to work, but it would be the last time that is ever required (unless I2PC changes name, which I think is unlikely).

I can wait for the next release to merge this so it is bundled into it and affects the minimum amount of users possible.

Note: The GitHub Actions pipeline will obviously fail until the name change is actually made, which I haven't done yet.