### PR TITLE
Restricting CUDA version to 12.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ if(${XMIPP_USE_CUDA})
   check_language(CUDA)
   if (CMAKE_CUDA_COMPILER)
     enable_language(CUDA)
-    find_package(CUDAToolkit 10.2)
+    find_package(CUDAToolkit 10.2...<12.5)
     if(CUDAToolkit_FOUND)
       file(APPEND ${XMIPP_VERSIONS_FILE} "CUDA=${CUDAToolkit_VERSION}\n")
 


### PR DESCRIPTION
Currently we are experiencing issues with CUDA 12.5 onwards. Thus, we are detecting this condition in CMake to prematurely throw an error.