### PR TITLE
Remove cudatoolkit/cudnn dependencies and pin TensorFlow CUDA 12.2

### DIFF
--- a/src/xmipp/bindings/python/envs_DLTK/xmipp_MicCleaner.yml
+++ b/src/xmipp/bindings/python/envs_DLTK/xmipp_MicCleaner.yml
@@ -5,11 +5,10 @@ channels:
 dependencies:
   - python=3.9
   - libstdcxx-ng # To be compatible with scipion env
-  - cudatoolkit=11.8
-  - cudnn=8.9.*
   - pip
   - pip:
-    - micrograph-cleaner-em==1.0.2
+    - micrograph-cleaner-em==1.0.2 # It include tensorflow[and-cuda]>=2.16 => CUDA 12.9
+    - tensorflow[and-cuda]==2.16.1 #CUDA 12.2
 
 
 


### PR DESCRIPTION
Omitting cudatoolkit and cudnn because tensorflow manage it, and micrographCleaner install tensofFLow >=2.16.
Installed tensorFlow[and-cuda] 2.16.1to force installa a CUDA 12.2 and not newer