### PR TITLE
Fix CUDA 12 Thrust missing include

### DIFF
--- a/src/xmipp/libraries/reconstruction_cuda/cuda_volume_restoration_kernels.cpp
+++ b/src/xmipp/libraries/reconstruction_cuda/cuda_volume_restoration_kernels.cpp
@@ -32,6 +32,7 @@
 #include <thrust/for_each.h>
 #include <thrust/remove.h>
 #include <thrust/execution_policy.h>
+#include <thrust/iterator/counting_iterator.h>
 
 #include "cuda_asserts.h"
 #include "cuda_vec2.h"


### PR DESCRIPTION
Fix compilation error with CUDA 12 where thrust::counting_iterator is not found due to missing header inclusion.

Change:
Add explicit include in cuda_volume_restoration_kernels.cpp:

#include <thrust/iterator/counting_iterator.h>

Impact:
Restores compatibility with CUDA 12.x. No functional changes

**CASE 1:**

>             "os": "Rocky Linux 9.7",
>             "architecture": "",
>             "cuda": "12.8.93",
>             "cmake": "3.26.5",
>             "gcc": "GNU-11.5.0",
>             "gpp": "GNU-11.5.0",
>             "mpi": "3.1",
>             "python": "3.8.20",
>             "sqlite": "3.53.1",
>             "java": "11.0.25",
>             "hdf5": "1.12.1",
>             "jpeg": "62"

Compile.log:

> 
> [ 81%] Linking CXX executable xmipp_transform_adjust_image_grey_levels
> [ 81%] Linking CXX executable xmipp_metadata_split
> [ 81%] Built target xmipp_phantom_create
> [ 81%] Linking CXX executable xmipp_volume_apply_deform_sph
> [ 81%] Linking CXX executable xmipp_transform_symmetrize
> [ 81%] Built target xmipp_tomo_extract_particlestacks
> [ 81%] Built target xmipp_tomo_project
> /opt/scipion3/software/em/xmipp3-v5/src/xmipp/libraries/reconstruction_cuda/cuda_volume_restoration_kernels.cpp(193): error: namespace "thrust" has no member "counting_iterator"
>    error = thrust::transform_reduce(thrust::device, thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(fourier_size), error_func, static_cast<T>(0), thrust::plus<T>());
>                                                             ^
> 
> /opt/scipion3/software/em/xmipp3-v5/src/xmipp/libraries/reconstruction_cuda/cuda_volume_restoration_kernels.cpp(193): error: type name is not allowed
>    error = thrust::transform_reduce(thrust::device, thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(fourier_size), error_func, static_cast<T>(0), thrust::plus<T>());
>                                                                               ^
> 
> /opt/scipion3/software/em/xmipp3-v5/src/xmipp/libraries/reconstruction_cuda/cuda_volume_restoration_kernels.cpp(193): error: namespace "thrust" has no member "counting_iterator"
>    error = thrust::transform_reduce(thrust::device, thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(fourier_size), error_func, static_cast<T>(0), thrust::plus<T>());
>                                                                                                ^
> 
> /opt/scipion3/software/em/xmipp3-v5/src/xmipp/libraries/reconstruction_cuda/cuda_volume_restoration_kernels.cpp(193): error: type name is not allowed
>    error = thrust::transform_reduce(thrust::device, thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(fourier_size), error_func, static_cast<T>(0), thrust::plus<T>());
>                                                                                                                  ^
> 
> /opt/scipion3/software/em/xmipp3-v5/src/xmipp/libraries/reconstruction_cuda/cuda_volume_restoration_kernels.cpp(203): error: namespace "thrust" has no member "counting_iterator"
>    thrust::for_each_n(thrust::device, thrust::counting_iterator<int>(0), volume_size, k);
>                                               ^
> 
> /opt/scipion3/software/em/xmipp3-v5/src/xmipp/libraries/reconstruction_cuda/cuda_volume_restoration_kernels.cpp(203): error: type name is not allowed
>    thrust::for_each_n(thrust::device, thrust::counting_iterator<int>(0), volume_size, k);
>                                                                 ^
> 
> /opt/scipion3/software/em/xmipp3-v5/src/xmipp/libraries/reconstruction_cuda/cuda_volume_restoration_kernels.cpp(244): error: namespace "thrust" has no member "counting_iterator"
>    const T avg = thrust::transform_reduce(thrust::device, thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(volume_size), masked_k,
>                                                                   ^
> 
> /opt/scipion3/software/em/xmipp3-v5/src/xmipp/libraries/reconstruction_cuda/cuda_volume_restoration_kernels.cpp(244): error: type name is not allowed
>    const T avg = thrust::transform_reduce(thrust::device, thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(volume_size), masked_k,
>                                                                                     ^
> 
> /opt/scipion3/software/em/xmipp3-v5/src/xmipp/libraries/reconstruction_cuda/cuda_volume_restoration_kernels.cpp(244): error: namespace "thrust" has no member "counting_iterator"
>    const T avg = thrust::transform_reduce(thrust::device, thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(volume_size), masked_k,