### PR TITLE
Update xmipp_DLTK_v0.3-gpu.yml with pip settings

### DIFF
--- a/src/xmipp/bindings/python/envs_DLTK/xmipp_DLTK_v0.3-gpu.yml
+++ b/src/xmipp/bindings/python/envs_DLTK/xmipp_DLTK_v0.3-gpu.yml
@@ -19,3 +19,8 @@ dependencies:
       - keras==2.2.5
       - scikit-learn==0.22
       - protobuf==3.20.3
+
+environment:
+  PIP_DEFAULT_TIMEOUT: "120"
+  PIP_RETRIES: "20"
+  PIP_NO_CACHE_DIR: "1"


### PR DESCRIPTION
This fixes intermittent failures during GPU environment creation caused by pip timeouts and unstable package downloads (notably TensorFlow 1.15), observed on @buildbot machine

This happens because TensorFlow 1.15 and its dependencies are legacy packages with large downloads that are prone to timeouts in CI environments. The added pip settings increase retries and timeout limits to make installation more robust against network interruptions

Main error:

> ERROR: Exception: socket.timeout: The read operation timed out
> pip._vendor.urllib3.exceptions.ReadTimeoutError: HTTPSConnectionPool(host='files.pythonhosted.org', port=443): Read timed out.