### PR TITLE
Fix shift assignment in align_volume when mirroring

### DIFF
--- a/src/xmipp/libraries/reconstruction/volume_align_prog.cpp
+++ b/src/xmipp/libraries/reconstruction/volume_align_prog.cpp
@@ -72,6 +72,13 @@ void applyTransformation(const MultidimArray<double> &V2,
     YY(r)            = p[8];
     XX(r)            = p[9];
 
+    if (flip < 0)
+    {
+
+	ZZ(r) *= -1;
+	ZZ(r) += 1;
+    }
+
     Euler_angles2matrix(rot, tilt, psi, A, true);
     for (int i = 0; i < 4; ++i)
     {


### PR DESCRIPTION
When considering mirrors in `xmipp_align_volume` the shift was not properly handled (my mistake in https://github.com/I2PC/xmipp3/pull/1039/changes). When mirroring, its Z component needs to be flipped and for some reason incremented by 1.