### PR TITLE
Remove conditional addition of Pascal architecture

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,12 +93,7 @@ if(${XMIPP_USE_CUDA})
       # 1. Define base architectures supported by almost everyone (Turing, Ampere)
       set(XMIPP_CUDA_ARCHS 75 86)
 
-      # 2. Conditionally add Pascal (compute_60) ONLY if CUDA is older than 12.0
-      if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS_EQUAL "12.0.0")
-        list(APPEND XMIPP_CUDA_ARCHS 60)
-      endif()
-
-      # 3. Add newer architectures for CUDA 11.8+ (Ada, Hopper)
+      # 2. Add newer architectures for CUDA 11.8+ (Ada, Hopper)
       if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "11.8.0")
         list(APPEND XMIPP_CUDA_ARCHS 89 90)
       endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,12 +91,11 @@ if(${XMIPP_USE_CUDA})
       string(APPEND CMAKE_CUDA_FLAGS " --expt-extended-lambda")
 
       # 1. Define base architectures supported by almost everyone (Turing, Ampere)
-      set(XMIPP_CUDA_ARCHS 75 86)
-
-      # 2. Add newer architectures for CUDA 11.8+ (Ada, Hopper)
-      if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "11.8.0")
-        list(APPEND XMIPP_CUDA_ARCHS 89 90)
-      endif()
+      set(XMIPP_CUDA_ARCHS 75 86 89 90)
+		
+	  if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS "13.0.0")
+		list(APPEND XMIPP_CUDA_ARCHS 61)
+	  endif()
 
       if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.18")
         # Modern CMake approach: Just pass the list


### PR DESCRIPTION
xmipp(cuda): drop compute_60 support and modernize CUDA arch selection

- Remove compute_60 (SM 6.0) due to incompatibility with CUDA 13+
- Include sm_61 architecture if CUDA < 13
- CUDA 13 no longer supports Pascal SM 6.0 compilation targets
- Simplify architecture list to modern supported GPUs:
  - 61 
  - 75 (Turing)
  - 86 (Ampere, e.g. RTX 30xx including RTX 3060)
  - 89 (Ada Lovelace)
  - 90 (Hopper)

BREAKING CHANGE:
- GPUs using compute capability 6.0 (SM 6.0) are no longer supported.
  This includes: NVIDIA Tesla P100,   NVIDIA Quadro GP100


Detected by this log error:

> /usr/bin/cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=False -DCMAKE_CUDA_COMPILER=/usr/local/cuda-13.2/bin/nvcc -DCMAKE_CXX_FLAGS=-mtune=native -DCMAKE_C_FLAGS=-mtune=native -DCMAKE_INSTALL_PREFIX=dist -DCMAKE_PREFIX_PATH=/home/erney/software/miniconda/envs/scipion3 -DCMAKE_SKIP_RPATH=True -DXMIPP_LINK_TO_SCIPION=True -DXMIPP_USE_CUDA=True -DXMIPP_USE_MATLAB=True -DXMIPP_USE_MPI=True
> -- The CUDA compiler identification is NVIDIA 13.2.51
> -- Detecting CUDA compiler ABI info
> -- Detecting CUDA compiler ABI info - done
> -- Check for working CUDA compiler: /usr/local/cuda-13.2/bin/nvcc - skipped
> -- Detecting CUDA compile features
> -- Detecting CUDA compile features - done
> -- Found CUDAToolkit: /usr/local/cuda-13.2/targets/x86_64-linux/include (found suitable version "13.2.51", minimum required is "10.2") 
> .......
> [ 95%] Building CXX object src/xmipp/CMakeFiles/XmippParallelCuda.dir/libraries/parallel_adapt_cuda/mpi_reconstruct_fourier_gpu.cpp.o
> nvcc fatal   : Unsupported gpu architecture 'compute_60'